### PR TITLE
Temporary patch to workaround #380 in linear ghc

### DIFF
--- a/src/Data/Bifunctor/Linear.hs
+++ b/src/Data/Bifunctor/Linear.hs
@@ -64,5 +64,7 @@ instance SymmetricMonoidal (,) () where
 instance SymmetricMonoidal Either Void where
   swap = either Right Left
   rassoc (Left (Left x)) = Left x
-  rassoc (Left (Right x)) = Right (Left x)
-  rassoc (Right x) = Right (Right x)
+  rassoc (Left (Right x)) = (Right :: a ->. Either b a) (Left x)
+  rassoc (Right x) = (Right :: a ->. Either b a) (Right x)
+-- XXX: the above type signatures are necessary for certain older versions of
+-- the compiler, and as such are temporary

--- a/src/Data/Profunctor/Kleisli/Linear.hs
+++ b/src/Data/Profunctor/Kleisli/Linear.hs
@@ -64,4 +64,6 @@ instance Data.Functor f => Profunctor (CoKleisli f) where
 
 -- instance of a more general idea, but this will do for now
 instance Strong Either Void (CoKleisli (Data.Const x)) where
-  first (CoKleisli f) = CoKleisli (\(Data.Const x) -> Left (f (Data.Const x)))
+  first (CoKleisli f) = CoKleisli (\(Data.Const x) -> (Left :: a ->. Either a b) (f (Data.Const x)))
+-- XXX: the above type signature is necessary for certain older versions of
+-- the compiler, and as such is temporary


### PR DESCRIPTION
For ghc-8.9.0.20190613, there is a bug in linearity checking (see also discussion in #43 
https://github.com/tweag/ghc/issues/380

This introduces a temporary fix so that linear-base compiles.