### PR TITLE
Traversable changes

### DIFF
--- a/src/Data/Functor/Linear.hs
+++ b/src/Data/Functor/Linear.hs
@@ -15,7 +15,6 @@
 module Data.Functor.Linear where
 
 import Prelude.Linear.Internal.Simple
-import qualified Control.Monad.Linear as Control
 
 class Functor f where
   fmap :: (a ->. b) -> f a ->. f b
@@ -50,9 +49,17 @@ class Functor f => Applicative f where
   f <*> x = liftA2 ($) f x
   liftA2 :: (a ->. b ->. c) -> f a ->. f b ->. f c
   liftA2 f x y = f <$> x <*> y
+-- TODO: Add monad and monad fail
+-- (>>=) :: m a ->. (a ->. m b) -> m b
+-- TODO: Add Foldable as a superclass of Traversable
+-- (and probably move them both elsewhere)
 
 class Functor t => Traversable t where
-  traverse :: Control.Applicative e => (a ->. e b) -> t a ->. e (t b)
+  {-# MINIMAL sequence | traverse #-}
+  traverse :: Applicative e => (a ->. e b) -> t a ->. e (t b)
+  traverse f = sequence . fmap f
+  sequence :: Applicative e => t (e a) ->. e (t a)
+  sequence = traverse id
 
 ---------------
 -- Instances --
@@ -63,5 +70,5 @@ instance Functor [] where
   fmap f (a:as) = f a : fmap f as
 
 instance Traversable [] where
-  traverse _f [] = Control.pure []
-  traverse f (a : as) = (:) Control.<$> (f a) Control.<*> (traverse f as)
+  traverse _f [] = pure []
+  traverse f (a : as) = (:) <$> f a <*> traverse f as

--- a/src/Data/Functor/Linear.hs
+++ b/src/Data/Functor/Linear.hs
@@ -49,8 +49,6 @@ class Functor f => Applicative f where
   f <*> x = liftA2 ($) f x
   liftA2 :: (a ->. b ->. c) -> f a ->. f b ->. f c
   liftA2 f x y = f <$> x <*> y
--- TODO: Add monad and monad fail
--- (>>=) :: m a ->. (a ->. m b) -> m b
 -- TODO: Add Foldable as a superclass of Traversable
 -- (and probably move them both elsewhere)
 

--- a/src/Data/Vector/Linear.hs
+++ b/src/Data/Vector/Linear.hs
@@ -33,7 +33,6 @@ module Data.Vector.Linear
   , make
   ) where
 
-import qualified Control.Monad.Linear as Control
 import qualified Data.Functor.Linear as Data
 import Data.Proxy
 import Data.Type.Equality
@@ -76,7 +75,7 @@ instance KnownNat n => Data.Applicative (V n) where
 
 instance KnownNat n => Data.Traversable (V n) where
   traverse f (V xs) =
-    (V . Unsafe.toLinear (Vector.fromListN (theLength @n))) Control.<$>
+    (V . Unsafe.toLinear (Vector.fromListN (theLength @n))) Data.<$>
     Data.traverse f (Unsafe.toLinear Vector.toList xs)
 
 type family FunN (n :: Nat) (a :: *) (b :: *) :: * where

--- a/src/Prelude/Linear.hs
+++ b/src/Prelude/Linear.hs
@@ -174,15 +174,11 @@ instance Consumable a => Consumable [a] where
   consume [] = ()
   consume (a:l) = consume a `lseq` consume l
 
--- TODO: write this using `traverse`
 instance Dupable a => Dupable [a] where
-  dupV [] = Data.pure []
-  dupV (a:l) = (:) Data.<$> dupV a Data.<*> dupV l
+  dupV = Data.traverse dupV
 
--- TODO: write this using `traverse`
 instance Movable a => Movable [a] where
-  move [] = Data.pure []
-  move (a:l) = (:) Data.<$> move a Data.<*> move l
+  move = Data.traverse move
 
 instance Consumable (Unrestricted a) where
   consume (Unrestricted _) = ()


### PR DESCRIPTION
Modify Data.Traversable to use Data.Applicatives and use this to write cleaner `Dupable a => Dupable [a]` and same for `Movable`.