### PR TITLE
η-expand a linear function used as an unrestricted one

### DIFF
--- a/src/System/IO/Linear.hs
+++ b/src/System/IO/Linear.hs
@@ -81,7 +81,7 @@ toSystemIO = Unsafe.coerce -- basically just subtyping
 --     ...
 -- @
 withLinearIO :: IO (Unrestricted a) -> System.IO a
-withLinearIO action = unUnrestricted <$> (toSystemIO action)
+withLinearIO action = (\x -> unUnrestricted x) <$> (toSystemIO action)
 
 -- $monad
 


### PR DESCRIPTION
It is necessary with the new specification which doesn't auto η-expand anymore.