### PR TITLE
Linear semigroups (attempt 2)

### DIFF
--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -23,9 +23,11 @@ library
     Control.Optics.Linear.Internal
     Data.Bifunctor.Linear
     Data.Functor.Linear
+    Data.Monoid.Linear
     Data.Vector.Linear
     Data.Profunctor.Linear
     Data.Profunctor.Kleisli.Linear
+    Data.Unrestricted.Linear
     Foreign.Marshal.Pure
     Prelude.Linear
     Prelude.Linear.Internal.Simple

--- a/src/Data/Functor/Linear.hs
+++ b/src/Data/Functor/Linear.hs
@@ -15,6 +15,7 @@
 module Data.Functor.Linear where
 
 import Prelude.Linear.Internal.Simple
+import Prelude (Maybe(..), Either(..))
 import Data.Functor.Const
 
 class Functor f where
@@ -74,3 +75,15 @@ instance Traversable [] where
 
 instance Functor (Const x) where
   fmap _ (Const x) = Const x
+
+instance Functor Maybe where
+  fmap _ Nothing = Nothing
+  fmap f (Just x) = Just (f x)
+
+instance Traversable Maybe where
+  sequence Nothing = pure Nothing
+  sequence (Just x) = fmap Just x
+
+instance Functor (Either e) where
+  fmap _ (Left x) = Left x
+  fmap f (Right x) = Right (f x)

--- a/src/Data/Monoid/Linear.hs
+++ b/src/Data/Monoid/Linear.hs
@@ -1,0 +1,103 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+-- | = The linear semigroup hierarchy
+--
+-- TODO: documentation
+
+module Data.Monoid.Linear
+  ( Semigroup(..)
+  , Monoid(..)
+  , LEndo(..), appLEndo
+  , module Data.Semigroup
+  )
+  where
+
+import Prelude.Linear.Internal.Simple
+import Data.Unrestricted.Linear
+import Data.Functor.Linear as Data
+import Data.Functor.Const
+import Data.Semigroup hiding (Semigroup(..))
+import qualified Data.Semigroup as Prelude
+import qualified Prelude
+
+class Prelude.Semigroup a => Semigroup a where
+  (<>) :: a ->. a ->. a
+
+class (Semigroup a, Prelude.Monoid a) => Monoid a where
+  {-# MINIMAL #-}
+  mempty :: a
+  mempty = mempty
+  -- convenience redefine
+
+---------------
+-- Instances --
+---------------
+
+instance Semigroup () where
+  () <> () = ()
+
+newtype LEndo a = LEndo (a ->. a)
+
+-- TODO: have this as a newtype deconstructor once the right type can be
+-- correctly inferred
+appLEndo :: LEndo a ->. a ->. a
+appLEndo (LEndo f) = f
+
+instance Prelude.Semigroup (LEndo a) where
+  LEndo f <> LEndo g = LEndo (f . g)
+instance Prelude.Monoid (LEndo a) where
+  mempty = LEndo id
+instance Semigroup (LEndo a) where
+  LEndo f <> LEndo g = LEndo (f . g)
+instance Monoid (LEndo a) where
+
+instance (Semigroup a, Semigroup b) => Semigroup (a,b) where
+  (a,x) <> (b,y) = (a <> b, x <> y)
+instance (Monoid a, Monoid b) => Monoid (a,b)
+
+instance Semigroup a => Semigroup (Dual a) where
+  Dual x <> Dual y = Dual (y <> x)
+instance Monoid a => Monoid (Dual a)
+
+newtype LWrap a = LWrap a
+  deriving (Prelude.Semigroup, Prelude.Monoid)
+
+instance (Movable a, Prelude.Semigroup a) => Semigroup (LWrap a) where
+  LWrap a <> LWrap b = LWrap (combine (move a) (move b))
+    where combine :: Prelude.Semigroup a => Unrestricted a ->. Unrestricted a ->. a
+          combine (Unrestricted x) (Unrestricted y) = x Prelude.<> y
+instance (Movable a, Prelude.Monoid a) => Monoid (LWrap a)
+
+deriving instance Consumable a => Consumable (Sum a)
+deriving instance Dupable a => Dupable (Sum a)
+deriving instance Movable a => Movable (Sum a)
+deriving instance Consumable a => Consumable (Product a)
+deriving instance Dupable a => Dupable (Product a)
+deriving instance Movable a => Movable (Product a)
+deriving instance Consumable All
+deriving instance Dupable All
+deriving instance Movable All
+deriving instance Consumable Any
+deriving instance Dupable Any
+deriving instance Movable Any
+
+deriving via (LWrap (Sum a)) instance (Movable a, Prelude.Num a) => Semigroup (Sum a)
+deriving via (LWrap (Sum a)) instance (Movable a, Prelude.Num a) => Monoid (Sum a)
+deriving via (LWrap (Product a)) instance (Movable a, Prelude.Num a) => Semigroup (Product a)
+deriving via (LWrap (Product a)) instance (Movable a, Prelude.Num a) => Monoid (Product a)
+
+deriving via LWrap All instance Semigroup All
+deriving via LWrap All instance Monoid All
+deriving via LWrap Any instance Semigroup Any
+deriving via LWrap Any instance Monoid Any
+
+instance Monoid x => Data.Applicative (Const x) where
+  pure _ = Const mempty
+  Const x <*> Const y = Const (x <> y)

--- a/src/Data/Monoid/Linear.hs
+++ b/src/Data/Monoid/Linear.hs
@@ -7,7 +7,7 @@
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
--- | = The linear semigroup hierarchy
+-- | = The linear monoid hierarchy
 --
 -- TODO: documentation
 
@@ -43,7 +43,7 @@ class (Semigroup a, Prelude.Monoid a) => Monoid a where
 instance Semigroup () where
   () <> () = ()
 
-newtype LEndo a = LEndo (a ->. a)
+newtype Endo a = Endo (a ->. a)
 
 -- TODO: have this as a newtype deconstructor once the right type can be
 -- correctly inferred

--- a/src/Data/Unrestricted/Linear.hs
+++ b/src/Data/Unrestricted/Linear.hs
@@ -1,0 +1,193 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE RankNTypes #-}
+module Data.Unrestricted.Linear
+  ( -- * Unrestricted
+    -- $ unrestricted
+    Unrestricted(..)
+  , unUnrestricted
+    -- * Typeclasses for non-linear actions
+    -- $ comonoid
+  , Consumable(..)
+  , Dupable(..)
+  , Movable(..)
+  , void
+  , lseq
+  , dup
+  , dup2
+  , dup3
+  ) where
+-- $ unrestricted
+
+import qualified Data.Functor.Linear as Data
+import Data.Vector.Linear (V)
+import qualified Data.Vector.Linear as V
+import GHC.TypeLits
+import GHC.Types
+import Prelude hiding
+  ( ($)
+  , id
+  , const
+  , seq
+  , curry
+  , uncurry
+  , either
+  , maybe
+  , (.)
+  , Functor(..)
+  , Applicative(..)
+  , Monad(..)
+  , Traversable(..)
+  , Semigroup(..)
+  , Monoid(..)
+  )
+import Prelude.Linear.Internal.Simple () -- TODO: delete if necessary but i'll probably need this
+import qualified Unsafe.Linear as Unsafe
+
+-- | @Unrestricted a@ represents unrestricted values of type @a@ in a linear context,
+data Unrestricted a where
+  Unrestricted :: a -> Unrestricted a
+
+-- | Project an @a@ out of an @Unrestricted a@. If the @Unrestricted a@ is
+-- linear, then we get only a linear value out.
+unUnrestricted :: Unrestricted a ->. a
+unUnrestricted (Unrestricted a) = a
+
+-- $ comonoid
+
+class Consumable a where
+  consume :: a ->. ()
+
+-- | Like 'seq' but since the first argument is restricted to be of type @()@ it
+-- is consumed, hence @seqUnit@ is linear in its first argument.
+seqUnit :: () ->. b ->. b
+seqUnit () b = b
+
+-- | Like 'seq' but the first argument is restricted to be 'Consumable'. Hence the
+-- first argument is 'consume'-ed and the result consumed.
+lseq :: Consumable a => a ->. b ->. b
+lseq a b = seqUnit (consume a) b
+
+-- | The laws of @Dupable@ are dual to those of 'Monoid':
+--
+-- * @first consume (dup a) ≃ a ≃ first consume (dup a)@ (neutrality)
+-- * @first dup (dup a) ≃ (second dup (dup a))@ (associativity)
+--
+-- Where the @(≃)@ sign represent equality up to type isomorphism
+class Consumable a => Dupable a where
+  dupV :: KnownNat n => a ->. V n a
+
+-- | The laws of the @Movable@ class mean that @move@ is compatible with @consume@
+-- and @dup@.
+--
+-- * @case move x of {Unrestricted _ -> ()} = consume x@ (this law is trivial)
+-- * @case move x of {Unrestricted x -> x} = x@
+-- * @case move x of {Unrestricted x -> (x, x)} = dup x@
+class Dupable a => Movable a where
+  move :: a ->. Unrestricted a
+
+dup2 :: Dupable a => a ->. (a, a)
+dup2 x = V.elim (dupV @_ @2 x) (,)
+
+dup3 :: Dupable a => a ->. (a, a, a)
+dup3 x = V.elim (dupV @_ @3 x) (,,)
+
+dup :: Dupable a => a ->. (a, a)
+dup = dup2
+
+instance Consumable () where
+  consume () = ()
+
+instance Dupable () where
+  dupV () = Data.pure ()
+
+instance Movable () where
+  move () = Unrestricted ()
+
+instance Consumable Bool where
+  consume True = ()
+  consume False = ()
+
+instance Dupable Bool where
+  dupV True = Data.pure True
+  dupV False = Data.pure False
+
+instance Movable Bool where
+  move True = Unrestricted True
+  move False = Unrestricted False
+
+instance Consumable Int where
+  -- /!\ 'Int#' is an unboxed unlifted data-types, therefore it cannot have any
+  -- linear values hidden in a closure anywhere. Therefore it is safe to call
+  -- non-linear functions linearly on this type: there is no difference between
+  -- copying an 'Int#' and using it several times. /!\
+  consume (I# i) = Unsafe.toLinear (\_ -> ()) i
+
+instance Dupable Int where
+  -- /!\ 'Int#' is an unboxed unlifted data-types, therefore it cannot have any
+  -- linear values hidden in a closure anywhere. Therefore it is safe to call
+  -- non-linear functions linearly on this type: there is no difference between
+  -- copying an 'Int#' and using it several times. /!\
+  dupV (I# i) = Unsafe.toLinear (\j -> Data.pure (I# j)) i
+
+instance Movable Int where
+  -- /!\ 'Int#' is an unboxed unlifted data-types, therefore it cannot have any
+  -- linear values hidden in a closure anywhere. Therefore it is safe to call
+  -- non-linear functions linearly on this type: there is no difference between
+  -- copying an 'Int#' and using it several times. /!\
+  move (I# i) = Unsafe.toLinear (\j -> Unrestricted (I# j)) i
+
+-- TODO: instances for longer primitive tuples
+-- TODO: default instances based on the Generic framework
+
+instance (Consumable a, Consumable b) => Consumable (a, b) where
+  consume (a, b) = consume a `lseq` consume b
+
+instance (Dupable a, Dupable b) => Dupable (a, b) where
+  dupV (a, b) = (,) Data.<$> dupV a Data.<*> dupV b
+
+instance (Movable a, Movable b) => Movable (a, b) where
+  move (a, b) = (,) Data.<$> move a Data.<*> move b
+
+instance (Consumable a, Consumable b, Consumable c) => Consumable (a, b, c) where
+  consume (a, b, c) = consume a `lseq` consume b `lseq` consume c
+
+instance (Dupable a, Dupable b, Dupable c) => Dupable (a, b, c) where
+  dupV (a, b, c) = (,,) Data.<$> dupV a Data.<*> dupV b Data.<*> dupV c
+
+instance (Movable a, Movable b, Movable c) => Movable (a, b, c) where
+  move (a, b, c) = (,,) Data.<$> move a Data.<*> move b Data.<*> move c
+
+instance Consumable a => Consumable [a] where
+  consume [] = ()
+  consume (a:l) = consume a `lseq` consume l
+
+instance Dupable a => Dupable [a] where
+  dupV = Data.traverse dupV
+
+instance Movable a => Movable [a] where
+  move = Data.traverse move
+
+instance Consumable (Unrestricted a) where
+  consume (Unrestricted _) = ()
+
+instance Dupable (Unrestricted a) where
+  dupV (Unrestricted a) = Data.pure (Unrestricted a)
+
+instance Movable (Unrestricted a) where
+  move (Unrestricted a) = Unrestricted (Unrestricted a)
+
+instance Data.Functor Unrestricted where
+  fmap f (Unrestricted a) = Unrestricted (f a)
+
+instance Data.Applicative Unrestricted where
+  pure = Unrestricted
+  Unrestricted f <*> Unrestricted x = Unrestricted (f x)
+
+-- | Discard a consumable value stored in a data functor.
+void :: (Data.Functor f, Consumable a) => f a ->. f ()
+void = Data.fmap consume

--- a/src/Data/Unrestricted/Linear.hs
+++ b/src/Data/Unrestricted/Linear.hs
@@ -10,7 +10,7 @@ module Data.Unrestricted.Linear
     -- $ unrestricted
     Unrestricted(..)
   , unUnrestricted
-    -- * Typeclasses for non-linear actions
+    -- * Duplicating and consuming value linearly
     -- $ comonoid
   , Consumable(..)
   , Dupable(..)

--- a/src/Data/Unrestricted/Linear.hs
+++ b/src/Data/Unrestricted/Linear.hs
@@ -28,24 +28,6 @@ import Data.Vector.Linear (V)
 import qualified Data.Vector.Linear as V
 import GHC.TypeLits
 import GHC.Types
-import Prelude hiding
-  ( ($)
-  , id
-  , const
-  , seq
-  , curry
-  , uncurry
-  , either
-  , maybe
-  , (.)
-  , Functor(..)
-  , Applicative(..)
-  , Monad(..)
-  , Traversable(..)
-  , Semigroup(..)
-  , Monoid(..)
-  )
-import Prelude.Linear.Internal.Simple () -- TODO: delete if necessary but i'll probably need this
 import qualified Unsafe.Linear as Unsafe
 
 -- | @Unrestricted a@ represents unrestricted values of type @a@ in a linear context,

--- a/src/Prelude/Linear.hs
+++ b/src/Prelude/Linear.hs
@@ -14,6 +14,8 @@ module Prelude.Linear
   , either
   , maybe
   , forget
+  , Semigroup(..)
+  , Monoid(..)
     -- * Unrestricted
     -- $ unrestricted
   , Unrestricted(..)
@@ -33,6 +35,7 @@ module Prelude.Linear
   ) where
 
 import Data.Unrestricted.Linear
+import Data.Monoid.Linear
 import Prelude hiding
   ( ($)
   , id
@@ -47,6 +50,8 @@ import Prelude hiding
   , Applicative(..)
   , Monad(..)
   , Traversable(..)
+  , Semigroup(..)
+  , Monoid(..)
   )
 import Prelude.Linear.Internal.Simple
 

--- a/src/Prelude/Linear.hs
+++ b/src/Prelude/Linear.hs
@@ -1,10 +1,5 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE GADTs #-}
 {-# LANGUAGE LinearTypes #-}
-{-# LANGUAGE MagicHash #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE RankNTypes #-}
 
 module Prelude.Linear
   ( -- * Standard 'Prelude' function with linear types
@@ -37,11 +32,7 @@ module Prelude.Linear
   , module Prelude
   ) where
 
-import qualified Data.Functor.Linear as Data
-import Data.Vector.Linear (V)
-import qualified Data.Vector.Linear as V
-import GHC.TypeLits
-import GHC.Types
+import Data.Unrestricted.Linear
 import Prelude hiding
   ( ($)
   , id
@@ -58,7 +49,6 @@ import Prelude hiding
   , Traversable(..)
   )
 import Prelude.Linear.Internal.Simple
-import qualified Unsafe.Linear as Unsafe
 
 -- | Linearly typed replacement for the standard `either` function, to allow
 -- linear consumption of an @Either@.
@@ -79,149 +69,3 @@ maybe _ f (Just y) = f y
 -- arrow but we have a linear arrow
 forget :: (a ->. b) ->. a -> b
 forget f x = f x
-
--- $ unrestricted
-
--- | @Unrestricted a@ represents unrestricted values of type @a@ in a linear context,
-data Unrestricted a where
-  Unrestricted :: a -> Unrestricted a
-
--- | Project an @a@ out of an @Unrestricted a@. If the @Unrestricted a@ is
--- linear, then we get only a linear value out.
-unUnrestricted :: Unrestricted a ->. a
-unUnrestricted (Unrestricted a) = a
-
--- $ comonoid
-
-class Consumable a where
-  consume :: a ->. ()
-
--- | Discard a consumable value stored in a data functor.
-void :: (Data.Functor f, Consumable a) => f a ->. f ()
-void = Data.fmap consume
-
--- | Like 'seq' but since the first argument is restricted to be of type @()@ it
--- is consumed, hence @seqUnit@ is linear in its first argument.
-seqUnit :: () ->. b ->. b
-seqUnit () b = b
-
--- | Like 'seq' but the first argument is restricted to be 'Consumable'. Hence the
--- first argument is 'consume'-ed and the result consumed.
-lseq :: Consumable a => a ->. b ->. b
-lseq a b = seqUnit (consume a) b
-
--- | The laws of @Dupable@ are dual to those of 'Monoid':
---
--- * @first consume (dup a) ≃ a ≃ first consume (dup a)@ (neutrality)
--- * @first dup (dup a) ≃ (second dup (dup a))@ (associativity)
---
--- Where the @(≃)@ sign represent equality up to type isomorphism
-class Consumable a => Dupable a where
-  dupV :: KnownNat n => a ->. V n a
-
--- | The laws of the @Movable@ class mean that @move@ is compatible with @consume@
--- and @dup@.
---
--- * @case move x of {Unrestricted _ -> ()} = consume x@ (this law is trivial)
--- * @case move x of {Unrestricted x -> x} = x@
--- * @case move x of {Unrestricted x -> (x, x)} = dup x@
-class Dupable a => Movable a where
-  move :: a ->. Unrestricted a
-
-dup2 :: Dupable a => a ->. (a, a)
-dup2 x = V.elim (dupV @_ @2 x) (,)
-
-dup3 :: Dupable a => a ->. (a, a, a)
-dup3 x = V.elim (dupV @_ @3 x) (,,)
-
-dup :: Dupable a => a ->. (a, a)
-dup = dup2
-
-instance Consumable () where
-  consume () = ()
-
-instance Dupable () where
-  dupV () = Data.pure ()
-
-instance Movable () where
-  move () = Unrestricted ()
-
-instance Consumable Bool where
-  consume True = ()
-  consume False = ()
-
-instance Dupable Bool where
-  dupV True = Data.pure True
-  dupV False = Data.pure False
-
-instance Movable Bool where
-  move True = Unrestricted True
-  move False = Unrestricted False
-
-instance Consumable Int where
-  -- /!\ 'Int#' is an unboxed unlifted data-types, therefore it cannot have any
-  -- linear values hidden in a closure anywhere. Therefore it is safe to call
-  -- non-linear functions linearly on this type: there is no difference between
-  -- copying an 'Int#' and using it several times. /!\
-  consume (I# i) = Unsafe.toLinear (\_ -> ()) i
-
-instance Dupable Int where
-  -- /!\ 'Int#' is an unboxed unlifted data-types, therefore it cannot have any
-  -- linear values hidden in a closure anywhere. Therefore it is safe to call
-  -- non-linear functions linearly on this type: there is no difference between
-  -- copying an 'Int#' and using it several times. /!\
-  dupV (I# i) = Unsafe.toLinear (\j -> Data.pure (I# j)) i
-
-instance Movable Int where
-  -- /!\ 'Int#' is an unboxed unlifted data-types, therefore it cannot have any
-  -- linear values hidden in a closure anywhere. Therefore it is safe to call
-  -- non-linear functions linearly on this type: there is no difference between
-  -- copying an 'Int#' and using it several times. /!\
-  move (I# i) = Unsafe.toLinear (\j -> Unrestricted (I# j)) i
-
--- TODO: instances for longer primitive tuples
--- TODO: default instances based on the Generic framework
-
-instance (Consumable a, Consumable b) => Consumable (a, b) where
-  consume (a, b) = consume a `lseq` consume b
-
-instance (Dupable a, Dupable b) => Dupable (a, b) where
-  dupV (a, b) = (,) Data.<$> dupV a Data.<*> dupV b
-
-instance (Movable a, Movable b) => Movable (a, b) where
-  move (a, b) = (,) Data.<$> move a Data.<*> move b
-
-instance (Consumable a, Consumable b, Consumable c) => Consumable (a, b, c) where
-  consume (a, b, c) = consume a `lseq` consume b `lseq` consume c
-
-instance (Dupable a, Dupable b, Dupable c) => Dupable (a, b, c) where
-  dupV (a, b, c) = (,,) Data.<$> dupV a Data.<*> dupV b Data.<*> dupV c
-
-instance (Movable a, Movable b, Movable c) => Movable (a, b, c) where
-  move (a, b, c) = (,,) Data.<$> move a Data.<*> move b Data.<*> move c
-
-instance Consumable a => Consumable [a] where
-  consume [] = ()
-  consume (a:l) = consume a `lseq` consume l
-
-instance Dupable a => Dupable [a] where
-  dupV = Data.traverse dupV
-
-instance Movable a => Movable [a] where
-  move = Data.traverse move
-
-instance Consumable (Unrestricted a) where
-  consume (Unrestricted _) = ()
-
-instance Dupable (Unrestricted a) where
-  dupV (Unrestricted a) = Data.pure (Unrestricted a)
-
-instance Movable (Unrestricted a) where
-  move (Unrestricted a) = Unrestricted (Unrestricted a)
-
-instance Data.Functor Unrestricted where
-  fmap f (Unrestricted a) = Unrestricted (f a)
-
-instance Data.Applicative Unrestricted where
-  pure = Unrestricted
-  Unrestricted f <*> Unrestricted x = Unrestricted (f x)


### PR DESCRIPTION
Moved `Unrestricted`, `Movable`, `Dupable`, `Consumable` to their own module (still exported by `Prelude.Linear` though) and added `Data.Monoid.Linear`.

Replaces #46.