### PR TITLE
Add more basic prisms and isos and match/build

### DIFF
--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -25,6 +25,8 @@ library
     Data.Functor.Linear
     Data.Vector.Linear
     Data.Profunctor.Linear
+    Data.Profunctor.Kleisli.Linear
+    Data.Profunctor.Kleisli.NonLinear
     Foreign.Marshal.Pure
     Prelude.Linear
     Prelude.Linear.Internal.Simple

--- a/src/Control/Optics/Linear/Internal.hs
+++ b/src/Control/Optics/Linear/Internal.hs
@@ -40,8 +40,8 @@ import Data.Functor.Const
 import Data.Functor.Linear
 import Data.Monoid
 import Data.Profunctor.Linear
-import qualified Data.Profunctor.Kleisli.Linear as L
-import qualified Data.Profunctor.Kleisli.NonLinear as NL
+import qualified Data.Profunctor.Kleisli.Linear as Linear
+import qualified Data.Profunctor.Kleisli.NonLinear as NonLinear
 import Data.Void
 import Prelude.Linear
 import qualified Prelude as P
@@ -96,27 +96,27 @@ traversed = Optical wander
 over :: Optic_ LinearArrow a b s t -> (a ->. b) -> s ->. t
 over (Optical l) f = getLA (l (LA f))
 
-traverseOf :: Optic_ (L.Kleisli f) a b s t -> (a ->. f b) -> s ->. f t
-traverseOf (Optical l) f = L.runKleisli (l (L.Kleisli f))
+traverseOf :: Optic_ (Linear.Kleisli f) a b s t -> (a ->. f b) -> s ->. f t
+traverseOf (Optical l) f = Linear.runKleisli (l (Linear.Kleisli f))
 
-get :: Optic_ (NL.Kleisli (Const a)) a b s t -> s -> a
+get :: Optic_ (NonLinear.Kleisli (Const a)) a b s t -> s -> a
 get l = gets l P.id
 
-gets :: Optic_ (NL.Kleisli (Const r)) a b s t -> (a -> r) -> s -> r
-gets (Optical l) f s = getConst' (NL.runKleisli (l (NL.Kleisli (Const P.. f))) s)
+gets :: Optic_ (NonLinear.Kleisli (Const r)) a b s t -> (a -> r) -> s -> r
+gets (Optical l) f s = getConst' (NonLinear.runKleisli (l (NonLinear.Kleisli (Const P.. f))) s)
 
 set :: Optic_ (->) a b s t -> b -> s -> t
 set (Optical l) x = l (const x)
 
-match :: Optic_ (L.Kleisli (Either a)) a b s t -> s ->. Either t a
-match (Optical l) = withIso swap (\x _ -> x) . L.runKleisli (l (L.Kleisli Left))
+match :: Optic_ (Linear.Kleisli (Either a)) a b s t -> s ->. Either t a
+match (Optical l) = withIso swap (\x _ -> x) . Linear.runKleisli (l (Linear.Kleisli Left))
 
 -- will be redundant with multiplicity polymorphism
-match' :: Optic_ (NL.Kleisli (Either a)) a b s t -> s -> Either t a
-match' (Optical l) = withIso swap (\x _ -> forget x) P.. NL.runKleisli (l (NL.Kleisli Left))
+match' :: Optic_ (NonLinear.Kleisli (Either a)) a b s t -> s -> Either t a
+match' (Optical l) = withIso swap (\x _ -> forget x) P.. NonLinear.runKleisli (l (NonLinear.Kleisli Left))
 
-build :: Optic_ (L.CoKleisli (Const b)) a b s t -> b ->. t
-build (Optical l) x = L.runCoKleisli (l (L.CoKleisli getConst')) (Const x)
+build :: Optic_ (Linear.CoKleisli (Const b)) a b s t -> b ->. t
+build (Optical l) x = Linear.runCoKleisli (l (Linear.CoKleisli getConst')) (Const x)
 
 -- XXX: move this to Prelude
 -- | Linearly typed patch for the newtype deconstructor. (Temporary until
@@ -124,7 +124,7 @@ build (Optical l) x = L.runCoKleisli (l (L.CoKleisli getConst')) (Const x)
 getConst' :: Const a b ->. a
 getConst' (Const x) = x
 
-lengthOf :: Num r => Optic_ (NL.Kleisli (Const (Sum r))) a b s t -> s -> r
+lengthOf :: Num r => Optic_ (NonLinear.Kleisli (Const (Sum r))) a b s t -> s -> r
 lengthOf l s = getSum (gets l (const (Sum 1)) s)
 
 -- XXX: the below two functions will be made redundant with multiplicity
@@ -132,8 +132,8 @@ lengthOf l s = getSum (gets l (const (Sum 1)) s)
 over' :: Optic_ (->) a b s t -> (a -> b) -> s -> t
 over' (Optical l) f = l f
 
-traverseOf' :: Optic_ (NL.Kleisli f) a b s t -> (a -> f b) -> s -> f t
-traverseOf' (Optical l) f = NL.runKleisli (l (NL.Kleisli f))
+traverseOf' :: Optic_ (NonLinear.Kleisli f) a b s t -> (a -> f b) -> s -> f t
+traverseOf' (Optical l) f = NonLinear.runKleisli (l (NonLinear.Kleisli f))
 
 iso :: (s ->. a) -> (b ->. t) -> Iso a b s t
 iso f g = Optical (dimap f g)

--- a/src/Control/Optics/Linear/Internal.hs
+++ b/src/Control/Optics/Linear/Internal.hs
@@ -14,6 +14,8 @@ import Data.Functor.Const
 import Data.Functor.Linear
 import Data.Monoid
 import Data.Profunctor.Linear
+import qualified Data.Profunctor.Kleisli.Linear as L
+import qualified Data.Profunctor.Kleisli.NonLinear as NL
 import Data.Void
 import Prelude.Linear
 import qualified Prelude as P
@@ -68,29 +70,27 @@ traversed = Optical wander
 over :: Optic_ LinearArrow a b s t -> (a ->. b) -> s ->. t
 over (Optical l) f = getLA (l (LA f))
 
-traverseOf :: Optic_ (LKleisli f) a b s t -> (a ->. f b) -> s ->. f t
-traverseOf (Optical l) f = runLKleisli (l (LKleisli f))
+traverseOf :: Optic_ (L.Kleisli f) a b s t -> (a ->. f b) -> s ->. f t
+traverseOf (Optical l) f = L.runKleisli (l (L.Kleisli f))
 
-get :: Optic_ (Kleisli (Const a)) a b s t -> s -> a
+get :: Optic_ (NL.Kleisli (Const a)) a b s t -> s -> a
 get l = gets l P.id
 
-gets :: Optic_ (Kleisli (Const r)) a b s t -> (a -> r) -> s -> r
-gets (Optical l) f s = getConst' (runKleisli (l (Kleisli (Const P.. f))) s)
+gets :: Optic_ (NL.Kleisli (Const r)) a b s t -> (a -> r) -> s -> r
+gets (Optical l) f s = getConst' (NL.runKleisli (l (NL.Kleisli (Const P.. f))) s)
 
 set :: Optic_ (->) a b s t -> b -> s -> t
 set (Optical l) x = l (const x)
 
--- get can't return a linear arrow, so `withIso swap const` needs to be used
--- instead of `get swap`
-match :: Optic_ (LKleisli (Either a)) a b s t -> s ->. Either t a
-match (Optical l) = withIso swap (\x _ -> x) . runLKleisli (l (LKleisli Left))
+match :: Optic_ (L.Kleisli (Either a)) a b s t -> s ->. Either t a
+match (Optical l) = withIso swap (\x _ -> x) . L.runKleisli (l (L.Kleisli Left))
 
 -- will be redundant with multiplicity polymorphism
-match' :: Optic_ (Kleisli (Either a)) a b s t -> s -> Either t a
-match' (Optical l) = get swap P.. runKleisli (l (Kleisli Left))
+match' :: Optic_ (NL.Kleisli (Either a)) a b s t -> s -> Either t a
+match' (Optical l) = withIso swap (\x _ -> forget x) P.. NL.runKleisli (l (NL.Kleisli Left))
 
-build :: Optic_ (CoLKleisli (Const b)) a b s t -> b ->. t
-build (Optical l) x = runCoLKleisli (l (CoLKleisli getConst')) (Const x)
+build :: Optic_ (L.CoKleisli (Const b)) a b s t -> b ->. t
+build (Optical l) x = L.runCoKleisli (l (L.CoKleisli getConst')) (Const x)
 
 -- XXX: move this to Prelude
 -- | Linearly typed patch for the newtype deconstructor. (Temporary until
@@ -98,7 +98,7 @@ build (Optical l) x = runCoLKleisli (l (CoLKleisli getConst')) (Const x)
 getConst' :: Const a b ->. a
 getConst' (Const x) = x
 
-lengthOf :: Num r => Optic_ (Kleisli (Const (Sum r))) a b s t -> s -> r
+lengthOf :: Num r => Optic_ (NL.Kleisli (Const (Sum r))) a b s t -> s -> r
 lengthOf l s = getSum (gets l (const (Sum 1)) s)
 
 -- XXX: the below two functions will be made redundant with multiplicity
@@ -106,8 +106,8 @@ lengthOf l s = getSum (gets l (const (Sum 1)) s)
 over' :: Optic_ (->) a b s t -> (a -> b) -> s -> t
 over' (Optical l) f = l f
 
-traverseOf' :: Optic_ (Kleisli f) a b s t -> (a -> f b) -> s -> f t
-traverseOf' (Optical l) f = runKleisli (l (Kleisli f))
+traverseOf' :: Optic_ (NL.Kleisli f) a b s t -> (a -> f b) -> s -> f t
+traverseOf' (Optical l) f = NL.runKleisli (l (NL.Kleisli f))
 
 iso :: (s ->. a) -> (b ->. t) -> Iso a b s t
 iso f g = Optical (dimap f g)
@@ -115,4 +115,3 @@ iso f g = Optical (dimap f g)
 withIso :: Optic_ (Exchange a b) a b s t -> ((s ->. a) -> (b ->. t) -> r) -> r
 withIso (Optical l) f = f fro to
   where Exchange fro to = l (Exchange id id)
-

--- a/src/Control/Optics/Linear/Internal.hs
+++ b/src/Control/Optics/Linear/Internal.hs
@@ -6,7 +6,33 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeOperators #-}
 
-module Control.Optics.Linear.Internal where
+module Control.Optics.Linear.Internal
+  ( -- * Types
+    Optic_(..)
+  , Optic
+  , Iso, Iso'
+  , Lens, Lens'
+  , Prism, Prism'
+  , Traversal, Traversal'
+    -- * Composing optics
+  , (.>)
+    -- * Common optics
+  , swap, assoc
+  , _1, _2
+  , _Left, _Right
+  , _Just, _Nothing
+  , traversed
+    -- * Using optics
+  , get, set, gets
+  , match, match', build
+  , over, over'
+  , traverseOf, traverseOf'
+  , lengthOf
+  , withIso
+    -- * Constructing optics
+  , iso, prism
+  )
+  where
 
 import qualified Data.Bifunctor.Linear as Bifunctor
 import Data.Bifunctor.Linear (SymmetricMonoidal)

--- a/src/Control/Optics/Linear/Internal.hs
+++ b/src/Control/Optics/Linear/Internal.hs
@@ -33,13 +33,16 @@ type Traversal a b s t = Optic Wandering a b s t
 type Traversal' a s = Traversal a a s s
 
 swap :: SymmetricMonoidal m u => Iso (a `m` b) (c `m` d) (b `m` a) (d `m` c)
-swap = Optical (dimap Bifunctor.swap Bifunctor.swap)
+swap = iso Bifunctor.swap Bifunctor.swap
 
 assoc :: SymmetricMonoidal m u => Iso ((a `m` b) `m` c) ((d `m` e) `m` f) (a `m` (b `m` c)) (d `m` (e `m` f))
-assoc = Optical (dimap Bifunctor.lassoc Bifunctor.rassoc)
+assoc = iso Bifunctor.lassoc Bifunctor.rassoc
 
 (.>) :: Optic_ arr a b s t -> Optic_ arr x y a b -> Optic_ arr x y s t
 Optical f .> Optical g = Optical (f P.. g)
+
+prism :: (b ->. t) -> (s ->. Either t a) -> Prism a b s t
+prism b s = Optical $ \f -> dimap s (either id id) (second (rmap b f))
 
 _1 :: Lens a b (a,c) (b,c)
 _1 = Optical first
@@ -52,6 +55,12 @@ _Left = Optical first
 
 _Right :: Prism a b (Either c a) (Either c b)
 _Right = Optical second
+
+_Just :: Prism a b (Maybe a) (Maybe b)
+_Just = prism Just (maybe (Left Nothing) Right)
+
+_Nothing :: Prism' () (Maybe a)
+_Nothing = prism (\() -> Nothing) Left
 
 traversed :: Traversable t => Traversal a b (t a) (t b)
 traversed = Optical wander
@@ -66,10 +75,28 @@ get :: Optic_ (Kleisli (Const a)) a b s t -> s -> a
 get l = gets l P.id
 
 gets :: Optic_ (Kleisli (Const r)) a b s t -> (a -> r) -> s -> r
-gets (Optical l) f s = getConst (runKleisli (l (Kleisli (Const P.. f))) s)
+gets (Optical l) f s = getConst' (runKleisli (l (Kleisli (Const P.. f))) s)
 
 set :: Optic_ (->) a b s t -> b -> s -> t
 set (Optical l) x = l (const x)
+
+-- get can't return a linear arrow, so `withIso swap const` needs to be used
+-- instead of `get swap`
+match :: Optic_ (LKleisli (Either a)) a b s t -> s ->. Either t a
+match (Optical l) = withIso swap (\x _ -> x) . runLKleisli (l (LKleisli Left))
+
+-- will be redundant with multiplicity polymorphism
+match' :: Optic_ (Kleisli (Either a)) a b s t -> s -> Either t a
+match' (Optical l) = get swap P.. runKleisli (l (Kleisli Left))
+
+build :: Optic_ (CoLKleisli (Const b)) a b s t -> b ->. t
+build (Optical l) x = runCoLKleisli (l (CoLKleisli getConst')) (Const x)
+
+-- XXX: move this to Prelude
+-- | Linearly typed patch for the newtype deconstructor. (Temporary until
+-- inference will get this from the newtype declaration.)
+getConst' :: Const a b ->. a
+getConst' (Const x) = x
 
 lengthOf :: Num r => Optic_ (Kleisli (Const (Sum r))) a b s t -> s -> r
 lengthOf l s = getSum (gets l (const (Sum 1)) s)
@@ -81,3 +108,11 @@ over' (Optical l) f = l f
 
 traverseOf' :: Optic_ (Kleisli f) a b s t -> (a -> f b) -> s -> f t
 traverseOf' (Optical l) f = runKleisli (l (Kleisli f))
+
+iso :: (s ->. a) -> (b ->. t) -> Iso a b s t
+iso f g = Optical (dimap f g)
+
+withIso :: Optic_ (Exchange a b) a b s t -> ((s ->. a) -> (b ->. t) -> r) -> r
+withIso (Optical l) f = f fro to
+  where Exchange fro to = l (Exchange id id)
+

--- a/src/Data/Functor/Linear.hs
+++ b/src/Data/Functor/Linear.hs
@@ -15,6 +15,7 @@
 module Data.Functor.Linear where
 
 import Prelude.Linear.Internal.Simple
+import Data.Functor.Const
 
 class Functor f where
   fmap :: (a ->. b) -> f a ->. f b
@@ -70,3 +71,6 @@ instance Functor [] where
 instance Traversable [] where
   traverse _f [] = pure []
   traverse f (a : as) = (:) <$> f a <*> traverse f as
+
+instance Functor (Const x) where
+  fmap _ (Const x) = Const x

--- a/src/Data/Profunctor/Kleisli/Linear.hs
+++ b/src/Data/Profunctor/Kleisli/Linear.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TupleSections #-}
+module Data.Profunctor.Kleisli.Linear
+  ( Kleisli(..)
+  , CoKleisli(..)
+  )
+  where
+
+-- | This module is intended to be imported qualified
+
+import Data.Functor.Const
+import Data.Profunctor.Linear
+import Data.Void
+import Prelude.Linear (Either(..), either)
+import Prelude.Linear.Internal.Simple
+import qualified Control.Monad.Linear as Control
+import qualified Data.Functor.Linear as Data
+
+-- Ideally, there would only be one Kleisli arrow, parametrised by
+-- a multiplicity parameter:
+-- newtype Kleisli p m a b = Kleisli { runKleisli :: a # p -> m b }
+--
+-- Some instances would also still work, eg
+-- instance Functor p f => Profunctor (Kleisli p f)
+
+-- | Linear Kleisli arrows for the monad `m`. These arrows are still useful
+-- in the case where `m` is not a monad however, and some profunctorial
+-- properties still hold in this weaker setting.
+newtype Kleisli m a b = Kleisli { runKleisli :: a ->. m b }
+
+instance Data.Functor f => Profunctor (Kleisli f) where
+  dimap f g (Kleisli h) = Kleisli (Data.fmap g . h . f)
+
+instance Control.Functor f => Strong (,) () (Kleisli f) where
+  first  (Kleisli f) = Kleisli (\(a,b) -> (,b) Control.<$> f a)
+  second (Kleisli g) = Kleisli (\(a,b) -> (a,) Control.<$> g b)
+
+instance Control.Applicative f => Strong Either Void (Kleisli f) where
+  first  (Kleisli f) = Kleisli (either (Data.fmap Left . f) (Control.pure . Right))
+  second (Kleisli g) = Kleisli (either (Control.pure . Left) (Data.fmap Right . g))
+
+instance Control.Applicative f => Wandering (Kleisli f) where
+  wander (Kleisli f) = Kleisli (Data.traverse f)
+
+-- | Linear co-Kleisli arrows for the comonad `w`. These arrows are still
+-- useful in the case where `w` is not a comonad however, and some
+-- profunctorial properties still hold in this weaker setting.
+-- However stronger requirements on `f` are needed for profunctorial
+-- strength, so we have fewer instances.
+--
+-- Category theoretic remark: duality doesn't work in the obvious way, since
+-- (,) isn't the categorical product. Instead, we have a product (&), called
+-- "With", defined by
+-- > type With a b = forall r. Either (a ->. r) (b ->. r) ->. r
+-- which satisfies the universal property of the product of `a` and `b`.
+-- CoKleisli arrows are strong with respect to this monoidal structure,
+-- although this might not be useful...
+newtype CoKleisli w a b = CoKleisli { runCoKleisli :: w a ->. b }
+
+instance Data.Functor f => Profunctor (CoKleisli f) where
+  dimap f g (CoKleisli h) = CoKleisli (g . h . Data.fmap f)
+
+-- instance of a more general idea, but this will do for now
+instance Strong Either Void (CoKleisli (Const x)) where
+  first (CoKleisli f) = CoKleisli (\(Const x) -> Left (f (Const x)))

--- a/src/Data/Profunctor/Kleisli/NonLinear.hs
+++ b/src/Data/Profunctor/Kleisli/NonLinear.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TupleSections #-}
+
+module Data.Profunctor.Kleisli.NonLinear
+  ( Kleisli(..)
+  )
+  where
+
+import Data.Profunctor.Linear
+import Data.Void
+import qualified Prelude
+import Prelude.Linear (Either(..), forget)
+import Prelude.Linear.Internal.Simple (($))
+
+-- Non-linear Kleisli arrows for the monad `m`. As in the linear case,
+-- these arrows are still useful if `m` is only a `Functor` or an
+-- `Applicative`.
+newtype Kleisli m a b = Kleisli { runKleisli :: a -> m b }
+
+instance Prelude.Functor f => Profunctor (Kleisli f) where
+  dimap f g (Kleisli h) = Kleisli (\x -> forget g Prelude.<$> h (f x))
+
+instance Prelude.Functor f => Strong (,) () (Kleisli f) where
+  first  (Kleisli f) = Kleisli (\(a,b) -> (,b) Prelude.<$> f a)
+  second (Kleisli g) = Kleisli (\(a,b) -> (a,) Prelude.<$> g b)
+
+instance Prelude.Applicative f => Strong Either Void (Kleisli f) where
+  first  (Kleisli f) = Kleisli $ \case
+                                   Left  x -> Prelude.fmap Left (f x)
+                                   Right y -> Prelude.pure (Right y)

--- a/src/Data/Profunctor/Linear.hs
+++ b/src/Data/Profunctor/Linear.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE LinearTypes #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
@@ -14,19 +12,13 @@ module Data.Profunctor.Linear
   , Strong(..)
   , Wandering(..)
   , LinearArrow(..), getLA
-  , Kleisli(..)
-  , LKleisli(..)
-  , CoLKleisli(..)
   , Exchange(..)
   ) where
 
-import qualified Control.Monad.Linear as Control
 import qualified Data.Functor.Linear as Data
 import Data.Bifunctor.Linear hiding (first, second)
-import Data.Functor.Const
 import Prelude.Linear
 import Data.Void
-import qualified Prelude
 
 -- TODO: write laws
 
@@ -69,7 +61,6 @@ class (Strong (,) () arr, Strong Either Void arr) => Wandering arr where
 
 newtype LinearArrow a b = LA (a ->. b)
 -- | Temporary deconstructor since inference doesn't get it right
--- TODO: maybe use TH to automatically write things like this?
 getLA :: LinearArrow a b ->. a ->. b
 getLA (LA f) = f
 
@@ -84,37 +75,6 @@ instance Strong Either Void LinearArrow where
   first  (LA f) = LA $ either (Left . f) Right
   second (LA g) = LA $ either Left (Right . g)
 
-newtype Kleisli m a b = Kleisli { runKleisli :: a -> m b }
-
-instance Prelude.Functor f => Profunctor (Kleisli f) where
-  dimap f g (Kleisli h) = Kleisli (\x -> forget g Prelude.<$> h (f x))
-
-instance Prelude.Functor f => Strong (,) () (Kleisli f) where
-  first  (Kleisli f) = Kleisli (\(a,b) -> (,b) Prelude.<$> f a)
-  second (Kleisli g) = Kleisli (\(a,b) -> (a,) Prelude.<$> g b)
-
-instance Prelude.Applicative f => Strong Either Void (Kleisli f) where
-  first  (Kleisli f) = Kleisli $ \case
-                                   Left  x -> Prelude.fmap Left (f x)
-                                   Right y -> Prelude.pure (Right y)
-
-
-newtype LKleisli m a b = LKleisli { runLKleisli :: a ->. m b }
-
-instance Data.Functor f => Profunctor (LKleisli f) where
-  dimap f g (LKleisli h) = LKleisli (Data.fmap g . h . f)
-
-instance Control.Functor f => Strong (,) () (LKleisli f) where
-  first  (LKleisli f) = LKleisli (\(a,b) -> (,b) Control.<$> f a)
-  second (LKleisli g) = LKleisli (\(a,b) -> (a,) Control.<$> g b)
-
-instance Control.Applicative f => Strong Either Void (LKleisli f) where
-  first  (LKleisli f) = LKleisli (either (Data.fmap Left . f) (Control.pure . Right))
-  second (LKleisli g) = LKleisli (either (Control.pure . Left) (Data.fmap Right . g))
-
-instance Control.Applicative f => Wandering (LKleisli f) where
-  wander (LKleisli f) = LKleisli (Data.traverse f)
-
 instance Profunctor (->) where
   dimap f g h x = g (h (f x))
 instance Strong (,) () (->) where
@@ -123,19 +83,6 @@ instance Strong Either Void (->) where
   first f (Left x) = Left (f x)
   first _ (Right y) = Right y
 
--- XXX: Since CoLKleisli has uses, it might be better to replace all this
--- with a Bif-like structure...
---
-newtype CoLKleisli w a b = CoLKleisli { runCoLKleisli :: w a ->. b }
-
-instance Data.Functor f => Profunctor (CoLKleisli f) where
-  dimap f g (CoLKleisli h) = CoLKleisli (g . h . Data.fmap f)
-
--- instance of a more general idea, but this will do for now
-instance Strong Either Void (CoLKleisli (Const x)) where
-  first (CoLKleisli f) = CoLKleisli (\(Const x) -> Left (f (Const x)))
-
 data Exchange a b s t = Exchange (s ->. a) (b ->. t)
 instance Profunctor (Exchange a b) where
   dimap f g (Exchange p q) = Exchange (p . f) (g . q)
-

--- a/src/Prelude/Linear.hs
+++ b/src/Prelude/Linear.hs
@@ -72,7 +72,9 @@ maybe :: b -> (a ->. b) -> Maybe a ->. b
 maybe x _ Nothing = x
 maybe _ f (Just y) = f y
 
--- XXX: temporary
+-- XXX: temporary: with multiplicity polymorphism functions expecting a
+-- non-linear arrow would allow a linear arrow passed, so this would be
+-- redundant
 -- | Convenience operator when a higher-order function expects a non-linear
 -- arrow but we have a linear arrow
 forget :: (a ->. b) ->. a -> b

--- a/src/Prelude/Linear.hs
+++ b/src/Prelude/Linear.hs
@@ -18,6 +18,7 @@ module Prelude.Linear
   , (.)
   , either
   , maybe
+  , forget
     -- * Unrestricted
     -- $ unrestricted
   , Unrestricted(..)
@@ -70,6 +71,12 @@ either _ g (Right y) = g y
 maybe :: b -> (a ->. b) -> Maybe a ->. b
 maybe x _ Nothing = x
 maybe _ f (Just y) = f y
+
+-- XXX: temporary
+-- | Convenience operator when a higher-order function expects a non-linear
+-- arrow but we have a linear arrow
+forget :: (a ->. b) ->. a -> b
+forget f x = f x
 
 -- $ unrestricted
 


### PR DESCRIPTION
Prisms:

- Add `prism` constructor
- Add `_Just`, `_Nothing`
- `Prism` consumers: `match`, `build` and non-linear `match'` (I haven't yet found any use for `build'`, so it's omitted for now)

Isos:
- `iso` constructor and `withIso` deconstructor

(This leaves the question of a `lens` constructor, which I will address in a forthcoming PR)