### PR TITLE
Stack: use a snapshot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: tweag/linear-types:0.1.6
+      - image: tweag/linear-types:0.1.7
     steps:
       - checkout
       # Restore last version of the dependencies in cache

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 # Configures GHC to be the 8.2 variant from the Docker image
 # See https://hub.docker.com/r/tweag/linear-types/
-resolver: ghc-8.2
+resolver: nightly-2017-12-20
 compiler: ghc-8.2
 system-ghc: true
 docker:
@@ -9,6 +9,3 @@ docker:
 
 packages:
 - '.'
-
-extra-deps:
-- text-1.2.2.2


### PR DESCRIPTION
Partly for better CI caching. Partly because I won't need to add swaths of `extra-deps`.

This requires stack 1.6.1. Therefore, I pushed a new linear-types image with the newer stack in it.