### PR TITLE
Use deriving via for Prelude Semigroup instances

### DIFF
--- a/src/Data/Array/Polarized/Pull/Internal.hs
+++ b/src/Data/Array/Polarized/Pull/Internal.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-partial-type-signatures #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LinearTypes #-}
 {-# LANGUAGE NoImplicitPrelude #-}
@@ -11,6 +12,7 @@ import Prelude.Linear
 import qualified Prelude
 import Data.Vector (Vector)
 import qualified Data.Vector as Vector
+import Data.Monoid.Linear
 
 import qualified Unsafe.Linear as Unsafe
 
@@ -19,6 +21,7 @@ import qualified Unsafe.Linear as Unsafe
 -- is called at a point out of range, the result is an error.
 data Array a where
   Array :: (Int -> a) -> Int -> Array a
+  deriving Prelude.Semigroup via NonLinear (Array a)
 -- Int is movable, so this is the same as Array :: (Int ->. a) -> ...
 
 instance Data.Functor Array where
@@ -45,9 +48,6 @@ append (Array f m) (Array g n) = Array (\k -> if k < m then f k else g (k-m)) (m
 make :: a -> Int -> Array a
 make x n = fromFunction (const x) n
 
--- TODO: Use a derivingvia combinator to omit this
-instance Prelude.Semigroup (Array a) where
-  a <> b = append a b
 instance Semigroup (Array a) where
   (<>) = append
 

--- a/src/Data/Array/Polarized/Push.hs
+++ b/src/Data/Array/Polarized/Push.hs
@@ -15,11 +15,13 @@ import Data.Array.Destination (DArray)
 import qualified Data.Array.Destination as DArray
 import qualified Data.Functor.Linear as Data
 import Data.Vector (Vector)
-import Prelude.Linear hiding (zip, zipWith, foldr)
+import Prelude.Linear
 import qualified Prelude
+import Data.Monoid.Linear
 
 data Array a where
   Array :: (forall b. (a ->. b) -> DArray b ->. ()) ->. Int -> Array a
+  deriving Prelude.Semigroup via NonLinear (Array a)
   -- A note on implementation: `exists b. ((a -> b), DArray b)` adjoins freely
   -- the structure of contravariant functor to `DArray`. Because it appears to
   -- the left of an arrow, we can curry the existential quantification (and,
@@ -34,8 +36,6 @@ data Array a where
 instance Data.Functor Array where
   fmap f (Array k n) = Array (\g dest -> k (g . f) dest) n
 
-instance Prelude.Semigroup (Array a) where
-  a <> b = append a b
 instance Semigroup (Array a) where
   (<>) = append
 


### PR DESCRIPTION
Tiny fix to simplify instances for Prelude Semigroups