### PR TITLE
Vectors of known length & refreshed Dupable

### DIFF
--- a/examples/Foreign/List.hs
+++ b/examples/Foreign/List.hs
@@ -10,8 +10,8 @@
 module Foreign.List where
 
 import qualified Data.List as List
-import qualified Foreign.Marshal.Pure as Manual
 import Foreign.Marshal.Pure (Pool, Box)
+import qualified Foreign.Marshal.Pure as Manual
 import Prelude.Linear hiding (map, foldl, foldr)
 
 -- XXX: we keep the last Cons in Memory here. A better approach would be to

--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -21,6 +21,7 @@ library
     Control.Monad.Linear
     Control.Monad.Linear.Builder
     Data.Functor.Linear
+    Data.Vector.Linear
     Foreign.Marshal.Pure
     Prelude.Linear
     System.IO.Linear
@@ -31,7 +32,8 @@ library
     containers,
     ghc-prim,
     storable-tuple,
-    text
+    text,
+    vector
   default-language:    Haskell2010
 
 test-suite test

--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -20,6 +20,7 @@ library
     Control.Monad.Builder
     Control.Monad.Linear
     Control.Monad.Linear.Builder
+    Data.Functor.Linear
     Foreign.Marshal.Pure
     Prelude.Linear
     System.IO.Linear

--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -24,6 +24,7 @@ library
     Data.Vector.Linear
     Foreign.Marshal.Pure
     Prelude.Linear
+    Prelude.Linear.Internal.Simple
     System.IO.Linear
     System.IO.Resource
     Unsafe.Linear

--- a/src/Control/Monad/Linear.hs
+++ b/src/Control/Monad/Linear.hs
@@ -15,7 +15,8 @@ module Control.Monad.Linear
   , join
   ) where
 
-import Prelude.Linear (String, id)
+import Prelude.Linear.Internal.Simple (id)
+import Prelude (String)
 
 -- $monad
 

--- a/src/Control/Monad/Linear.hs
+++ b/src/Control/Monad/Linear.hs
@@ -7,6 +7,7 @@ module Control.Monad.Linear
   ( -- * Linear monad hierarchy
     -- $ monad
     Functor(..)
+  , (<$>)
   , Applicative(..)
   , Monad(..)
   , MonadFail(..)
@@ -33,6 +34,9 @@ import Prelude.Linear (String, id)
 -- | Enriched linear functors.
 class Functor f where
   fmap :: (a ->. b) ->. f a ->. f b
+
+(<$>) :: Functor f => (a ->. b) ->. f a ->. f b
+(<$>) = fmap
 
 -- | Enriched linear applicative functors
 class Functor f => Applicative f where

--- a/src/Data/Functor/Linear.hs
+++ b/src/Data/Functor/Linear.hs
@@ -19,6 +19,9 @@ import qualified Control.Monad.Linear as Control
 class Functor f where
   fmap :: (a ->. b) -> f a ->. f b
 
+(<$>) :: Functor f => (a ->. b) -> f a ->. f b
+(<$>) = fmap
+
 -- | Data 'Applicative'-s can be seen as containers which can be zipped
 -- together. A prime example of data 'Applicative' are vectors of known lengths
 -- ('ZipLists' would be, if it were not for the fact that zipping them together
@@ -44,3 +47,15 @@ class Functor f => Applicative f where
 
 class Functor t => Traversable t where
   traverse :: Control.Applicative e => (a ->. e b) -> t a ->. e (t b)
+
+---------------
+-- Instances --
+---------------
+
+instance Functor [] where
+  fmap f [] = []
+  fmap f (a:as) = f a : fmap f as
+
+instance Traversable [] where
+  traverse f [] = Control.pure []
+  traverse f (a : as) = (:) Control.<$> (f a) Control.<*> (traverse f as)

--- a/src/Data/Functor/Linear.hs
+++ b/src/Data/Functor/Linear.hs
@@ -53,9 +53,9 @@ class Functor t => Traversable t where
 ---------------
 
 instance Functor [] where
-  fmap f [] = []
+  fmap _f [] = []
   fmap f (a:as) = f a : fmap f as
 
 instance Traversable [] where
-  traverse f [] = Control.pure []
+  traverse _f [] = Control.pure []
   traverse f (a : as) = (:) Control.<$> (f a) Control.<*> (traverse f as)

--- a/src/Data/Functor/Linear.hs
+++ b/src/Data/Functor/Linear.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+-- | = The data functor hierarchy
+--
+-- This module defines the data functor library. These are linear functors which
+-- are better understood as containers of data. Unlike unrestricted functor,
+-- there is a split between such data functors and control functors which
+-- represent effects (see "Control.Monad.Linear" for more).
+--
+-- The data functor hierarchy contains a notion of applicative functors
+-- (containers which can be zipped) and traversable functors (containers which
+-- store a finite number of values).
+
+module Data.Functor.Linear where
+
+import qualified Control.Monad.Linear as Control
+
+class Functor f where
+  fmap :: (a ->. b) -> f a ->. f b
+
+-- | Data 'Applicative'-s can be seen as containers which can be zipped
+-- together. A prime example of data 'Applicative' are vectors of known lengths
+-- ('ZipLists' would be, if it were not for the fact that zipping them together
+-- drops values, which we are not allowed to do in a linear container).
+--
+-- In fact, an applicative functor is precisely a functor equipped with (pure
+-- and) @zipWith :: (a ->. b ->. c) -> f a ->. f b ->. f c@
+--
+-- == Remarks for the mathematically inclined
+--
+-- An 'Applicative' is, as in the restricted case, a lax monoidal endofunctor of
+-- the category of linear types. That is, it is equipped with
+--
+-- * a (linear) function @() ->. f ()@
+-- * a (linear) natural transformation @(f a, f b) ->. f (a, b)@
+--
+-- It is a simple exercise to verify that these are equivalent to the definition
+-- of 'Applicative'. Hence that the choice of linearity of the various arrow is
+-- indeed natural.
+class Functor f => Applicative f where
+  pure :: a -> f a
+  (<*>) :: f (a ->. b) ->. f a ->. f b
+
+class Functor t => Traversable t where
+  traverse :: Control.Applicative e => (a ->. e b) -> t a ->. e (t b)

--- a/src/Data/Vector/Linear.hs
+++ b/src/Data/Vector/Linear.hs
@@ -38,7 +38,7 @@ import Data.Proxy
 import Data.Type.Equality
 import Data.Vector (Vector)
 import qualified Data.Vector as Vector
-import GHC.Exts (Constraint, Proxy#, proxy#)
+import GHC.Exts (Constraint, proxy#)
 import GHC.TypeLits
 import Prelude
   ( Eq
@@ -54,7 +54,7 @@ import qualified Prelude as Prelude
 import Prelude.Linear.Internal.Simple
 import qualified Unsafe.Linear as Unsafe
 
-newtype V (n :: Nat) (a :: *) = V { unV :: Vector a }
+newtype V (n :: Nat) (a :: *) = V (Vector a)
   deriving (Eq, Ord, Prelude.Functor)
   -- Using vector rather than, say, 'Array' (or directly 'Array#') because it
   -- offers many convenience function. Since all these unsafeCoerces probably
@@ -107,7 +107,7 @@ predNat = case someNatVal (natVal' (proxy# @_ @n) - 1) of
   Just (SomeNat (_ :: Proxy p)) -> Unsafe.coerce (Dict @(KnownNat p))
   Nothing -> error "Vector.pred: n-1 is necessarily a Nat, if 1<=n"
 
-caseNat :: forall n. KnownNat n => Either (n :~: 0) ((1 <=? n) :~: True)
+caseNat :: forall n. KnownNat n => Either (n :~: 0) ((1 <=? n) :~: 'True)
 caseNat =
   case theLength @n of
     0 -> Left $ unsafeZero @n
@@ -124,5 +124,5 @@ elim xs f =
     Right Refl -> elimS (split xs) f
   where
     elimS :: 1 <= n => (# a, V (n-1) a #) ->. Elim n a b ->. b
-    elimS (# x, xs' #) f = case predNat @n of
-      Dict -> elim  xs' ((Unsafe.coerce f :: a ->. Elim (n-1) a b) x)
+    elimS (# x, xs' #) g = case predNat @n of
+      Dict -> elim  xs' ((Unsafe.coerce g :: a ->. Elim (n-1) a b) x)

--- a/src/Data/Vector/Linear.hs
+++ b/src/Data/Vector/Linear.hs
@@ -40,8 +40,18 @@ import Data.Vector (Vector)
 import qualified Data.Vector as Vector
 import GHC.Exts (Constraint, Proxy#, proxy#)
 import GHC.TypeLits
+import Prelude
+  ( Eq
+  , Ord
+  , Int
+  , Bool(..)
+  , Either(..)
+  , Maybe(..)
+  , fromIntegral
+  , error
+  , (-))
 import qualified Prelude as Prelude
-import Prelude.Linear
+import Prelude.Linear.Internal.Simple
 import qualified Unsafe.Linear as Unsafe
 
 newtype V (n :: Nat) (a :: *) = V { unV :: Vector a }

--- a/src/Data/Vector/Linear.hs
+++ b/src/Data/Vector/Linear.hs
@@ -63,7 +63,7 @@ newtype V (n :: Nat) (a :: *) = V (Vector a)
   -- Arrays at the moment.
 
 theLength :: forall n. KnownNat n => Int
-theLength = fromIntegral (natVal' (proxy# @_ @n))
+theLength = fromIntegral (natVal' @n (proxy# @_))
 
 instance Data.Functor (V n) where
   fmap f (V xs) = V $ Unsafe.toLinear ((Unsafe.coerce Vector.map) f) xs
@@ -74,7 +74,7 @@ instance KnownNat n => Data.Applicative (V n) where
     Unsafe.toLinear2 (Vector.zipWith @(_ ->. _) (\f x -> f x)) fs xs
 
 instance KnownNat n => Data.Traversable (V n) where
-  traverse f (V xs) = 
+  traverse f (V xs) =
     (V . Unsafe.toLinear (Vector.fromListN (theLength @n))) Control.<$>
     Data.traverse f (Unsafe.toLinear Vector.toList xs)
 
@@ -103,7 +103,7 @@ data Dict (c :: Constraint) where
   Dict :: c => Dict c
 
 predNat :: forall n. (1 <= n, KnownNat n) => Dict (KnownNat (n-1))
-predNat = case someNatVal (natVal' (proxy# @_ @n) - 1) of
+predNat = case someNatVal (natVal' @n (proxy# @_) - 1) of
   Just (SomeNat (_ :: Proxy p)) -> Unsafe.coerce (Dict @(KnownNat p))
   Nothing -> error "Vector.pred: n-1 is necessarily a Nat, if 1<=n"
 

--- a/src/Data/Vector/Linear.hs
+++ b/src/Data/Vector/Linear.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | This module defines vectors of known length which can hold linear values
+--
+-- Having a known length matters with linear types, because many common vector
+-- operations (like zip) are not total with linear types.
+--
+-- A much more expensive library of vectors of known size (including matrices
+-- and tensors of all dimensions) is the [@linear@ library on
+-- Hackage](https://hackage.haskell.org/package/linear) (that's /linear/ in the
+-- sense of [linear algebra](https://en.wikipedia.org/wiki/Linear_algebra),
+-- rather than linear types).
+
+module Data.Vector.Linear
+  ( V
+  , Elim
+  , elim
+  ) where
+
+import qualified Control.Monad.Linear as Control
+import qualified Data.Functor.Linear as Data
+import Data.Proxy
+import Data.Type.Equality
+import Data.Vector (Vector)
+import qualified Data.Vector as Vector
+import GHC.Exts (Constraint, Proxy#, proxy#)
+import GHC.TypeLits
+import qualified Prelude as Prelude
+import Prelude.Linear
+import qualified Unsafe.Linear as Unsafe
+
+newtype V (n :: Nat) (a :: *) = V { unV :: Vector a }
+  deriving (Eq, Ord, Prelude.Functor)
+  -- Using vector rather than, say, 'Array' (or directly 'Array#') because it
+  -- offers many convenience function. Since all these unsafeCoerces probably
+  -- kill the fusion rules, it may be worth it going lower level since I
+  -- probably have to write my own fusion anyway. Therefore, starting from
+  -- Arrays at the moment.
+
+theLength :: forall n. KnownNat n => Int
+theLength = fromIntegral (natVal' (proxy# @_ @n))
+
+instance Data.Functor (V n) where
+  fmap f (V xs) = V $ Unsafe.toLinear ((Unsafe.coerce Vector.map) f) xs
+
+instance KnownNat n => Data.Applicative (V n) where
+  pure a = V $ Vector.replicate (theLength @n) a
+  (V fs) <*> (V xs) = V $
+    Unsafe.toLinear2 (Vector.zipWith @(_ ->. _) (\f x -> f x)) fs xs
+
+instance KnownNat n => Data.Traversable (V n) where
+  traverse f (V xs) = 
+    (V . Unsafe.toLinear (Vector.fromListN (theLength @n))) Control.<$>
+    Data.traverse f (Unsafe.toLinear Vector.toList xs)
+
+type family Elim (n :: Nat) (a :: *) (b :: *) :: * where
+  Elim 0 a b = b
+  Elim n a b = a ->. Elim (n-1) a b
+
+split :: 1 <= n => V n a ->. (# a, V (n-1) a #)
+split = Unsafe.toLinear split'
+  where
+    split' :: 1 <= n => V n a -> (# a, V (n-1) a #)
+    split' (V xs) = (# Vector.head xs, V (Vector.tail xs)#)
+
+consumeV :: V 0 a ->. b ->. b
+consumeV = Unsafe.toLinear (\_ -> id)
+
+unsafeZero :: n :~: 0
+unsafeZero = Unsafe.coerce Refl
+
+unsafeNonZero :: (1 <=? n) :~: 'True
+unsafeNonZero = Unsafe.coerce Refl
+
+-- Same as in the constraints library, but it's just as easy to avoid a
+-- dependency here.
+data Dict (c :: Constraint) where
+  Dict :: c => Dict c
+
+predNat :: forall n. (1 <= n, KnownNat n) => Dict (KnownNat (n-1))
+predNat = case someNatVal (natVal' (proxy# @_ @n) - 1) of
+  Just (SomeNat (_ :: Proxy p)) -> Unsafe.coerce (Dict @(KnownNat p))
+  Nothing -> error "Vector.pred: n-1 is necessarily a Nat, if 1<=n"
+
+caseNat :: forall n. KnownNat n => Either (n :~: 0) ((1 <=? n) :~: True)
+caseNat =
+  case theLength @n of
+    0 -> Left $ unsafeZero @n
+    _ -> Right $ unsafeNonZero @n
+{-# INLINE caseNat #-}
+
+-- TODO: consider using template haskell to make this expression more efficient.
+-- | This is like pattern-matching on a n-tuple. It will eventually be
+-- polymorphic the same way as a case expression.
+elim :: forall n a b. KnownNat n => V n a ->. Elim n a b ->. b
+elim xs f =
+  case caseNat @n of
+    Left Refl -> consumeV xs $ Unsafe.coerce f
+    Right Refl -> elimS (split xs) f
+  where
+    elimS :: 1 <= n => (# a, V (n-1) a #) ->. Elim n a b ->. b
+    elimS (# x, xs' #) f = case predNat @n of
+      Dict -> elim  xs' ((Unsafe.coerce f :: a ->. Elim (n-1) a b) x)

--- a/src/Foreign/Marshal/Pure.hs
+++ b/src/Foreign/Marshal/Pure.hs
@@ -52,6 +52,7 @@ module Foreign.Marshal.Pure
   ) where
 
 import Control.Exception
+import qualified Data.Functor.Linear as Data
 import Data.Kind (Constraint)
 import Data.Word (Word8)
 import Foreign.Marshal.Alloc
@@ -59,10 +60,10 @@ import Foreign.Marshal.Utils
 import Foreign.Ptr
 import Foreign.Storable
 import Foreign.Storable.Tuple ()
+import Prelude (($), return, (<*>))
 import Prelude.Linear hiding (($))
 import System.IO.Unsafe
 import qualified Unsafe.Linear as Unsafe
-import Prelude (($), return, (<*>))
 
 -- XXX: [2018-02-09] I'm having trouble with the `constraints` package (it seems
 -- that the version of Type.Reflection.Unsafe in the linear ghc compiler is not
@@ -325,7 +326,7 @@ instance Consumable Pool where
   consume (Pool _) = ()
 
 instance Dupable Pool where
-  dup (Pool l) = (Pool l, Pool l)
+  dupV (Pool l) = Data.pure (Pool l)
 
 -- | 'Box a' is the abstract type of manually managed data. It can be used as
 -- part of data type definitions in order to store linked data structure off

--- a/src/Prelude/Linear.hs
+++ b/src/Prelude/Linear.hs
@@ -30,8 +30,8 @@ module Prelude.Linear
   , module Prelude
   ) where
 
-import qualified Unsafe.Linear as Unsafe
 import GHC.Types
+import qualified Prelude
 import Prelude hiding
   ( ($)
   , id
@@ -44,55 +44,8 @@ import Prelude hiding
   , Applicative(..)
   , Monad(..)
   )
-import qualified Prelude
-
--- $linearized-prelude
-
--- A note on implementation: to avoid silly mistakes, very easy functions are
--- simply reimplemented here. For harder function, we reuse the Prelude
--- definition and make an unsafe cast.
-
--- | Beware: @($)@ is not compatible with the standard one because it is
--- higher-order and we don't have multiplicity polymorphism yet.
-($) :: (a ->. b) ->. a ->. b
--- XXX: Temporary as `($)` should get its typing rule directly from the type
--- inference mechanism.
-($) f x = f x
-
-infixr 0 $
-
-id :: a ->. a
-id x = x
-
-const :: a ->. b -> a
-const x _ = x
-
--- XXX: To be decided: In `base`, this is not a prelude function (it's in
--- `Data.Tuple`), maybe we don't want it to be in `Prelude.Linear`.
-swap :: (a,b) ->. (b,a)
-swap (x,y) = (y,x)
-
--- | @seq x y@ only forces @x@ to head normal form, therefore is not guaranteed
--- to consume @x@ when the resulting computation is consumed. Therefore, @seq@
--- cannot be linear in it's first argument.
-seq :: a -> b ->. b
-seq x = Unsafe.toLinear (Prelude.seq x)
-
-
--- | Beware, 'curry' is not compatible with the standard one because it is
--- higher-order and we don't have multiplicity polymorphism yet.
-curry :: ((a, b) ->. c) ->. a ->. b ->. c
-curry f x y = f (x, y)
-
--- | Beware, 'uncurry' is not compatible with the standard one because it is
--- higher-order and we don't have multiplicity polymorphism yet.
-uncurry :: (a ->. b ->. c) ->. (a, b) ->. c
-uncurry f (x,y) = f x y
-
--- | Beware: @(.)@ is not compatible with the standard one because it is
--- higher-order and we don't have multiplicity polymorphism yet.
-(.) :: (b ->. c) -> (a ->. b) ->. a ->. c
-f . g = \x -> f (g x)
+import Prelude.Linear.Internal.Simple
+import qualified Unsafe.Linear as Unsafe
 
 -- $ unrestricted
 

--- a/src/Prelude/Linear.hs
+++ b/src/Prelude/Linear.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LinearTypes #-}
 {-# LANGUAGE MagicHash #-}
@@ -25,11 +27,17 @@ module Prelude.Linear
   , Dupable(..)
   , Movable(..)
   , lseq
+  , dup
+  , dup2
   , dup3
     -- * Re-exports from the standard 'Prelude' for convenience
   , module Prelude
   ) where
 
+import qualified Data.Functor.Linear as Data
+import Data.Vector.Linear (V)
+import qualified Data.Vector.Linear as V
+import GHC.TypeLits
 import GHC.Types
 import qualified Prelude
 import Prelude hiding
@@ -80,7 +88,7 @@ lseq a b = seqUnit (consume a) b
 --
 -- Where the @(≃)@ sign represent equality up to type isomorphism
 class Consumable a => Dupable a where
-  dup :: a ->. (a, a)
+  dupV :: KnownNat n => a ->. V n a
 
 -- | The laws of the @Movable@ class mean that @move@ is compatible with @consume@
 -- and @dup@.
@@ -91,20 +99,20 @@ class Consumable a => Dupable a where
 class Dupable a => Movable a where
   move :: a ->. Unrestricted a
 
-dup3 :: Dupable a => a ->. (a, a, a)
-dup3 x = oneMore $ dup x
-  where
-    oneMore :: Dupable a => (a, a) ->. (a, a, a)
-    oneMore (y, z) = flatten (y, dup z)
+dup2 :: Dupable a => a ->. (a, a)
+dup2 x = V.elim (dupV @_ @2 x) (,)
 
-    flatten :: (a, (a, a)) ->. (a, a, a)
-    flatten (y, (z, w)) = (y, z, w)
+dup3 :: Dupable a => a ->. (a, a, a)
+dup3 x = V.elim (dupV @_ @3 x) (,,)
+
+dup :: Dupable a => a ->. (a, a)
+dup = dup2
 
 instance Consumable () where
   consume () = ()
 
 instance Dupable () where
-  dup () = ((), ())
+  dupV () = Data.pure ()
 
 instance Movable () where
   move () = Unrestricted ()
@@ -114,8 +122,8 @@ instance Consumable Bool where
   consume False = ()
 
 instance Dupable Bool where
-  dup True = (True, True)
-  dup False = (False, False)
+  dupV True = Data.pure True
+  dupV False = Data.pure False
 
 instance Movable Bool where
   move True = Unrestricted True
@@ -133,7 +141,7 @@ instance Dupable Int where
   -- linear values hidden in a closure anywhere. Therefore it is safe to call
   -- non-linear functions linearly on this type: there is no difference between
   -- copying an 'Int#' and using it several times. /!\
-  dup (I# i) = Unsafe.toLinear (\j -> (I# j, I# j)) i
+  dupV (I# i) = Unsafe.toLinear (\j -> Data.pure (I# j)) i
 
 instance Movable Int where
   -- /!\ 'Int#' is an unboxed unlifted data-types, therefore it cannot have any
@@ -149,10 +157,7 @@ instance (Consumable a, Consumable b) => Consumable (a, b) where
   consume (a, b) = consume a `lseq` consume b
 
 instance (Dupable a, Dupable b) => Dupable (a, b) where
-  dup (a, b) = shuffle (dup a) (dup b)
-    where
-      shuffle :: (a, a) ->. (b, b) ->. ((a, b), (a, b))
-      shuffle (a', a'') (b', b'') = ((a', b'), (a'', b''))
+  dupV (a, b) = (,) Data.<$> dupV a Data.<*> dupV b
 
 instance (Movable a, Movable b) => Movable (a, b) where
   move (a, b) = liftu (move a) (move b)
@@ -166,10 +171,7 @@ instance (Consumable a, Consumable b, Consumable c) => Consumable (a, b, c) wher
   consume (a, b, c) = consume a `lseq` consume b `lseq` consume c
 
 instance (Dupable a, Dupable b, Dupable c) => Dupable (a, b, c) where
-  dup (a, b, c) = shuffle (dup a) (dup b) (dup c)
-    where
-      shuffle :: (a, a) ->. (b, b) ->. (c, c) ->. ((a, b, c), (a, b, c))
-      shuffle (a', a'') (b', b'') (c', c'') = ((a', b', c'), (a'', b'', c''))
+  dupV (a, b, c) = (,,) Data.<$> dupV a Data.<*> dupV b Data.<*> dupV c
 
 instance (Movable a, Movable b, Movable c) => Movable (a, b, c) where
   move (a, b, c) = liftu (move a) (move b) (move c)
@@ -182,11 +184,8 @@ instance Consumable a => Consumable [a] where
   consume (a:l) = consume a `lseq` consume l
 
 instance Dupable a => Dupable [a] where
-  dup [] = ([], [])
-  dup (a:l) = shuffle (dup a) (dup l)
-    where
-      shuffle :: (a, a) ->. ([a], [a]) ->. ([a], [a])
-      shuffle (a', a'') (l', l'') = (a':l', a'':l'')
+  dupV [] = Data.pure []
+  dupV (a:l) = (:) Data.<$> dupV a Data.<*> dupV l
 
 instance Movable a => Movable [a] where
   move [] = Unrestricted []
@@ -201,7 +200,7 @@ instance Consumable (Unrestricted a) where
   consume (Unrestricted _) = ()
 
 instance Dupable (Unrestricted a) where
-  dup (Unrestricted a) = (Unrestricted a, Unrestricted a)
+  dupV (Unrestricted a) = Data.pure (Unrestricted a)
 
 instance Movable (Unrestricted a) where
   move (Unrestricted a) = Unrestricted (Unrestricted a)

--- a/src/Prelude/Linear.hs
+++ b/src/Prelude/Linear.hs
@@ -39,7 +39,6 @@ import Data.Vector.Linear (V)
 import qualified Data.Vector.Linear as V
 import GHC.TypeLits
 import GHC.Types
-import qualified Prelude
 import Prelude hiding
   ( ($)
   , id

--- a/src/Prelude/Linear.hs
+++ b/src/Prelude/Linear.hs
@@ -14,6 +14,7 @@ module Prelude.Linear
   , seq
   , curry
   , uncurry
+  , (.)
     -- * Unrestricted
     -- $ unrestricted
   , Unrestricted(..)
@@ -38,6 +39,7 @@ import Prelude hiding
   , seq
   , curry
   , uncurry
+  , (.)
   , Functor(..)
   , Applicative(..)
   , Monad(..)
@@ -86,6 +88,11 @@ curry f x y = f (x, y)
 -- higher-order and we don't have multiplicity polymorphism yet.
 uncurry :: (a ->. b ->. c) ->. (a, b) ->. c
 uncurry f (x,y) = f x y
+
+-- | Beware: @(.)@ is not compatible with the standard one because it is
+-- higher-order and we don't have multiplicity polymorphism yet.
+(.) :: (b ->. c) -> (a ->. b) ->. a ->. c
+f . g = \x -> f (g x)
 
 -- $ unrestricted
 

--- a/src/Prelude/Linear/Internal/Simple.hs
+++ b/src/Prelude/Linear/Internal/Simple.hs
@@ -51,5 +51,5 @@ uncurry f (x,y) = f x y
 
 -- | Beware: @(.)@ is not compatible with the standard one because it is
 -- higher-order and we don't have multiplicity polymorphism yet.
-(.) :: (b ->. c) -> (a ->. b) ->. a ->. c
+(.) :: (b ->. c) ->. (a ->. b) ->. a ->. c
 f . g = \x -> f (g x)

--- a/src/Prelude/Linear/Internal/Simple.hs
+++ b/src/Prelude/Linear/Internal/Simple.hs
@@ -1,0 +1,55 @@
+-- | This is a very very simple prelude, which doesn't depend on anything else
+-- in the linear-base library (except possibly "Unsafe.Linear").
+
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE LinearTypes #-}
+
+module Prelude.Linear.Internal.Simple where
+
+import qualified Prelude as Prelude
+import qualified Unsafe.Linear as Unsafe
+
+-- A note on implementation: to avoid silly mistakes, very easy functions are
+-- simply reimplemented here. For harder function, we reuse the Prelude
+-- definition and make an unsafe cast.
+
+-- | Beware: @($)@ is not compatible with the standard one because it is
+-- higher-order and we don't have multiplicity polymorphism yet.
+($) :: (a ->. b) ->. a ->. b
+-- XXX: Temporary as `($)` should get its typing rule directly from the type
+-- inference mechanism.
+($) f x = f x
+
+infixr 0 $
+
+id :: a ->. a
+id x = x
+
+const :: a ->. b -> a
+const x _ = x
+
+-- XXX: To be decided: In `base`, this is not a prelude function (it's in
+-- `Data.Tuple`), maybe we don't want it to be in `Prelude.Linear`.
+swap :: (a,b) ->. (b,a)
+swap (x,y) = (y,x)
+
+-- | @seq x y@ only forces @x@ to head normal form, therefore is not guaranteed
+-- to consume @x@ when the resulting computation is consumed. Therefore, @seq@
+-- cannot be linear in it's first argument.
+seq :: a -> b ->. b
+seq x = Unsafe.toLinear (Prelude.seq x)
+
+-- | Beware, 'curry' is not compatible with the standard one because it is
+-- higher-order and we don't have multiplicity polymorphism yet.
+curry :: ((a, b) ->. c) ->. a ->. b ->. c
+curry f x y = f (x, y)
+
+-- | Beware, 'uncurry' is not compatible with the standard one because it is
+-- higher-order and we don't have multiplicity polymorphism yet.
+uncurry :: (a ->. b ->. c) ->. (a, b) ->. c
+uncurry f (x,y) = f x y
+
+-- | Beware: @(.)@ is not compatible with the standard one because it is
+-- higher-order and we don't have multiplicity polymorphism yet.
+(.) :: (b ->. c) -> (a ->. b) ->. a ->. c
+f . g = \x -> f (g x)


### PR DESCRIPTION
This comes in three part

- A data-functor hierarchy representing containers (especially a `Data.Applicative` which represents zippable things)
- Vectors of known length, which are `Data.Applicative`
- An `Dupable`'s one method now has type `KnownNat n => a ->. V n a`.

Here is the rationale

> One immediate benefit is that the instances are much easier to write, using the applicative instance (of course, it would have worked just fine, if that was the only goal, to make a V2 applicative functor).
>
> The other benefit is that there was no pleasant way to produce more than two things from a dupable. It is possible to write a function `(a ->. (a,a)) ->. a ->. V n a`, but at this point we already have `V n` defined. And producing a `V n a` directly is, I expect, significantly more efficient.
>
> Another approach would be to write a function `(a ->. (a,a)) ->. Int ->. a ->. [a]`, and rely on incomplete pattern-matchings. But this is rather yucky.