### PR TITLE
Manually managed data: make exception safe

### DIFF
--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -26,6 +26,7 @@ library
     base >= 4.7 && < 5,
     containers,
     ghc-prim,
+    storable-tuple,
     text
   default-language:    Haskell2010
 


### PR DESCRIPTION
_Depends on #8 . There is only one commit in this PR._

Memory is freed in case of exception. A list of pointers is kept in a
non-gc'd region in order not to add to the GC pressure, and not
contribute to less predictable latencies.