### PR TITLE
Foreign.Marshal.Pure without Storable

### DIFF
--- a/examples/Foreign/Heap.hs
+++ b/examples/Foreign/Heap.hs
@@ -14,9 +14,6 @@ import qualified Foreign.List as List
 import Foreign.List (List)
 import qualified Foreign.Marshal.Pure as Manual
 import Foreign.Marshal.Pure (Pool, Box)
-import Foreign.Ptr
-import Foreign.Storable
-import Foreign.Storable.Tuple ()
 import Prelude.Linear hiding (foldl)
 
 data Heap k a

--- a/examples/Foreign/Heap.hs
+++ b/examples/Foreign/Heap.hs
@@ -1,5 +1,9 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- | Implementation of pairing heaps stored off-heap
 
@@ -21,25 +25,33 @@ data Heap k a
 data NEHeap k a
   = Heap k a (Box (List (NEHeap k a)))
 
--- TODO: generate with Generic
-instance (Storable k, Storable a) => Storable (NEHeap k a) where
-  sizeOf _ = sizeOf (undefined :: (k, a, (Box (List.List (NEHeap k a)))))
-  alignment _ = alignment (undefined :: (k, a, (Box (List.List (NEHeap k a)))))
+instance (Manual.Representable k, Manual.Representable a)
+  => Manual.MkRepresentable (NEHeap k a) (k, a, Box (List (NEHeap k a))) where
 
-  peek ptr = do
-    (k, a, h) <- peek (castPtr ptr :: Ptr (k, a, (Box (List.List (NEHeap k a)))))
-    return $ Heap k a h
+  toRepr (Heap k a l) = (k, a, l)
+  ofRepr (k, a, l) = Heap k a l
 
-  poke ptr (Heap k a h) = poke (castPtr ptr :: Ptr (k, a, (Box (List.List (NEHeap k a))))) (k, a, h)
+instance (Manual.Representable k, Manual.Representable a) => Manual.Representable (NEHeap k a) where
+  type AsKnown (NEHeap k a) = Manual.AsKnown (k, a, (Box (List (NEHeap k a))))
+-- -- TODO: generate with Generic
+-- instance (Storable k, Storable a) => Storable (NEHeap k a) where
+--   sizeOf _ = sizeOf (undefined :: (k, a, (Box (List.List (NEHeap k a)))))
+--   alignment _ = alignment (undefined :: (k, a, (Box (List.List (NEHeap k a)))))
+
+--   peek ptr = do
+--     (k, a, h) <- peek (castPtr ptr :: Ptr (k, a, (Box (List.List (NEHeap k a)))))
+--     return $ Heap k a h
+
+--   poke ptr (Heap k a h) = poke (castPtr ptr :: Ptr (k, a, (Box (List.List (NEHeap k a))))) (k, a, h)
 
 -- * Non-empty heap primitives
 
-singletonN :: (Storable k, Storable a) => k ->. a ->. Pool ->. NEHeap k a
+singletonN :: (Manual.Representable k, Manual.Representable a) => k ->. a ->. Pool ->. NEHeap k a
 singletonN k a pool = Heap k a (Manual.alloc List.Nil pool)
 
 -- XXX: (Movable k, Ord k) is a bit stronger than strictly required. We could
 -- give a linear version of `Ord` instead.
-mergeN :: forall k a. (Storable k, Storable a, Movable k, Ord k) => NEHeap k a ->. NEHeap k a ->. Pool ->. NEHeap k a
+mergeN :: forall k a. (Manual.Representable k, Manual.Representable a, Movable k, Ord k) => NEHeap k a ->. NEHeap k a ->. Pool ->. NEHeap k a
 mergeN (Heap k1 a1 h1) (Heap k2 a2 h2) pool =
     testAndRebuild (move k1) a1 h1 (move k2) a2 h2 pool
   where
@@ -52,14 +64,14 @@ mergeN (Heap k1 a1 h1) (Heap k2 a2 h2) pool =
       else
         Heap k2' a2' (Manual.alloc (List.Cons (Heap k1' a1' h1') h2') pool')
 
-mergeN' :: forall k a. (Storable k, Storable a, Movable k, Ord k) => NEHeap k a ->. Heap k a ->. Pool ->. NEHeap k a
+mergeN' :: forall k a. (Manual.Representable k, Manual.Representable a, Movable k, Ord k) => NEHeap k a ->. Heap k a ->. Pool ->. NEHeap k a
 mergeN' h Empty pool = pool `lseq` h
 mergeN' h (NonEmpty h') pool = mergeN h (Manual.deconstruct h') pool
 
-extractMinN :: (Storable k, Storable a, Movable k, Ord k) => NEHeap k a ->. Pool ->. (k, a, Heap k a)
+extractMinN :: (Manual.Representable k, Manual.Representable a, Movable k, Ord k) => NEHeap k a ->. Pool ->. (k, a, Heap k a)
 extractMinN (Heap k a h) pool = (k, a, pairUp (Manual.deconstruct h) pool)
 
-pairUp :: forall k a. (Storable k, Storable a, Movable k, Ord k) => List (NEHeap k a) ->. Pool ->. Heap k a
+pairUp :: forall k a. (Manual.Representable k, Manual.Representable a, Movable k, Ord k) => List (NEHeap k a) ->. Pool ->. Heap k a
 pairUp List.Nil pool = pool `lseq` Empty
 pairUp (List.Cons h r) pool = pairOne h (Manual.deconstruct r) (dup pool)
   where
@@ -78,18 +90,18 @@ pairUp (List.Cons h r) pool = pairOne h (Manual.deconstruct r) (dup pool)
 empty :: Heap k a
 empty = Empty
 
-singleton :: forall k a. (Storable k, Storable a) => k ->. a ->. Pool ->. Heap k a
+singleton :: forall k a. (Manual.Representable k, Manual.Representable a) => k ->. a ->. Pool ->. Heap k a
 singleton k a pool = NonEmpty $ singletonAlloc k a (dup pool)
   where
     singletonAlloc :: k ->. a ->. (Pool, Pool) ->. Box (NEHeap k a)
     singletonAlloc k' a' (pool1, pool2) =
       Manual.alloc (singletonN k' a' pool1) pool2
 
-extractMin :: (Storable k, Storable a, Movable k, Ord k) => Heap k a ->. Pool ->. Maybe (k, a, Heap k a)
+extractMin :: (Manual.Representable k, Manual.Representable a, Movable k, Ord k) => Heap k a ->. Pool ->. Maybe (k, a, Heap k a)
 extractMin Empty pool = pool `lseq` Nothing
 extractMin (NonEmpty h) pool = Just $ extractMinN (Manual.deconstruct h) pool
 
-merge :: forall k a. (Storable k, Storable a, Movable k, Ord k) => Heap k a ->. Heap k a ->. Pool ->. Heap k a
+merge :: forall k a. (Manual.Representable k, Manual.Representable a, Movable k, Ord k) => Heap k a ->. Heap k a ->. Pool ->. Heap k a
 merge Empty h' pool = pool `lseq` h'
 merge (NonEmpty h) h' pool = NonEmpty $ neMerge (Manual.deconstruct h) h' (dup pool)
   where
@@ -100,7 +112,7 @@ merge (NonEmpty h) h' pool = NonEmpty $ neMerge (Manual.deconstruct h) h' (dup p
 -- * Heap sort
 
 -- | Guaranteed to yield pairs in ascending key order
-foldl :: forall k a b. (Storable k, Storable a, Movable k, Ord k) => (b ->. k ->. a ->. b) -> b ->. Heap k a ->. Pool ->. b
+foldl :: forall k a b. (Manual.Representable k, Manual.Representable a, Movable k, Ord k) => (b ->. k ->. a ->. b) -> b ->. Heap k a ->. Pool ->. b
 foldl f acc h pool = go acc h (dup pool)
   where
     go :: b ->. Heap k a ->. (Pool, Pool) ->. b
@@ -112,7 +124,7 @@ foldl f acc h pool = go acc h (dup pool)
       foldl f (f acc' k a) h' pool'
 
 -- | Strict: stream must terminate.
-unfold :: forall k a s. (Storable k, Storable a, Movable k, Ord k) => (s -> Maybe ((k, a), s)) -> s -> Pool ->. Heap k a
+unfold :: forall k a s. (Manual.Representable k, Manual.Representable a, Movable k, Ord k) => (s -> Maybe ((k, a), s)) -> s -> Pool ->. Heap k a
 unfold step seed pool = dispatch (step seed) pool
   where
     dispatch :: (Maybe ((k, a), s)) -> Pool ->. Heap k a
@@ -125,14 +137,14 @@ unfold step seed pool = dispatch (step seed) pool
 
 -- TODO: linear unfold: could apply to off-heap lists!
 
-ofList :: (Storable k, Storable a, Movable k, Ord k) => [(k, a)] -> Pool ->. Heap k a
+ofList :: (Manual.Representable k, Manual.Representable a, Movable k, Ord k) => [(k, a)] -> Pool ->. Heap k a
 ofList l pool = unfold List.uncons l pool
 
 -- XXX: sorts in reverse
-toList :: (Storable k, Storable a, Movable k, Ord k) => Heap k a ->. Pool ->. [(k, a)]
+toList :: (Manual.Representable k, Manual.Representable a, Movable k, Ord k) => Heap k a ->. Pool ->. [(k, a)]
 toList h pool = foldl (\l k a -> (k,a):l) [] h pool
 
-sort :: forall k a. (Storable k, Storable a, Movable k, Ord k, Movable a) => [(k, a)] -> [(k,a)]
+sort :: forall k a. (Manual.Representable k, Manual.Representable a, Movable k, Ord k, Movable a) => [(k, a)] -> [(k,a)]
 sort l = unUnrestricted $ Manual.withPool (\pool -> move $ sort' l (dup pool))
     -- XXX: can we avoid this call to `move`?
   where

--- a/examples/Foreign/List.hs
+++ b/examples/Foreign/List.hs
@@ -9,12 +9,8 @@
 module Foreign.List where
 
 import qualified Data.List as List
-import Data.Word
 import qualified Foreign.Marshal.Pure as Manual
 import Foreign.Marshal.Pure (Pool, Box)
-import Foreign.Ptr
-import Foreign.Storable
-import Foreign.Storable.Tuple ()
 import Prelude.Linear hiding (map, foldl, foldr)
 
 -- XXX: we keep the last Cons in Memory here. A better approach would be to

--- a/examples/Foreign/List.hs
+++ b/examples/Foreign/List.hs
@@ -1,6 +1,10 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Foreign.List where
 
@@ -20,19 +24,18 @@ data List a
   | Cons !a !(Box (List a))
 
 -- TODO: generating appropriate instances using the Generic framework
-instance Storable a => Storable (List a) where
-  sizeOf _ = sizeOf (undefined :: (Word8, a, Box (List a)))
-  alignment _ = alignment (undefined :: (Word8, a, Box (List a)))
+instance
+  Manual.Representable a
+  => Manual.MkRepresentable (List a) (Maybe (a, Box (List a))) where
 
-  peek ptr = do
-    (tag, a, l) <- peek (castPtr ptr :: Ptr (Word8, a, Box (List a)))
-    case tag of
-      0 -> return Nil
-      1 -> return $ Cons a l
-      t -> error ("Storable (List a): peek: unknown tag ( " ++ show t ++ " )")
+  toRepr Nil = Nothing
+  toRepr (Cons a l) = Just (a, l)
 
-  poke ptr Nil = poke (castPtr ptr :: Ptr Word8) 0
-  poke ptr (Cons a l) = poke (castPtr ptr :: Ptr (Word8, a, Box (List a))) (1, a, l)
+  ofRepr Nothing = Nil
+  ofRepr (Just (a,l)) = Cons a l
+
+instance Manual.Representable a => Manual.Representable (List a) where
+  type AsKnown (List a) = Manual.AsKnown (Maybe (a, Box (List a)))
 
 -- Remark: this is a bit wasteful, we could implement an allocation-free map by
 -- reusing the old pointer with realloc.
@@ -40,7 +43,7 @@ instance Storable a => Storable (List a) where
 -- XXX: the mapped function should be of type (a ->. Pool ->. b)
 --
 -- Remark: map could be tail-recursive in destination-passing style
-map :: forall a b. (Storable a, Storable b) => (a ->. b) -> List a ->. Pool ->. List b
+map :: forall a b. (Manual.Representable a, Manual.Representable b) => (a ->. b) -> List a ->. Pool ->. List b
 map _f Nil pool = pool `lseq` Nil
 map f (Cons a l) pool =
     withPools (dup pool) a (Manual.deconstruct l)
@@ -49,18 +52,18 @@ map f (Cons a l) pool =
     withPools (pool1, pool2) a' l' =
       Cons (f a') (Manual.alloc (map f l' pool1) pool2)
 
-foldr :: forall a b. Storable a => (a ->. b ->. b) -> b ->. List a ->. b
+foldr :: forall a b. Manual.Representable a => (a ->. b ->. b) -> b ->. List a ->. b
 foldr _f seed Nil = seed
 foldr f seed (Cons a l) = f a (foldr f seed (Manual.deconstruct l))
 
-foldl :: forall a b. Storable a => (b ->. a ->. b) -> b ->. List a ->. b
+foldl :: forall a b. Manual.Representable a => (b ->. a ->. b) -> b ->. List a ->. b
 foldl _f seed Nil = seed
 foldl f seed (Cons a l) = foldl f (f seed a) (Manual.deconstruct l)
 
 -- Remark: could be tail-recursive with destination-passing style
 -- | Make a 'List' from a stream. 'List' is a type of strict lists, therefore
 -- the stream must terminate otherwise 'unfold' will loop. Not tail-recursive.
-unfold :: forall a s. Storable a => (s -> Maybe (a,s)) -> s -> Pool ->. List a
+unfold :: forall a s. Manual.Representable a => (s -> Maybe (a,s)) -> s -> Pool ->. List a
 unfold step state pool = dispatch (step state) (dup pool)
   -- XXX: ^ The reason why we need to `dup` the pool before we know whether the
   -- next step is a `Nothing` (in which case we don't need the pool at all) or a
@@ -74,7 +77,7 @@ unfold step state pool = dispatch (step state) (dup pool)
 
 -- | Linear variant of 'unfold'. Note how they are implemented exactly
 -- identically. They could be merged if multiplicity polymorphism was supported.
-unfoldL :: forall a s. Storable a => (s ->. Maybe (a,s)) -> s ->. Pool ->. List a
+unfoldL :: forall a s. Manual.Representable a => (s ->. Maybe (a,s)) -> s ->. Pool ->. List a
 unfoldL step state pool = dispatch (step state) (dup pool)
   where
     dispatch :: Maybe (a, s) ->. (Pool, Pool) ->. List a
@@ -82,14 +85,14 @@ unfoldL step state pool = dispatch (step state) (dup pool)
     dispatch (Just (a, next)) (pool1, pool2) =
       Cons a (Manual.alloc (unfoldL step next pool1) pool2)
 
-ofList :: Storable a => [a] -> Pool ->. List a
+ofList :: Manual.Representable a => [a] -> Pool ->. List a
 ofList l pool = unfold List.uncons l pool
 
-toList :: Storable a => List a ->. [a]
+toList :: Manual.Representable a => List a ->. [a]
 toList l = foldr (:) [] l
 
 -- | Like unfold but builds the list in reverse, and tail recursive
-runfold :: forall a s. Storable a => (s -> Maybe (a,s)) -> s -> Pool ->. List a
+runfold :: forall a s. Manual.Representable a => (s -> Maybe (a,s)) -> s -> Pool ->. List a
 runfold step state pool = loop state Nil pool
   where
     loop :: s -> List a ->. Pool ->. List a
@@ -100,5 +103,5 @@ runfold step state pool = loop state Nil pool
     dispatch (Just (a, next)) !acc (pool1, pool2) =
       loop next (Cons a (Manual.alloc acc pool1)) pool2
 
-ofRList :: Storable a => [a] -> Pool ->. List a
+ofRList :: Manual.Representable a => [a] -> Pool ->. List a
 ofRList l pool = runfold List.uncons l pool

--- a/examples/Spec.hs
+++ b/examples/Spec.hs
@@ -11,12 +11,11 @@ import qualified Foreign.List as List
 import Foreign.List (List)
 import qualified Foreign.Marshal.Pure as Manual
 import Foreign.Marshal.Pure (Pool)
-import Foreign.Storable (Storable)
 import Prelude.Linear
 import Test.Hspec
 import Test.QuickCheck
 
-eqList :: forall a. (Storable a, Movable a, Eq a) => List a ->. List a ->. Unrestricted Bool
+eqList :: forall a. (Manual.Representable a, Movable a, Eq a) => List a ->. List a ->. Unrestricted Bool
 eqList l1 l2 =
     eqUL (move (List.toList l1)) (move (List.toList l2))
   where

--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -26,6 +26,7 @@ library
     base >= 4.7 && < 5,
     containers,
     ghc-prim,
+    storable-tuple,
     text
   default-language:    Haskell2010
 

--- a/src/Foreign/Marshal/Pure.hs
+++ b/src/Foreign/Marshal/Pure.hs
@@ -188,6 +188,10 @@ instance Representable (Ptr a) where
   type AsKnown (Ptr a) = Ptr a
   toKnown = id
   ofKnown = id
+instance Representable () where
+  type AsKnown () = ()
+  toKnown = id
+  ofKnown = id
 instance
   (Representable a, Representable b)
   => Representable (a, b) where

--- a/src/Foreign/Marshal/Pure.hs
+++ b/src/Foreign/Marshal/Pure.hs
@@ -1,3 +1,8 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+-- XXX: deactivate orphan instance warning as we're defining a few Storable
+-- instances here. It's not worth fixing as I [aspiwack] intend to change the
+-- interface for something more appropriate, which won't require these Storable
+-- instances.
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleContexts #-}


### PR DESCRIPTION
This proposes an interface for pure off-heap data which doesn't expose a `Storable` constraint.

Instead, it defines a ground truth abstract type class `KnownRepresentable`. Which holds at basic types, tuples, and `Maybe`.

The `Foreign.Marshal.Pure` primitives are relativised with a `Representable` constraints. To implement representable, one must provide a retraction to `KnownRepresentable` (a helper type class `MkRepresentable` helps make it more modular).

This is an ok interface. But it yield slightly ugly memory-representation for sum types. (as `Either a b` would be represented as `(Word8, Maybe a, Maybe b)`. So I want to change it for a better representation later. But this is still better than `Storable`: instances are safe to define on the user side.