### PR TITLE
A linear monad hierarchy

### DIFF
--- a/examples/Spec.hs
+++ b/examples/Spec.hs
@@ -9,10 +9,11 @@ import Control.Monad (void)
 import Data.Typeable
 -- TODO: restore (see #18)
 -- import qualified Foreign.Heap as Heap
-import qualified Foreign.List as List
 import Foreign.List (List)
-import qualified Foreign.Marshal.Pure as Manual
+import qualified Foreign.List as List
 import Foreign.Marshal.Pure (Pool)
+import qualified Foreign.Marshal.Pure as Manual
+import Prelude (return)
 import qualified Prelude as P
 import Prelude.Linear
 import Test.Hspec

--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -17,6 +17,8 @@ cabal-version: >=1.10
 library
   hs-source-dirs: src
   exposed-modules:
+    Control.Monad.Linear
+    Control.Monad.Linear.Builder
     Foreign.Marshal.Pure
     Prelude.Linear
     System.IO.Linear

--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -17,6 +17,7 @@ cabal-version: >=1.10
 library
   hs-source-dirs: src
   exposed-modules:
+    Control.Monad.Builder
     Control.Monad.Linear
     Control.Monad.Linear.Builder
     Foreign.Marshal.Pure

--- a/src/Control/Monad/Builder.hs
+++ b/src/Control/Monad/Builder.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Control.Monad.Builder
+  ( BuilderType(..)
+  , monadBuilder
+  ) where
+
+-- TODO: Link to example of builder
+
+import qualified Control.Monad as Unrestricted hiding (fail)
+import qualified Control.Monad.Fail as Unrestricted
+import Prelude.Linear (String)
+
+-- | Type of 'monadBuilder'. Note how the constraint on @m@ varies depending on
+-- the field. The constraints are solved lazily when a field is used by the do
+-- notation (in particular, if you don't do a pattern-matching, then you don't
+-- need a 'LMonadFail').
+data BuilderType = Builder
+  { (>>=) :: forall m a b. Unrestricted.Monad m => m a -> (a -> m b) -> m b
+  , (>>) :: forall m b. Unrestricted.Monad m => m () -> m b -> m b
+  , fail :: forall m a. Unrestricted.MonadFail m => String -> m a
+  , return :: forall m a. Unrestricted.Monad m => a -> m a
+    -- See also 'Control.Monad.Linear.Builder.return'
+  }
+
+-- | A builder to be used with @-XRebindableSyntax@ in conjunction with
+-- @RecordWildCards@
+monadBuilder :: BuilderType
+monadBuilder = Builder
+  { (>>=) = (Unrestricted.>>=)
+  , (>>) = (Unrestricted.>>)
+  , fail = Unrestricted.fail
+  , return = Unrestricted.return }

--- a/src/Control/Monad/Linear.hs
+++ b/src/Control/Monad/Linear.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Control.Monad.Linear
+  ( -- * Linear monad hierarchy
+    -- $ monad
+    Functor(..)
+  , Applicative(..)
+  , Monad(..)
+  , MonadFail(..)
+  , return
+  , join
+  ) where
+
+import Prelude.Linear (String, id)
+
+-- $monad
+
+-- TODO: explain that the category of linear function is self-enriched, and that
+-- this is a hierarchy of enriched monads. In order to have some common
+-- vocabulary.
+
+-- There is also room for another type of functor where map has type `(a ->.b)
+-- -> f a ->. f b`. `[]` and `Maybe` are such functors (they are regular
+-- (endo)functors of the category of linear functions whereas `LFunctor` are
+-- enriched functors). A Traversable hierarchy would start with non-enriched
+-- functors.
+
+-- TODO: make the laws explicit
+
+-- | Enriched linear functors.
+class Functor f where
+  fmap :: (a ->. b) ->. f a ->. f b
+
+-- | Enriched linear applicative functors
+class Functor f => Applicative f where
+  pure :: a ->. f a
+  (<*>) :: f (a ->. b) ->. f a ->. f b
+
+-- | Enriched linear monads
+class Applicative m => Monad m where
+  (>>=) :: m a ->. (a ->. m b) ->. m b
+  (>>) :: m () ->. m a ->. m a
+
+-- | Handles pattern-matching failure in do-notation. See 'Control.Monad.Fail'.
+class Monad m => MonadFail m where
+  fail :: String -> m a
+
+{-# INLINE return #-}
+return :: Monad m => a ->. m a
+return x = pure x
+
+join :: Monad m => m (m a) ->. m a
+join action = action >>= id

--- a/src/Control/Monad/Linear/Builder.hs
+++ b/src/Control/Monad/Linear/Builder.hs
@@ -21,6 +21,12 @@ data BuilderType = Builder
   { (>>=) :: forall m a b. Linear.Monad m => m a ->. (a ->. m b) ->. m b
   , (>>) :: forall m b. Linear.Monad m => m () ->. m b ->. m b
   , fail :: forall m a. Linear.MonadFail m => String -> m a
+  , return :: forall m a. Linear.Monad m => a ->. m a
+    -- I [aspiwack] need `return` in my builder due to
+    -- https://ghc.haskell.org/trac/ghc/ticket/14670
+    --
+    -- I originally intended `return` to be used qualified. But this is fine
+    -- too. So we may stick to it
   }
 
 -- | A builder to be used with @-XRebindableSyntax@ in conjunction with
@@ -29,4 +35,5 @@ monadBuilder :: BuilderType
 monadBuilder = Builder
   { (>>=) = (Linear.>>=)
   , (>>) = (Linear.>>)
-  , fail = Linear.fail }
+  , fail = Linear.fail
+  , return = Linear.return }

--- a/src/Control/Monad/Linear/Builder.hs
+++ b/src/Control/Monad/Linear/Builder.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Control.Monad.Linear.Builder
+  ( BuilderType(..)
+  , monadBuilder
+  ) where
+
+-- TODO: Link to example of builder
+
+
+import qualified Control.Monad.Linear as Linear
+import Prelude.Linear (String)
+
+-- | Type of 'monadBuilder'. Note how the constraint on @m@ varies depending on
+-- the field. The constraints are solved lazily when a field is used by the do
+-- notation (in particular, if you don't do a pattern-matching, then you don't
+-- need a 'LMonadFail').
+data BuilderType = Builder
+  { (>>=) :: forall m a b. Linear.Monad m => m a ->. (a ->. m b) ->. m b
+  , (>>) :: forall m b. Linear.Monad m => m () ->. m b ->. m b
+  , fail :: forall m a. Linear.MonadFail m => String -> m a
+  }
+
+-- | A builder to be used with @-XRebindableSyntax@ in conjunction with
+-- @RecordWildCards@
+monadBuilder :: BuilderType
+monadBuilder = Builder
+  { (>>=) = (Linear.>>=)
+  , (>>) = (Linear.>>)
+  , fail = Linear.fail }

--- a/src/Foreign/Marshal/Pure.hs
+++ b/src/Foreign/Marshal/Pure.hs
@@ -179,20 +179,20 @@ class (KnownRepresentable (AsKnown a)) => Representable a where
 -- tuples of Representable (not only KnownRepresentable) are Representable.
 instance Representable Word where
   type AsKnown Word = Word
-  toKnown = lid
-  ofKnown = lid
+  toKnown = id
+  ofKnown = id
 instance Representable Int where
   type AsKnown Int = Int
-  toKnown = lid
-  ofKnown = lid
+  toKnown = id
+  ofKnown = id
 instance Representable (Ptr a) where
   type AsKnown (Ptr a) = Ptr a
-  toKnown = lid
-  ofKnown = lid
+  toKnown = id
+  ofKnown = id
 instance Representable () where
   type AsKnown () = ()
-  toKnown = lid
-  ofKnown = lid
+  toKnown = id
+  ofKnown = id
 instance
   (Representable a, Representable b)
   => Representable (a, b) where
@@ -346,8 +346,8 @@ instance Storable (Box a) where
 instance KnownRepresentable (Box a) where
 instance Representable (Box a) where
   type AsKnown (Box a) = Box a
-  ofKnown = lid
-  toKnown = lid
+  ofKnown = id
+  toKnown = id
 
 -- TODO: a way to store GC'd data using a StablePtr
 

--- a/src/Foreign/Marshal/Pure.hs
+++ b/src/Foreign/Marshal/Pure.hs
@@ -61,7 +61,7 @@ import Foreign.Storable.Tuple ()
 import Prelude.Linear hiding (($))
 import System.IO.Unsafe
 import qualified Unsafe.Linear as Unsafe
-import Prelude (($))
+import Prelude (($), return, (<*>))
 
 -- XXX: [2018-02-09] I'm having trouble with the `constraints` package (it seems
 -- that the version of Type.Reflection.Unsafe in the linear ghc compiler is not

--- a/src/Prelude/Linear.hs
+++ b/src/Prelude/Linear.hs
@@ -12,7 +12,7 @@ module Prelude.Linear
   , seq
   , curry
   , uncurry
-  , lid
+  , id
     -- * Unrestricted
     -- $ unrestricted
   , Unrestricted(..)
@@ -39,6 +39,7 @@ import qualified Unsafe.Linear as Unsafe
 import GHC.Types
 import Prelude hiding
   ( ($)
+  , id
   , const
   , seq
   , curry
@@ -64,8 +65,8 @@ import qualified Prelude
 
 infixr 0 $
 
-lid :: a ->. a
-lid a = a
+id :: a ->. a
+id x = x
 
 const :: a ->. b -> a
 const x _ = x
@@ -292,7 +293,7 @@ lreturn :: LMonad m => a ->. m a
 lreturn x = lpure x
 
 ljoin :: LMonad m => m (m a) ->. m a
-ljoin action = action `lbind` (\x -> x)
+ljoin action = action `lbind` id
 
 -- | Type of 'monadBuilder'. Note how the constraint on @m@ varies depending on
 -- the field. The constraints are solved lazily when a field is used by the do

--- a/src/System/IO/Linear.hs
+++ b/src/System/IO/Linear.hs
@@ -97,6 +97,8 @@ instance Linear.Applicative IO where
   pure :: forall a. a ->. IO a
   pure a = IO $ \s -> (# s, a #)
 
+  -- TODO: define a combinator 'ap' to define (<*>) from a monadic instance
+  -- (alt: define a default implementation).
   (<*>) :: forall a b. IO (a ->. b) ->. IO a ->. IO b
   f <*> x = do
       f' <- f

--- a/src/System/IO/Linear.hs
+++ b/src/System/IO/Linear.hs
@@ -38,7 +38,7 @@ import qualified Control.Exception as System (throwIO, catch, mask_)
 import qualified Control.Monad.Linear as Linear
 import qualified Control.Monad.Linear.Builder as Linear
 import GHC.Exts (State#, RealWorld)
-import Prelude.Linear hiding (IO, return, (>>=), (>>))
+import Prelude.Linear hiding (IO)
 import qualified Unsafe.Linear as Unsafe
 import qualified System.IO as System
 

--- a/src/System/IO/Linear.hs
+++ b/src/System/IO/Linear.hs
@@ -105,9 +105,6 @@ instance Linear.Applicative IO where
       x' <- x
       Linear.pure $ f' x'
     where
-      -- XXX: why must I declare `return` here? Why does this type even work?
-      return :: Int
-      return = 0
       Linear.Builder { .. } = Linear.monadBuilder
 
 instance Linear.Monad IO where

--- a/src/System/IO/Resource.hs
+++ b/src/System/IO/Resource.hs
@@ -43,6 +43,9 @@ module System.IO.Resource
   ) where
 
 import Control.Exception (onException, mask, finally)
+import Control.Monad (fmap, fail)
+  -- XXX: ^ should be imported qualified. Fail should be made available in a
+  -- builder.
 import Data.Coerce
 import qualified Data.IORef as System
 import Data.IORef (IORef)
@@ -50,9 +53,12 @@ import qualified Data.IntMap.Strict as IntMap
 import Data.IntMap.Strict (IntMap)
 import Data.Text (Text)
 import qualified Data.Text.IO as Text
-import Prelude.Linear hiding (IO, (>>=), (>>), return, ($))
+import Prelude.Linear hiding (IO, ($))
 import Prelude (($))
 import qualified Prelude as P
+  -- XXX: ^ is only imported for a few monadic primitives. Should be replaced by
+  -- importing Control.Monad qualified (for return) and a generic builder for
+  -- monads.
 import qualified System.IO.Linear as Linear
 import qualified System.IO as System
 


### PR DESCRIPTION
This PR adds a linear (enriched) monad hierarchy.

Highlights:

- The linear monad hiearchy is in its own module, in order to reuse the same notations as regular monads, in particular the infix notations. Defining instance feels quite native this way.
- I put the entire functor/applicative/monad/monad-fail hierarchy in the same module (`Control.Monad.Linear`). This is unlike the usual hierarchy which has one module per type-class. We could want to instead follow the same module layout as `base` (except that this kind of enriched functors should be in `Control.Functor.Linear`, `Data.Functor.Linear` will have a different type). I decided this way because they are generally used together (an alternative is to define them in separate files and re-export the preceding modules)
- This uses F#-style builders to benefit from the `do` notation (it's a bit awkward, but works). Due to how `-XRebindableSyntax` works the builder is defined in a distinguished module `Control.Monad.Linear.Builder`: the projections from the builder must also be named `(>>=)` and so one. It would conflict with the definition of `Monad` if defined in the same place.
- For `-XRebindableSyntax` to work well, `Monad(..)` is excluded from `Prelude.Linear`
- A builder for regular monads is provided in `Control.Monad.Builder`.