### PR TITLE
Profunctors

### DIFF
--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -20,6 +20,7 @@ library
     Control.Monad.Builder
     Control.Monad.Linear
     Control.Monad.Linear.Builder
+    Data.Bifunctor.Linear
     Data.Functor.Linear
     Data.Vector.Linear
     Data.Profunctor.Linear

--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -22,6 +22,7 @@ library
     Control.Monad.Linear.Builder
     Data.Functor.Linear
     Data.Vector.Linear
+    Data.Profunctor.Linear
     Foreign.Marshal.Pure
     Prelude.Linear
     Prelude.Linear.Internal.Simple

--- a/src/Control/Monad/Linear.hs
+++ b/src/Control/Monad/Linear.hs
@@ -5,7 +5,7 @@
 
 module Control.Monad.Linear
   ( -- * Linear monad hierarchy
-    -- $ monad
+    -- $monad
     Functor(..)
   , (<$>)
   , dataFmapDefault
@@ -43,6 +43,7 @@ class Data.Functor f => Functor f where
 
 (<$>) :: Functor f => (a ->. b) ->. f a ->. f b
 (<$>) = fmap
+{-# INLINE (<$>) #-}
 
 dataFmapDefault :: Functor f => (a ->. b) -> f a ->. f b
 dataFmapDefault f = fmap f

--- a/src/Data/Bifunctor/Linear.hs
+++ b/src/Data/Bifunctor/Linear.hs
@@ -1,21 +1,54 @@
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeOperators #-}
 
 module Data.Bifunctor.Linear where
 
+import Prelude.Linear
 import Data.Void
 
--- TODO: Is a bifunctor
 -- TODO: associators
 -- TODO: remove `swap` from Prelude
+
+-- | Bifunctors on the category of linear types
+--
+-- Laws:
+-- If 'bimap' is supplied, then
+-- * @'bimap' 'id' 'id' = 'id'@
+-- If 'first' and 'second' are supplied, then
+-- * @
+-- 'first' 'id' ≡ 'id'
+-- 'second' 'id' ≡ 'id'
+-- @
+-- If all are supplied, then
+-- * @'bimap' f g = 'first' f '.' 'second' g
+class Bifunctor p where
+  {-# MINIMAL bimap | (first , second) #-}
+  bimap :: (a ->. b) -> (c ->. d) -> a `p` c ->. b `p` d
+  bimap f g = first f . second g
+
+  first :: (a ->. b) -> a `p` c ->. b `p` c
+  first f = bimap f id
+
+  second :: (b ->. c) -> a `p` b ->. a `p` c
+  second = bimap id
+
+instance Bifunctor (,) where
+  bimap f g (x,y) = (f x, g y)
+  first f (x,y) = (f x, y)
+  second g (x,y) = (x, g y)
+
+instance Bifunctor Either where
+  bimap f _ (Left x) = Left (f x)
+  bimap _ g (Right y) = Right (g y)
 
 -- | Symmetric monoidal products on the category of linear types
 --
 -- Laws
--- * @swap . swap = id@
-class SymmetricMonoidal (m :: * -> * -> *) (u :: *) | m -> u, u -> m where
+-- * @'swap' . 'swap' = 'id'@
+class Bifunctor m => SymmetricMonoidal (m :: * -> * -> *) (u :: *) | m -> u, u -> m where
   swap :: a `m` b ->. b `m` a
 
 instance SymmetricMonoidal (,) () where

--- a/src/Data/Bifunctor/Linear.hs
+++ b/src/Data/Bifunctor/Linear.hs
@@ -25,12 +25,15 @@ class Bifunctor p where
   {-# MINIMAL bimap | (first , second) #-}
   bimap :: (a ->. b) -> (c ->. d) -> a `p` c ->. b `p` d
   bimap f g = first f . second g
+  {-# INLINE bimap #-}
 
   first :: (a ->. b) -> a `p` c ->. b `p` c
   first f = bimap f id
+  {-# INLINE first #-}
 
   second :: (b ->. c) -> a `p` b ->. a `p` c
   second = bimap id
+  {-# INLINE second #-}
 
 instance Bifunctor (,) where
   bimap f g (x,y) = (f x, g y)

--- a/src/Data/Bifunctor/Linear.hs
+++ b/src/Data/Bifunctor/Linear.hs
@@ -9,9 +9,6 @@ module Data.Bifunctor.Linear where
 import Prelude.Linear
 import Data.Void
 
--- TODO: associators
--- TODO: remove `swap` from Prelude
-
 -- | Bifunctors on the category of linear types
 --
 -- Laws:
@@ -44,16 +41,27 @@ instance Bifunctor Either where
   bimap f _ (Left x) = Left (f x)
   bimap _ g (Right y) = Right (g y)
 
+-- TODO: assoc laws
 -- | Symmetric monoidal products on the category of linear types
 --
 -- Laws
 -- * @'swap' . 'swap' = 'id'@
 class Bifunctor m => SymmetricMonoidal (m :: * -> * -> *) (u :: *) | m -> u, u -> m where
+  {-# MINIMAL swap, (assoc | unassoc) #-}
+  assoc :: (a `m` b) `m` c ->. a `m` (b `m` c)
+  assoc = swap . unassoc . swap . unassoc . swap
+  unassoc :: a `m` (b `m` c) ->. (a `m` b) `m` c
+  unassoc = swap . assoc . swap . assoc . swap
   swap :: a `m` b ->. b `m` a
+-- XXX: should unitors be added?
 
 instance SymmetricMonoidal (,) () where
   swap (x, y) = (y, x)
+  assoc ((x,y),z) = (x,(y,z))
 
 instance SymmetricMonoidal Either Void where
   swap (Left x) = Right x
   swap (Right x) = Left x
+  assoc (Left (Left x)) = Left x
+  assoc (Left (Right x)) = Right (Left x)
+  assoc (Right x) = Right (Right x)

--- a/src/Data/Bifunctor/Linear.hs
+++ b/src/Data/Bifunctor/Linear.hs
@@ -24,7 +24,7 @@ import Data.Void
 class Bifunctor p where
   {-# MINIMAL bimap | (first , second) #-}
   bimap :: (a ->. b) -> (c ->. d) -> a `p` c ->. b `p` d
-  bimap f g = first f . second g
+  bimap f g x = first f (second g x)
   {-# INLINE bimap #-}
 
   first :: (a ->. b) -> a `p` c ->. b `p` c

--- a/src/Data/Bifunctor/Linear.hs
+++ b/src/Data/Bifunctor/Linear.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Data.Bifunctor.Linear where
+
+import Data.Void
+
+-- TODO: Is a bifunctor
+-- TODO: associators
+-- TODO: remove `swap` from Prelude
+
+-- | Symmetric monoidal products on the category of linear types
+--
+-- Laws
+-- * @swap . swap = id@
+class SymmetricMonoidal (m :: * -> * -> *) (u :: *) | m -> u, u -> m where
+  swap :: a `m` b ->. b `m` a
+
+instance SymmetricMonoidal (,) () where
+  swap (x, y) = (y, x)
+
+instance SymmetricMonoidal Either Void where
+  swap (Left x) = Right x
+  swap (Right x) = Left x

--- a/src/Data/Bifunctor/Linear.hs
+++ b/src/Data/Bifunctor/Linear.hs
@@ -50,21 +50,21 @@ instance Bifunctor Either where
 -- Laws
 -- * @'swap' . 'swap' = 'id'@
 class Bifunctor m => SymmetricMonoidal (m :: * -> * -> *) (u :: *) | m -> u, u -> m where
-  {-# MINIMAL swap, (assoc | unassoc) #-}
-  assoc :: (a `m` b) `m` c ->. a `m` (b `m` c)
-  assoc = swap . unassoc . swap . unassoc . swap
-  unassoc :: a `m` (b `m` c) ->. (a `m` b) `m` c
-  unassoc = swap . assoc . swap . assoc . swap
+  {-# MINIMAL swap, (rassoc | lassoc) #-}
+  rassoc :: (a `m` b) `m` c ->. a `m` (b `m` c)
+  rassoc = swap . lassoc . swap . lassoc . swap
+  lassoc :: a `m` (b `m` c) ->. (a `m` b) `m` c
+  lassoc = swap . rassoc . swap . rassoc . swap
   swap :: a `m` b ->. b `m` a
 -- XXX: should unitors be added?
 
 instance SymmetricMonoidal (,) () where
   swap (x, y) = (y, x)
-  assoc ((x,y),z) = (x,(y,z))
+  rassoc ((x,y),z) = (x,(y,z))
 
 instance SymmetricMonoidal Either Void where
   swap (Left x) = Right x
   swap (Right x) = Left x
-  assoc (Left (Left x)) = Left x
-  assoc (Left (Right x)) = Right (Left x)
-  assoc (Right x) = Right (Right x)
+  rassoc (Left (Left x)) = Left x
+  rassoc (Left (Right x)) = Right (Left x)
+  rassoc (Right x) = Right (Right x)

--- a/src/Data/Profunctor/Linear.hs
+++ b/src/Data/Profunctor/Linear.hs
@@ -19,15 +19,15 @@ import Prelude.Linear
 class Profunctor (arr :: * -> * -> *) where
   {-# MINIMAL dimap | lmap, rmap #-}
 
-  dimap :: (s ->. a) -> (b ->. t) -> a `arr` b ->. s `arr` t
-  dimap f g = lmap f . rmap g
+  dimap :: (s ->. a) -> (b ->. t) -> a `arr` b -> s `arr` t
+  dimap f g x = lmap f (rmap g x)
   {-# INLINE dimap #-}
 
-  lmap :: (s ->. a) -> a `arr` t ->. s `arr` t
+  lmap :: (s ->. a) -> a `arr` t -> s `arr` t
   lmap f = dimap f id
   {-# INLINE lmap #-}
 
-  rmap :: (b ->. t) -> s `arr` b ->. s `arr` t
+  rmap :: (b ->. t) -> s `arr` b -> s `arr` t
   rmap = dimap id
   {-# INLINE rmap #-}
 

--- a/src/Data/Profunctor/Linear.hs
+++ b/src/Data/Profunctor/Linear.hs
@@ -14,7 +14,7 @@ module Data.Profunctor.Linear
   , Strong(..)
   ) where
 
-import Data.Bifunctor.Linear
+import Data.Bifunctor.Linear hiding (first, second)
 import Prelude.Linear hiding (swap)
 
 -- TODO: write laws

--- a/src/Data/Profunctor/Linear.hs
+++ b/src/Data/Profunctor/Linear.hs
@@ -1,10 +1,7 @@
-{-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LinearTypes #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeOperators #-}
 
 module Data.Profunctor.Linear
@@ -15,7 +12,7 @@ module Data.Profunctor.Linear
   ) where
 
 import Data.Bifunctor.Linear hiding (first, second)
-import Prelude.Linear hiding (swap)
+import Prelude.Linear
 
 -- TODO: write laws
 

--- a/src/Data/Profunctor/Linear.hs
+++ b/src/Data/Profunctor/Linear.hs
@@ -14,7 +14,7 @@ module Data.Profunctor.Linear
   , Strong(..)
   ) where
 
-import Data.Void
+import Data.Bifunctor.Linear
 import Prelude.Linear hiding (swap)
 
 -- TODO: write laws
@@ -33,24 +33,6 @@ class Profunctor (arr :: * -> * -> *) where
   rmap :: (b ->. t) -> s `arr` b -> s `arr` t
   rmap = dimap id
   {-# INLINE rmap #-}
-
--- TODO: Move to a dedicated module
--- TODO: Is a bifunctor
--- TODO: associators
--- TODO: remove `swap` from Prelude
--- | Symmetric monoidal products on the category of linear types
---
--- Laws
--- * @swap . swap = id@
-class SymmetricMonoidal (m :: * -> * -> *) (u :: *) | m -> u, u -> m where
-  swap :: a `m` b ->. b `m` a
-
-instance SymmetricMonoidal (,) () where
-  swap (x, y) = (y, x)
-
-instance SymmetricMonoidal Either Void where
-  swap (Left x) = Right x
-  swap (Right x) = Left x
 
 class (SymmetricMonoidal m u, Profunctor arr) => Monoidal m u arr where
   (***) :: a `arr` b -> x `arr` y -> (a `m` x) `arr` (b `m` y)

--- a/src/Data/Profunctor/Linear.hs
+++ b/src/Data/Profunctor/Linear.hs
@@ -19,15 +19,15 @@ import Prelude.Linear
 class Profunctor (arr :: * -> * -> *) where
   {-# MINIMAL dimap | lmap, rmap #-}
 
-  dimap :: (s ->. a) -> (b ->. t) -> a `arr` b -> s `arr` t
-  dimap f g x = lmap f (rmap g x)
+  dimap :: (s ->. a) -> (b ->. t) -> a `arr` b ->. s `arr` t
+  dimap f g = lmap f . rmap g
   {-# INLINE dimap #-}
 
-  lmap :: (s ->. a) -> a `arr` t -> s `arr` t
+  lmap :: (s ->. a) -> a `arr` t ->. s `arr` t
   lmap f = dimap f id
   {-# INLINE lmap #-}
 
-  rmap :: (b ->. t) -> s `arr` b -> s `arr` t
+  rmap :: (b ->. t) -> s `arr` b ->. s `arr` t
   rmap = dimap id
   {-# INLINE rmap #-}
 

--- a/src/Data/Profunctor/Linear.hs
+++ b/src/Data/Profunctor/Linear.hs
@@ -23,7 +23,7 @@ class Profunctor (arr :: * -> * -> *) where
   {-# MINIMAL dimap | lmap, rmap #-}
 
   dimap :: (s ->. a) -> (b ->. t) -> a `arr` b -> s `arr` t
-  dimap f g = lmap f . rmap g
+  dimap f g x = lmap f (rmap g x)
   {-# INLINE dimap #-}
 
   lmap :: (s ->. a) -> a `arr` t -> s `arr` t
@@ -60,9 +60,9 @@ class (SymmetricMonoidal m u, Profunctor arr) => Strong m u arr where
   {-# MINIMAL first | second #-}
 
   first :: a `arr` b -> (a `m` c) `arr` (b `m` c)
-  first arr = dimap swap swap $ second arr
+  first arr = dimap swap swap (second arr)
   {-# INLINE first #-}
 
   second :: b `arr` c -> (a `m` b) `arr` (a `m` c)
-  second arr = dimap swap swap $ first arr
+  second arr = dimap swap swap (first arr)
   {-# INLINE second #-}

--- a/src/Data/Profunctor/Linear.hs
+++ b/src/Data/Profunctor/Linear.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Data.Profunctor.Linear
+  ( Profunctor(..)
+  , SymmetricMonoidal(..)
+  , Monoidal(..)
+  , Strong(..)
+  ) where
+
+import Data.Void
+import Prelude.Linear hiding (swap)
+
+-- TODO: write laws
+
+class Profunctor (arr :: * -> * -> *) where
+  {-# MINIMAL dimap | lmap, rmap #-}
+
+  dimap :: (s ->. a) -> (b ->. t) -> a `arr` b -> s `arr` t
+  dimap f g = lmap f . rmap g
+  {-# INLINE dimap #-}
+
+  lmap :: (s ->. a) -> a `arr` t -> s `arr` t
+  lmap f = dimap f id
+  {-# INLINE lmap #-}
+
+  rmap :: (b ->. t) -> s `arr` b -> s `arr` t
+  rmap = dimap id
+  {-# INLINE rmap #-}
+
+-- TODO: Move to a dedicated module
+-- TODO: Is a bifunctor
+-- TODO: associators
+-- TODO: remove `swap` from Prelude
+-- | Symmetric monoidal products on the category of linear types
+--
+-- Laws
+-- * @swap . swap = id@
+class SymmetricMonoidal (m :: * -> * -> *) (u :: *) | m -> u, u -> m where
+  swap :: a `m` b ->. b `m` a
+
+instance SymmetricMonoidal (,) () where
+  swap (x, y) = (y, x)
+
+instance SymmetricMonoidal Either Void where
+  swap (Left x) = Right x
+  swap (Right x) = Left x
+
+class (SymmetricMonoidal m u, Profunctor arr) => Monoidal m u arr where
+  (***) :: a `arr` b -> x `arr` y -> (a `m` x) `arr` (b `m` y)
+  unit :: u `arr` u
+
+class (SymmetricMonoidal m u, Profunctor arr) => Strong m u arr where
+  {-# MINIMAL first | second #-}
+
+  first :: a `arr` b -> (a `m` c) `arr` (b `m` c)
+  first arr = dimap swap swap $ second arr
+  {-# INLINE first #-}
+
+  second :: b `arr` c -> (a `m` b) `arr` (a `m` c)
+  second arr = dimap swap swap $ first arr
+  {-# INLINE second #-}

--- a/src/Prelude/Linear.hs
+++ b/src/Prelude/Linear.hs
@@ -12,7 +12,6 @@ module Prelude.Linear
     ($)
   , const
   , id
-  , swap
   , seq
   , curry
   , uncurry

--- a/src/Prelude/Linear/Internal/Simple.hs
+++ b/src/Prelude/Linear/Internal/Simple.hs
@@ -28,11 +28,6 @@ id x = x
 const :: a ->. b -> a
 const x _ = x
 
--- XXX: To be decided: In `base`, this is not a prelude function (it's in
--- `Data.Tuple`), maybe we don't want it to be in `Prelude.Linear`.
-swap :: (a,b) ->. (b,a)
-swap (x,y) = (y,x)
-
 -- | @seq x y@ only forces @x@ to head normal form, therefore is not guaranteed
 -- to consume @x@ when the resulting computation is consumed. Therefore, @seq@
 -- cannot be linear in it's first argument.


### PR DESCRIPTION
Basic profunctor classes

Replaces part of #35, with a cleaner history. Only includes profunctor classes and no lenses.