### PR TITLE
Add `ap` as convenience operator for Control.Monad

### DIFF
--- a/src/Control/Monad/Linear.hs
+++ b/src/Control/Monad/Linear.hs
@@ -13,6 +13,7 @@ module Control.Monad.Linear
   , MonadFail(..)
   , return
   , join
+  , ap
   ) where
 
 import Prelude.Linear.Internal.Simple (id)
@@ -65,3 +66,7 @@ return x = pure x
 
 join :: Monad m => m (m a) ->. m a
 join action = action >>= id
+
+-- | Convenience operator to define Applicative instances in terms of Monad
+ap :: Monad m => m (a ->. b) ->. m a ->. m b
+ap f x = f >>= (\f' -> fmap f' x)

--- a/src/System/IO/Linear.hs
+++ b/src/System/IO/Linear.hs
@@ -37,7 +37,6 @@ import qualified Data.IORef as System
 import Control.Exception (Exception)
 import qualified Control.Exception as System (throwIO, catch, mask_)
 import qualified Control.Monad.Linear as Control
-import qualified Control.Monad.Linear.Builder as Control
 import GHC.Exts (State#, RealWorld)
 import Prelude.Linear hiding (IO)
 import qualified Unsafe.Linear as Unsafe


### PR DESCRIPTION
Define `ap` for Control.Monad so Control.Applicative instances can be defined conveniently.