### PR TITLE
Some typo fixes

### DIFF
--- a/src/Data/Array/Polarized/Push.hs
+++ b/src/Data/Array/Polarized/Push.hs
@@ -22,9 +22,9 @@ import Data.Monoid.Linear
 
 -- TODO: the below isn't really true yet since no friendly way of constructing
 -- a PushArray directly is given yet (see issue #62), but the spirit holds.
--- TODO: There's also a slight lie in that one might one to consume a PushArray
--- into a commutative monoid, for instance summing all the elements, and this
--- is not yet possible, although it should be.
+-- TODO: There's also a slight lie in that one might want to consume a
+-- PushArray into a commutative monoid, for instance summing all the elements,
+-- and this is not yet possible, although it should be.
 
 -- | PushArrays are those arrays which are friendly in returned value position.
 -- They are easy to create and can be constructed by supplying elements in any

--- a/src/Data/Functor/Linear/Internal.hs
+++ b/src/Data/Functor/Linear/Internal.hs
@@ -33,19 +33,19 @@ class Functor f where
 
 -- | Data 'Applicative'-s can be seen as containers which can be zipped
 -- together. A prime example of data 'Applicative' are vectors of known length
--- ('ZipLists' would be, if it were not for the fact that zipping them together
+-- ('ZipList's would be, if it were not for the fact that zipping them together
 -- drops values, which we are not allowed to do in a linear container).
 --
 -- In fact, an applicative functor is precisely a functor equipped with (pure
 -- and) @liftA2 :: (a ->. b ->. c) -> f a ->. f b ->. f c@. In the case where
 -- @f = []@, the signature of 'liftA2' would specialise to that of 'zipWith'.
 --
--- Intuitively, Data 'Applicative's can be seen as containers whose "number" of
--- elements is known at compile-time. This includes vectors of known length
--- but excludes 'Maybe', since this may contain either zero or one value.
--- Similarly, @((->) r)@ forms a Data 'Applicative', since this is a (possibly
--- infinitary) container indexed by @r@, while lists do not, since they may
--- contain any number of elements.
+-- Intuitively, the type of 'liftA2' means that 'Applicative's can be seen as
+-- containers whose "number" of elements is known at compile-time. This
+-- includes vectors of known length but excludes 'Maybe', since this may
+-- contain either zero or one value.  Similarly, @((->) r)@ forms a Data
+-- 'Applicative', since this is a (possibly infinitary) container indexed by
+-- @r@, while lists do not, since they may contain any number of elements.
 --
 -- == Remarks for the mathematically inclined
 --


### PR DESCRIPTION
Fixed some typos, and added that Applicatives should be _non-empty_ fixed size containers.