### PR TITLE
Transformer instances

### DIFF
--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -48,6 +48,7 @@ library
     vector
   default-language:    Haskell2010
   other-modules:
+    Control.Monad.Linear.Internal
     Data.Functor.Linear.Internal
     Data.Functor.Linear.Internal.Traversable
     Data.Array.Polarized.Pull.Internal

--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -45,6 +45,7 @@ library
     ghc-prim,
     storable-tuple,
     text,
+    transformers,
     vector
   default-language:    Haskell2010
   other-modules:

--- a/src/Control/Monad/Linear.hs
+++ b/src/Control/Monad/Linear.hs
@@ -1,8 +1,5 @@
-{-# LANGUAGE GADTs #-}
 {-# LANGUAGE LinearTypes #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 
 module Control.Monad.Linear
   ( -- * Linear monad hierarchy

--- a/src/Control/Monad/Linear.hs
+++ b/src/Control/Monad/Linear.hs
@@ -9,6 +9,7 @@ module Control.Monad.Linear
     -- $monad
     Functor(..)
   , (<$>)
+  , (<$)
   , dataFmapDefault
   , Applicative(..)
   , dataPureDefault
@@ -21,82 +22,9 @@ module Control.Monad.Linear
   , foldM
   ) where
 
-import Prelude.Linear.Internal.Simple (foldr, id)
-import Prelude (String)
-import qualified Data.Functor.Linear.Internal as Data
+import Control.Monad.Linear.Internal
+import Data.Unrestricted.Linear
 
--- $monad
-
--- TODO: explain that the category of linear function is self-enriched, and that
--- this is a hierarchy of enriched monads. In order to have some common
--- vocabulary.
-
--- There is also room for another type of functor where map has type `(a ->.b)
--- -> f a ->. f b`. `[]` and `Maybe` are such functors (they are regular
--- (endo)functors of the category of linear functions whereas `LFunctor` are
--- enriched functors). A Traversable hierarchy would start with non-enriched
--- functors.
-
--- TODO: make the laws explicit
-
--- | Enriched linear functors.
-class Data.Functor f => Functor f where
-  fmap :: (a ->. b) ->. f a ->. f b
-
-(<$>) :: Functor f => (a ->. b) ->. f a ->. f b
-(<$>) = fmap
-{-# INLINE (<$>) #-}
-
-dataFmapDefault :: Functor f => (a ->. b) -> f a ->. f b
-dataFmapDefault f = fmap f
-
--- | Enriched linear applicative functors
-class (Data.Applicative f, Functor f) => Applicative f where
-  {-# MINIMAL pure, ((<*>) | liftA2) #-}
-  pure :: a ->. f a
-  (<*>) :: f (a ->. b) ->. f a ->. f b
-  (<*>) = liftA2 id
-  liftA2 :: (a ->. b ->. c) ->. f a ->. f b ->. f c
-  liftA2 f x y = f <$> x <*> y
-
-dataPureDefault :: Applicative f => a -> f a
-dataPureDefault x = pure x
-
--- | Enriched linear monads
-class Applicative m => Monad m where
-  {-# MINIMAL (>>=) #-}
-  (>>=) :: m a ->. (a ->. m b) ->. m b
-  (>>) :: m () ->. m a ->. m a
-  m >> k = m >>= (\() -> k)
-
--- | Handles pattern-matching failure in do-notation. See 'Control.Monad.Fail'.
-class Monad m => MonadFail m where
-  fail :: String -> m a
-
-{-# INLINE return #-}
-return :: Monad m => a ->. m a
-return x = pure x
-
-join :: Monad m => m (m a) ->. m a
-join action = action >>= id
-
--- | Convenience operator to define Applicative instances in terms of Monad
-ap :: Monad m => m (a ->. b) ->. m a ->. m b
-ap f x = f >>= (\f' -> fmap f' x)
-
--- | DerivingVia combinators for Data.XXX in terms of Control.XXX
-newtype Data f a = Data (f a)
-
-instance Functor f => Data.Functor (Data f) where
-  fmap f (Data x) = Data (fmap f x)
-
-instance Applicative f => Data.Applicative (Data f) where
-  pure x = Data (pure x)
-  Data f <*> Data x = Data (f <*> x)
-
--- | Linearly typed replacement for the standard 'foldM' function.
-foldM :: forall m a b. Monad m => (b ->. a ->. m b) -> b ->. [a] ->. m b
-foldM f z0 xs = foldr f' return xs z0
-  where
-    f' :: a ->. (b ->. m b) ->. b ->. m b
-    f' x k z = f z x >>= k
+-- | Linearly typed replacement for the standard '(Prelude.<$)' function.
+(<$) :: (Functor f, Consumable b) => a ->. f b ->. f a
+a <$ fb = fmap (`lseq` a) fb

--- a/src/Control/Monad/Linear/Internal.hs
+++ b/src/Control/Monad/Linear/Internal.hs
@@ -1,0 +1,98 @@
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE RebindableSyntax #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Control.Monad.Linear.Internal where
+
+import Prelude.Linear.Internal.Simple
+import Prelude (String)
+import Data.Functor.Identity
+import qualified Data.Functor.Linear.Internal as Data
+
+-- $monad
+
+-- TODO: explain that the category of linear function is self-enriched, and that
+-- this is a hierarchy of enriched monads. In order to have some common
+-- vocabulary.
+
+-- There is also room for another type of functor where map has type `(a ->.b)
+-- -> f a ->. f b`. `[]` and `Maybe` are such functors (they are regular
+-- (endo)functors of the category of linear functions whereas `LFunctor` are
+-- enriched functors). A Traversable hierarchy would start with non-enriched
+-- functors.
+
+-- TODO: make the laws explicit
+
+-- | Enriched linear functors.
+class Data.Functor f => Functor f where
+  fmap :: (a ->. b) ->. f a ->. f b
+
+-- | Enriched linear applicative functors
+class (Data.Applicative f, Functor f) => Applicative f where
+  {-# MINIMAL pure, ((<*>) | liftA2) #-}
+  pure :: a ->. f a
+  (<*>) :: f (a ->. b) ->. f a ->. f b
+  (<*>) = liftA2 id
+  liftA2 :: (a ->. b ->. c) ->. f a ->. f b ->. f c
+  liftA2 f x y = f <$> x <*> y
+
+-- | Enriched linear monads
+class Applicative m => Monad m where
+  {-# MINIMAL (>>=) #-}
+  (>>=) :: m a ->. (a ->. m b) ->. m b
+  (>>) :: m () ->. m a ->. m a
+  m >> k = m >>= (\() -> k)
+
+-- | Handles pattern-matching failure in do-notation. See 'Control.Monad.Fail'.
+class Monad m => MonadFail m where
+  fail :: String -> m a
+
+---------------------------
+-- Convenience operators --
+---------------------------
+
+dataFmapDefault :: Functor f => (a ->. b) -> f a ->. f b
+dataFmapDefault f = fmap f
+
+dataPureDefault :: Applicative f => a -> f a
+dataPureDefault x = pure x
+
+{-# INLINE (<$>) #-}
+(<$>) :: Functor f => (a ->. b) ->. f a ->. f b
+(<$>) = fmap
+
+{-# INLINE return #-}
+return :: Monad m => a ->. m a
+return x = pure x
+
+join :: Monad m => m (m a) ->. m a
+join action = action >>= id
+
+-- | Convenience operator to define Applicative instances in terms of Monad
+ap :: Monad m => m (a ->. b) ->. m a ->. m b
+ap f x = f >>= (\f' -> fmap f' x)
+
+-------------------
+-- Miscellaneous --
+-------------------
+
+-- | Linearly typed replacement for the standard 'foldM' function.
+foldM :: forall m a b. Monad m => (b ->. a ->. m b) -> b ->. [a] ->. m b
+foldM f z0 xs = foldr f' return xs z0
+  where
+    f' :: a ->. (b ->. m b) ->. b ->. m b
+    f' x k z = f z x >>= k
+
+-----------------------------------------------
+-- Deriving Data.XXX in terms of Control.XXX --
+-----------------------------------------------
+
+newtype Data f a = Data (f a)
+
+instance Functor f => Data.Functor (Data f) where
+  fmap f (Data x) = Data (fmap f x)
+
+instance Applicative f => Data.Applicative (Data f) where
+  pure x = Data (pure x)
+  Data f <*> Data x = Data (f <*> x)

--- a/src/Data/Functor/Linear.hs
+++ b/src/Data/Functor/Linear.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE LinearTypes #-}
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
 -- | = The data functor hierarchy
@@ -17,7 +16,7 @@ module Data.Functor.Linear
   ( Functor(..)
   , Applicative(..)
   , (<$>)
-  , Reader(..), runReader
+  , (<$)
   , Const(..)
     -- * Linear traversable hierarchy
     -- $ traversable

--- a/src/Data/Functor/Linear.hs
+++ b/src/Data/Functor/Linear.hs
@@ -29,3 +29,7 @@ module Data.Functor.Linear
 import Data.Functor.Linear.Internal
 import Data.Functor.Linear.Internal.Traversable
 import Data.Functor.Const
+import Data.Unrestricted.Linear
+
+(<$) :: (Functor f, Consumable b) => a -> f b ->. f a
+a <$ fb = fmap (`lseq` a) fb

--- a/src/Data/Functor/Linear/Internal.hs
+++ b/src/Data/Functor/Linear/Internal.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE LinearTypes #-}
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
 -- | = The data functor hierarchy
@@ -19,6 +18,12 @@ import Prelude.Linear.Internal.Simple
 import Prelude (Maybe(..), Either(..))
 import Data.Functor.Const
 import Data.Monoid.Linear
+import Data.Functor.Identity
+import qualified Control.Monad.Trans.Reader as NonLinear
+import qualified Control.Monad.Trans.Cont as NonLinear
+import qualified Control.Monad.Trans.Maybe as NonLinear
+import qualified Control.Monad.Trans.Except as NonLinear
+import qualified Control.Monad.Trans.State.Strict as Strict
 
 class Functor f where
   fmap :: (a ->. b) -> f a ->. f b
@@ -27,13 +32,20 @@ class Functor f where
 (<$>) = fmap
 
 -- | Data 'Applicative'-s can be seen as containers which can be zipped
--- together. A prime example of data 'Applicative' are vectors of known lengths
+-- together. A prime example of data 'Applicative' are vectors of known length
 -- ('ZipLists' would be, if it were not for the fact that zipping them together
 -- drops values, which we are not allowed to do in a linear container).
 --
 -- In fact, an applicative functor is precisely a functor equipped with (pure
 -- and) @liftA2 :: (a ->. b ->. c) -> f a ->. f b ->. f c@. In the case where
--- @f = []@, the signature of 'liftA2' specialises to that of 'zipWith'.
+-- @f = []@, the signature of 'liftA2' would specialise to that of 'zipWith'.
+--
+-- Intuitively, Data 'Applicative's can be seen as containers whose "number" of
+-- elements is known at compile-time. This includes vectors of known length
+-- but excludes 'Maybe', since this may contain either zero or one value.
+-- Similarly, @((->) r)@ forms a Data 'Applicative', since this is a (possibly
+-- infinitary) container indexed by @r@, while lists do not, since they may
+-- contain any number of elements.
 --
 -- == Remarks for the mathematically inclined
 --
@@ -58,6 +70,7 @@ class Functor f => Applicative f where
 -- Instances --
 ---------------
 
+-- Standard instances
 instance Functor [] where
   fmap _f [] = []
   fmap f (a:as) = f a : fmap f as
@@ -77,14 +90,48 @@ instance Functor (Either e) where
   fmap _ (Left x) = Left x
   fmap f (Right x) = Right (f x)
 
-newtype Reader r x = Reader (r ->. x)
--- TODO: replace below with a newtype deconstructor once record projections
--- are inferred properly
-runReader :: Reader r x ->. r ->. x
-runReader (Reader f) = f
-
-instance Functor (Reader r) where
-  fmap f (Reader g) = Reader (f . g)
-
 instance Functor ((,) a) where
   fmap f (x,y) = (x, f y)
+
+instance Monoid a => Applicative ((,) a) where
+  pure x = (mempty, x)
+  (u,f) <*> (v,x) = (u <> v, f x)
+
+instance Functor Identity where
+  fmap f (Identity x) = Identity (f x)
+
+instance Applicative Identity where
+  pure = Identity
+  Identity f <*> Identity x = Identity (f x)
+
+---------------------------------
+-- Monad transformer instances --
+---------------------------------
+
+instance Functor m => Functor (NonLinear.ReaderT r m) where
+  fmap f (NonLinear.ReaderT g) = NonLinear.ReaderT (\r -> fmap f (g r))
+
+instance Applicative m => Applicative (NonLinear.ReaderT r m) where
+  pure x = NonLinear.ReaderT (\_ -> pure x)
+  NonLinear.ReaderT f <*> NonLinear.ReaderT x = NonLinear.ReaderT (\r -> f r <*> x r)
+
+-- The below transformers are all Data.Functors and all fail to be
+-- Data.Applicatives without further restriction. In every case however,
+-- @pure :: a -> f a@ can be defined in the standard way.
+-- For @MaybeT@ and @ExceptT e@, the failure to be applicative is as detailed
+-- above: @Maybe@ and @Either e@ can contain 0 or 1 elements, and so fail
+-- to be applicative.
+-- To give applicative instances for ContT (resp. StateT), we require the
+-- parameter r (resp. s) to be Movable.
+
+instance Functor m => Functor (NonLinear.MaybeT m) where
+  fmap f (NonLinear.MaybeT x) = NonLinear.MaybeT $ fmap (fmap f) x
+
+instance Functor m => Functor (NonLinear.ExceptT e m) where
+  fmap f (NonLinear.ExceptT x) = NonLinear.ExceptT $ fmap (fmap f) x
+
+instance Functor (NonLinear.ContT r m) where
+  fmap f (NonLinear.ContT x) = NonLinear.ContT $ \k -> x (\a -> k (f a))
+
+instance Functor m => Functor (Strict.StateT s m) where
+  fmap f (Strict.StateT x) = Strict.StateT (\s -> fmap (\(a, s') -> (f a, s')) (x s))

--- a/src/Data/Functor/Linear/Internal/Traversable.hs
+++ b/src/Data/Functor/Linear/Internal/Traversable.hs
@@ -15,7 +15,7 @@ module Data.Functor.Linear.Internal.Traversable
   , mapM, sequenceA, for, forM
   ) where
 
-import qualified Control.Monad.Linear as Control
+import qualified Control.Monad.Linear.Internal as Control
 import qualified Data.Functor.Linear.Internal as Data
 import Data.Functor.Const
 import Prelude.Linear.Internal.Simple

--- a/src/Data/Unrestricted/Linear.hs
+++ b/src/Data/Unrestricted/Linear.hs
@@ -30,7 +30,7 @@ module Data.Unrestricted.Linear
   ) where
 -- $ unrestricted
 
-import qualified Data.Functor.Linear as Data
+import qualified Data.Functor.Linear.Internal as Data
 import Data.Vector.Linear (V)
 import qualified Data.Vector.Linear as V
 import GHC.TypeLits

--- a/src/Prelude/Linear.hs
+++ b/src/Prelude/Linear.hs
@@ -89,10 +89,6 @@ forget f x = f x
 flip :: (a -->.(p) b -->.(q) c) -->.(r) b -->.(q) a -->.(p) c
 flip f b a = f a b
 
--- | Linearly typed replacement for the standard '(Prelude.<$)' function.
-(<$) :: (Control.Functor f, Consumable b) => a ->. f b ->. f a
-a <$ fb = Control.fmap (`lseq` a) fb
-
 -- | Linearly typed replacement for the standard '(Prelude.<*)' function.
 (<*) :: (Data.Applicative f, Consumable b) => f a ->. f b ->. f a
 fa <* fb = Data.fmap (flip lseq) fa Data.<*> fb

--- a/src/Prelude/Linear.hs
+++ b/src/Prelude/Linear.hs
@@ -5,7 +5,6 @@ module Prelude.Linear
   ( -- * Standard 'Prelude' function with linear types
     -- $linearized-prelude
     ($)
-  , (<$)
   , (<*)
   , foldr
   , const
@@ -38,7 +37,6 @@ module Prelude.Linear
   , module Prelude
   ) where
 
-import qualified Control.Monad.Linear as Control
 import qualified Data.Functor.Linear as Data
 import Data.Unrestricted.Linear
 import Data.Monoid.Linear


### PR DESCRIPTION
Created `Control.Monad.Linear.Internal`, and moved the majority of `Control.Monad.Linear` there.
This makes it possible to put `<$` in `Control.Monad.Linear`, since there is a different data version which may also be useful:
```haskell
(<$) :: (Functor f, Consumable b) => a -> f b ->. f a
```
for instance to replace every element of a list, one can use `3 Data.<$ [True, False, True]`.
(@facundominguez this may mean your use of `<$` for Control Functors needs to be adjusted to Linear.<$, if you import Control.Monad.Linear as Linear).

Also adds Functor/Monad instances for some standard monad transformers from `transformers`, where appropriate, but the transformers are not re-exported.