### PR TITLE
WIP: Prelude Functor => Data Functor constraint

### DIFF
--- a/src/Control/Monad/Linear.hs
+++ b/src/Control/Monad/Linear.hs
@@ -33,14 +33,14 @@ import Prelude (String)
 -- TODO: make the laws explicit
 
 -- | Enriched linear functors.
-class Functor f where
+class Data.Functor f => Functor f where
   fmap :: (a ->. b) ->. f a ->. f b
 
 (<$>) :: Functor f => (a ->. b) ->. f a ->. f b
 (<$>) = fmap
 
 -- | Enriched linear applicative functors
-class Functor f => Applicative f where
+class (Data.Applicative f, Functor f) => Applicative f where
   {-# MINIMAL pure, ((<*>) | liftA2) #-}
   pure :: a ->. f a
   (<*>) :: f (a ->. b) ->. f a ->. f b

--- a/src/Data/Functor/Linear.hs
+++ b/src/Data/Functor/Linear.hs
@@ -15,8 +15,9 @@
 module Data.Functor.Linear where
 
 import Prelude.Linear.Internal.Simple
+import qualified Prelude
 
-class Functor f where
+class Prelude.Functor f => Functor f where
   fmap :: (a ->. b) -> f a ->. f b
 
 (<$>) :: Functor f => (a ->. b) -> f a ->. f b

--- a/src/Prelude/Linear.hs
+++ b/src/Prelude/Linear.hs
@@ -39,6 +39,7 @@ import Data.Vector.Linear (V)
 import qualified Data.Vector.Linear as V
 import GHC.TypeLits
 import GHC.Types
+import qualified Prelude
 import Prelude hiding
   ( ($)
   , id
@@ -189,9 +190,15 @@ instance Dupable (Unrestricted a) where
 instance Movable (Unrestricted a) where
   move (Unrestricted a) = Unrestricted (Unrestricted a)
 
+instance Prelude.Functor Unrestricted where
+  fmap f (Unrestricted a) = Unrestricted (f a)
+
 instance Data.Functor Unrestricted where
   fmap f (Unrestricted a) = Unrestricted (f a)
 
 instance Data.Applicative Unrestricted where
   pure = Unrestricted
   Unrestricted f <*> Unrestricted x = Unrestricted (f x)
+
+instance Data.Traversable Unrestricted where
+  sequence (Unrestricted t) = Prelude.fmap Unrestricted t


### PR DESCRIPTION
First brush at a (temporary) functor hierarchy.
(WIP: does not yet compile)

Prelude.Functor is now a superclass of Data.Functor. This is temporary, until multiplicity polymorphism is added, when the type of `Data.fmap` includes the type of `Prelude.fmap`. 
Until then, to `fmap` a non-linear arrow we must use `Prelude.fmap`, so it is now a required constraint.

Data.Functor is now a superclass of Control.Functor, similarly for Applicative.