### PR TITLE
Rewriting hashmap implementation for correctness

### DIFF
--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -82,7 +82,6 @@ test-suite test
     tasty,
     tasty-hedgehog,
     mmorph
-
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   default-language: Haskell2010
 

--- a/src/Data/HashMap/Linear.hs
+++ b/src/Data/HashMap/Linear.hs
@@ -3,10 +3,13 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE MagicHash #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UnliftedNewtypes #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
 {-# OPTIONS_GHC -Wno-incomplete-patterns #-}
 
@@ -14,27 +17,25 @@
 -- This module provides mutable hashmaps with a linear interface.
 --
 -- To use mutable hashmaps, create a linear computation of type
--- @HashMap k v #-> Unrestricted b@ and feed it to 'singleton' with
--- an initial key-value pair @(k,v)@.
+-- @HashMap k v #-> Unrestricted b@ and feed it to 'empty'.
 --
 -- This hashmap is implemented with robin hood hashing which has good average
 -- case performance.
 module Data.HashMap.Linear
   ( -- * A mutable hashmap
     HashMap,
+    Keyed,
+    Size(..),
     -- * Run a computation using a 'HashMap'
-    singleton,
-    singleton',
+    empty,
     -- * Modifiers and Constructors
-    alter,
     insert,
     delete,
     insertAll,
     -- * Accessors
     size,
-    member,
     lookup,
-    Keyed,
+    member
   )
 where
 
@@ -42,9 +43,10 @@ import Data.Array.Mutable.Linear
 import Data.Hashable
 import Data.Unrestricted.Linear
 import Prelude.Linear hiding ((+), lookup, read)
-import qualified Unsafe.Linear as Unsafe
 import Prelude ((+))
 import qualified Prelude
+import qualified Unsafe.Linear as Unsafe
+import GHC.Stack
 
 -- # Implementation Notes
 -- This is a simple implementatation of robin hood hashing.
@@ -59,218 +61,219 @@ import qualified Prelude
 -- # Core Data Types
 --------------------------------------------------
 
--- | Robin values are triples of the key, value and PSL
--- (the probe sequence length).
-type RobinVal k v = (k, v, PSL)
-
--- | A probe sequence length
-newtype PSL = PSL Int
-  deriving (Prelude.Eq, Prelude.Ord, Prelude.Num, Prelude.Show)
-
--- | An array of Robin values
-type RobinArr k v = Array (RobinVal k v)
-
--- | At minimum, we need to store hashable
--- and identifiable keys
-type Keyed k = (Eq k, Hashable k)
-
 -- | A mutable hashmap with a linear API
 data HashMap k v where
   -- | HashMap (size,count) array-of-robin-values
   -- The size is the amount of memory the array takes up.
   -- The count is the number of stored mappings.
   -- Our sparseness invariant: count*3 <= size.
-  HashMap :: (Int, Int) -> RobinArr k v #-> HashMap k v
+  HashMap :: Size -> Count -> RobinArr k v #-> HashMap k v
 
 -- INVARIANTS:
 --   * Cells are empty iff the PSL is -1.
---   * We are sparse: count*3 <= size, with correct values of count and size
 --   * Each (RobinVal k v) has the correct PSL
+--   * We NEVER evaluate the key-val pair for PSL -1
+--     since it might be (error "some message")
+
+-- | The size allocated for the array
+newtype Size = Size Int
+  deriving (Prelude.Num)
+
+-- | The number of pairs stored in the hashmap
+newtype Count = Count Int
+  deriving (Prelude.Num)
+
+-- | An array of Robin values
+type RobinArr k v = Array (RobinVal k v)
+
+-- | Robin values are triples of the key, value and PSL
+-- (the probe sequence length).
+type RobinVal k v = (PSL, (k, v))
+
+-- | A probe sequence length
+newtype PSL = PSL Int
+  deriving (Prelude.Eq, Prelude.Ord, Prelude.Num, Prelude.Show)
+
+-- | At minimum, we need to store hashable
+-- and identifiable keys
+type Keyed k = (Eq k, Hashable k)
 
 -- | The results of searching for where to insert a key
-data RobinQuery k where
+data ProbeResult k where
   -- | A key, PSL pair to insert at an index, that has not
   -- yet been touched. Invariant: the PSL must be -1 at that index.
-  IndexToInsert :: (k, PSL) -> Int -> RobinQuery k
+  IndexToInsert :: (k, PSL) -> Int -> ProbeResult k
   -- A key, PSL pair to update the value at an index.
-  IndexToUpdate :: (k, PSL) -> Int -> RobinQuery k
+  IndexToUpdate :: (k, PSL) -> Int -> ProbeResult k
   -- | A key, PSL pair for a swap at an index.
   -- The swapped-out pair will then need to be inserted downstream.
-  IndexToSwap :: (k, PSL) -> Int -> RobinQuery k
+  IndexToSwap :: (k, PSL) -> Int -> ProbeResult k
+
 
 -- # Construction and Modification
 --------------------------------------------------
 
--- | Run a computation using a singleton hashmap
-singleton :: Keyed k =>
-  (k, v) -> (HashMap k v #-> Unrestricted b) -> Unrestricted b
-singleton (k :: k, v :: v) (f :: HashMap k v #-> Unrestricted b) =
-  alloc defaultSize (k, v, -1) applyHM
+-- | Run a computation given an empty hashmap
+empty :: forall k v b.
+  Keyed k => Size -> (HashMap k v #-> Unrestricted b) -> Unrestricted b
+empty sz@(Size s) scope =
+  alloc
+    s
+    ( -1
+    , ( error "reading error hashmap key"
+      , error "reading error hashmap val"
+      )
+    )
+    scope'
   where
-    applyHM :: Array (RobinVal k v) #-> Unrestricted b
-    applyHM arr = let ixToHash = (hash k) `mod` defaultSize in
-      f $ HashMap (defaultSize, 1) (write arr ixToHash (k, v, 0))
+    scope' :: RobinArr k v #-> Unrestricted b
+    scope' arr = scope $ HashMap sz (Count 0) arr
 
-singleton' :: Keyed k =>
-  (k, v) -> (HashMap k v #-> Unrestricted b) -> b
-singleton' kv f = unUnrestricted (singleton kv f)
+-- | If the key is present, this update the value.
+-- If not, if there's enough space, insert a new pair.
+-- If there isn't enough space, resize and insert
+insert :: (Keyed k, HasCallStack) => HashMap k v #-> k -> v -> HashMap k v
+insert (HashMap sz@(Size s) ct@(Count c) arr) k v = case c < s of
+  False -> resizeMap (HashMap sz ct arr) & \case
+    !hmap' -> insert hmap' k v
+  True -> tryInsertAtIndex (HashMap sz ct arr) ((hash k) `mod` s) (k,0) v
 
--- XXX: re-write linearly
--- | Given a key @k@ to 'lookup', look up a @Maybe v@ and feed it to
--- a function @Maybe v -> Maybe v@, and if the result is @Nothing@,
--- delete that key, and otherwise, replace the value with the @v@
--- in the returned @Just v@.
-alter ::
-  Keyed k =>
-  HashMap k v #-> (Maybe v -> Maybe v) ->
-  k ->
-  HashMap k v
-alter = Unsafe.toLinear unsafeAlter
+-- | Try to insert at a given index with a given PSL. So the
+-- probing starts from the given index (with the given PSL).
+tryInsertAtIndex :: Keyed k =>
+  HashMap k v #-> Int -> (k, PSL) -> v -> HashMap k v
+tryInsertAtIndex hmap ix kPSL v = probeFrom kPSL ix hmap & \case
+  (HashMap sz ct arr, IndexToUpdate (k',psl') ix') ->
+    HashMap sz ct (write arr ix' (psl', (k',v)))
+  (HashMap sz (Count c) arr, IndexToInsert (k',psl') ix') ->
+    HashMap sz (Count (c + 1)) (write arr ix' (psl', (k',v)))
+  (HashMap (Size s) ct arr, IndexToSwap (k',psl') ix') -> read arr ix' & \case
+    (arr'', Unrestricted (p_old, (k_old, v_old))) ->
+      tryInsertAtIndex
+        (HashMap (Size s) ct (write arr'' ix' (psl', (k',v))))
+        ((ix' + 1) `mod` s)
+        (k_old, p_old + 1)
+        v_old
+
+-- | Resizes the hashmap to be about 2.5 times the previous size
+resizeMap :: Keyed k => HashMap k v #-> HashMap k v
+resizeMap (HashMap (Size s) _ arr) = extractPairs arr & \case
+  (arr', Unrestricted kvs) ->
+    resizeSeed (s*2 + s`div`2) (-1, errKV) arr' & \case
+      arr'' ->
+        insertAll kvs (HashMap (Size (s*2 + s`div`2)) (Count 0) arr'')
   where
-    unsafeAlter :: Keyed k =>
-      HashMap k v -> (Maybe v -> Maybe v) -> k -> HashMap k v
-    unsafeAlter hmap f k =
-      case lookup hmap k of
-        (hmap', Unrestricted maybeV) -> case f maybeV of
-          Nothing -> delete hmap' k
-          Just v -> insert hmap' k v
+    errKV :: Keyed k => (k,v)
+    errKV =
+      ( error "reading error hashmap key"
+      , error "reading error hashmap val"
+      )
+    extractPairs :: Keyed k =>
+      RobinArr k v #-> (RobinArr k v, Unrestricted [(k,v)])
+    extractPairs arr = walk arr (s - 1) []
 
--- | If the key is present, this update the value,
--- otherwise insert a new key-value pair.
-insert :: Keyed k => HashMap k v #-> k -> v -> HashMap k v
-insert hmap k v = insertFromQuery v $ queryIndex (maybeResize hmap) k
-  where
-    insertFromQuery :: Keyed k =>
-      v -> (HashMap k v, RobinQuery k) #-> HashMap k v
-    insertFromQuery v (HashMap (!size, !count) arr, IndexToInsert (k, psl) ix) =
-      HashMap (size, count + 1) (write arr ix (k, v, psl))
-    insertFromQuery v (HashMap sizes arr, IndexToUpdate (k, psl) ix) =
-      HashMap sizes (write arr ix (k, v, psl))
-    insertFromQuery v (HashMap sizes arr, IndexToSwap (k, psl) ix) =
-      (Unsafe.toLinear swapFromRead) (read arr ix) sizes ix (k, v, psl)
-    -- XXX: This re-does the probe sequence of (k',v')
-    swapFromRead ::
-      Keyed k =>
-      (RobinArr k v, RobinVal k v) ->
-      (Int, Int) ->
-      Int ->
-      RobinVal k v ->
-      HashMap k v
-    swapFromRead (arr', (k', v', _)) sizes ix (k, v, psl) =
-      insert (HashMap sizes (write arr' ix (k, v, psl))) k' v'
+    walk :: Keyed k =>
+      RobinArr k v #-> Int -> [(k,v)] -> (RobinArr k v, Unrestricted [(k,v)])
+    walk arr ix kvs
+      | ix < 0 = (arr, Unrestricted kvs)
+      | otherwise = read arr ix & \case
+        (arr', Unrestricted (-1, _)) -> walk arr' (ix-1) kvs
+        (arr', Unrestricted (_, (!k,!v))) -> walk arr' (ix-1) ((k,v):kvs)
 
--- | This deletes the key-value pair if it is present, and otherwise does
--- nothing.
+-- | 'delete h k' deletes key k and its value if it is present.
+-- If it's not present, this does nothing.
 delete :: Keyed k => HashMap k v #-> k -> HashMap k v
-delete hmap k = deleteFromQuery $ queryIndex hmap k
-  where
-    deleteFromQuery :: Keyed k => (HashMap k v, RobinQuery k) #-> HashMap k v
-    deleteFromQuery (h, IndexToInsert _ _) = h
-    deleteFromQuery (h, IndexToSwap _ _) = h
-    deleteFromQuery (h, IndexToUpdate _ ix) =
-      shiftBack h ix
-    -- Continue to shift back the next element and decrease the PSL
-    -- until we see an element with PSL 0 (or an empty cell, with PSL -1).
-    -- The arguments are: `deleteShiftFrom (hashmap, size) index`
-    shiftBack :: Keyed k => HashMap k v #-> Int -> HashMap k v
-    shiftBack (HashMap (!size, !count) arr) ix =
-      HashMap (size, count -1) ((Unsafe.toLinear shiftBackArr) arr size ix)
-    -- XXX: make this linear
-    shiftBackArr :: Keyed k => RobinArr k v -> Int -> Int -> RobinArr k v
-    shiftBackArr arr size ix =
-      case read arr ((ix + 1) `mod` size) of
-        (arr', (_, _, PSL p)) | p <= 0 ->
-          case read arr' ix of
-            (arr'', (k', v', _)) -> write arr'' ix (k', v', -1)
-        (arr', (k, v, PSL p)) ->
-          let arr'' = (write arr' ix (k, v, PSL (p -1))) in
-            shiftBackArr arr''  size ((ix + 1) `mod` size)
+delete (HashMap sz@(Size s) ct@(Count c) arr) k =
+  probeFrom (k,0) ((hash k) `mod` s) (HashMap sz ct arr) & \case
+    (h, IndexToInsert _ _) -> h
+    (h, IndexToSwap _ _) -> h
+    (HashMap sz _ arr', IndexToUpdate _ ix) ->
+      write arr' ix (-1, (error "key", error "val")) & \case
+        arr'' -> shiftSegmentBackward sz arr'' ((ix + 1) `mod` s) & \case
+          arr''' -> HashMap sz (Count (c - 1)) arr'''
 
--- | If the load is too high resize by tripling the array.
--- XXX: This is ugly, but algorithmically simple and correct.
-maybeResize :: Keyed k => HashMap k v #-> HashMap k v
-maybeResize (HashMap (!size, !count) arr)
-  | count * 3 < size = HashMap (size, count) arr
-  | otherwise =
-    (Unsafe.toLinear withAssocList) $
-      (Unsafe.toLinear assocList) (HashMap (size, count) arr)
-  where
-    withAssocList :: Keyed k => (HashMap k v, [(k, v)]) -> HashMap k v
-    withAssocList (HashMap _ arr, kvs@((k, v) : _)) =
-      let resizedArr = resizeSeed (size * 3) (k, v, -1) arr in
-        insertAll kvs (HashMap (size * 3, 0) resizedArr)
-    assocList :: Keyed k => HashMap k v -> (HashMap k v, [(k, v)])
-    assocList h@(HashMap _ arr) = (h, filterValidPSL (snd (toList arr)))
-      where
-        filterValidPSL [] = []
-        filterValidPSL ((k, v, psl) : xs)
-          | psl < 0 = filterValidPSL xs
-          | otherwise = (k, v) : filterValidPSL xs
+-- | Shift all cells with PSLs > 0 in a continuous segment
+-- following the deleted cell, backwards by one and decrement
+-- their PSLs.
+shiftSegmentBackward :: Keyed k =>
+  Size -> RobinArr k v #-> Int -> RobinArr k v
+shiftSegmentBackward (Size s) arr ix = read arr ix & \case
+  (arr', Unrestricted (psl, kv)) ->
+    case psl <= 0 of
+      True -> arr'
+      False -> write arr' ix (-1, (error "key", error "val")) & \case
+        arr'' ->
+          shiftSegmentBackward
+            (Size s)
+            (write arr'' ((ix+s-1) `mod` s) (psl + (-1),kv))
+            ((ix+1) `mod` s)
 
--- | 'insert' (in the provided order) a list of key-value pairs to a given
--- hashmap.
+-- | 'insert' (in the provided order) a list of key-value pairs
+-- to a given hashmap.
 insertAll :: Keyed k => [(k, v)] -> HashMap k v #-> HashMap k v
 insertAll [] hmap = hmap
 insertAll ((k, v) : xs) hmap = insertAll xs (insert hmap k v)
+
+-- | Given a key, psl of the probe so far, current unread index, and
+-- a full hashmap, return a probe result: the place the key already
+-- exists, a place to swap from, or an unfilled cell to write over.
+probeFrom :: Keyed k =>
+  (k, PSL) -> Int -> HashMap k v #-> (HashMap k v, ProbeResult k)
+probeFrom (k, p) ix (HashMap sz@(Size s) ct arr) = read arr ix & \case
+  (arr', Unrestricted (PSL (-1), _)) ->
+    (HashMap sz ct arr', IndexToInsert (k, p) ix)
+  (arr', Unrestricted (psl,(k',_))) -> case k == k' of
+    -- Note: in the True case, we must have p == psl
+    True -> (HashMap sz ct arr', IndexToUpdate (k, psl) ix)
+    False -> case psl < p of
+      True -> (HashMap sz ct arr', IndexToSwap (k, p) ix)
+      False -> probeFrom (k, p+1) ((ix+1)`mod` s) (HashMap sz ct arr')
+
 
 -- # Querying
 --------------------------------------------------
 
 size :: HashMap k v #-> (HashMap k v, Int)
-size (HashMap (!size, !count) arr) = (HashMap (size, count) arr, count)
+size (HashMap sz ct@(Count c) arr) = (HashMap sz ct arr, c)
 
 member :: Keyed k => HashMap k v #-> k -> (HashMap k v, Bool)
-member hmap k = memberFromQuery (queryIndex hmap k)
-  where
-    memberFromQuery ::
-      Keyed k =>
-      (HashMap k v, RobinQuery k) #-> (HashMap k v, Bool)
-    memberFromQuery (h, IndexToInsert _ _) = (h, False)
-    memberFromQuery (h, IndexToSwap _ _) = (h, False)
-    memberFromQuery (h, IndexToUpdate _ _) = (h, True)
+member (HashMap (Size s) ct arr) k =
+  probeFrom (k,0) ((hash k) `mod` s) (HashMap (Size s) ct arr) & \case
+    (h, IndexToUpdate _ _) -> (h, True)
+    (h, IndexToInsert _ _) -> (h, False)
+    (h, IndexToSwap _ _) -> (h, False)
 
 lookup :: Keyed k => HashMap k v #-> k -> (HashMap k v, Unrestricted (Maybe v))
-lookup hmap k = (Unsafe.toLinear lookupFromIx) $ queryIndex hmap k
-  where
-    lookupFromIx :: (HashMap k v, RobinQuery k) -> (HashMap k v, Unrestricted (Maybe v))
-    lookupFromIx (h, IndexToInsert _ _) = (h, Unrestricted Nothing)
-    lookupFromIx (h@(HashMap _ arr), IndexToUpdate _ ix) =
-      case read arr ix of (_, (_, v, _)) -> (h, Unrestricted (Just v))
-    lookupFromIx (h, IndexToSwap _ _) = (h, Unrestricted Nothing)
+lookup (HashMap (Size s) ct arr) k =
+  probeFrom (k,0) ((hash k) `mod` s) (HashMap (Size s) ct arr) & \case
+    (HashMap sz ct arr, IndexToUpdate _ ix) -> read arr ix & \case
+      (arr', Unrestricted (_,(_,v))) ->
+        (HashMap sz ct arr', Unrestricted (Just v))
+    (h, IndexToInsert _ _) -> (h, Unrestricted Nothing)
+    (h, IndexToSwap _ _) -> (h, Unrestricted Nothing)
 
--- | Internal function:
--- Find the index a key ought to hash into, and the PSL it should have.
--- NOTE: if the underlying array is too small, this never terminates.
-queryIndex :: Keyed k => HashMap k v #-> k -> (HashMap k v, RobinQuery k)
-queryIndex = Unsafe.toLinear unsafeQueryIx
-  where
-    unsafeQueryIx :: Keyed k => HashMap k v -> k -> (HashMap k v, RobinQuery k)
-    unsafeQueryIx h@(HashMap (size, _) arr) key =
-      (h, walkDownArr (arr, (hash key) `mod` size) (key, 0) size)
-    walkDownArr :: Keyed k =>
-      (RobinArr k v, Int) -> (k, PSL) -> Int -> RobinQuery k
-    walkDownArr (arr, ix) (key, psl) size = case read arr ix of
-      (_, (_, _, psl_ix)) | psl_ix == (-1) -> IndexToInsert (key, psl) ix
-      (_, (k_ix, _, _)) | key == k_ix -> IndexToUpdate (key, psl) ix
-      (_, (_, _, psl_ix)) | psl_ix < psl -> IndexToSwap (key, psl) ix
-      _ -> walkDownArr (arr, (ix + 1) `mod` size) (key, psl + PSL 1) size
 
 -- # Instances
 --------------------------------------------------
 
 instance Consumable (HashMap k v) where
   consume :: HashMap k v #-> ()
-  consume (HashMap _ arr) = consume arr
+  consume (HashMap _ _ arr) = consume arr
 
 -- # This is provided for debugging only.
 instance (Show k, Show v) => Show (HashMap k v) where
-  show (HashMap _ robinArr) = show robinArr
+  show (HashMap _ _ robinArr) = toList robinArr & \case
+    (arr, xs) -> display (lseq arr xs)
 
--- # Internal Library
---------------------------------------------------
+display :: (Show k, Show v) => [RobinVal k v] #-> String
+display = Unsafe.toLinear wrapper
+  where
+    wrapper :: (Show k, Show v) => [RobinVal k v] -> String
+    wrapper xs = "[" ++ display' xs ++ "]"
 
--- | Default intial size of underlying array.
--- We initially assume space for 8 pairs, and allocate 8*3 slots.
--- We aim to make the number of pairs some power of two.
-defaultSize :: Int
-defaultSize = 24
+    display' :: (Show k, Show v) => [RobinVal k v] -> String
+    display' [] = ""
+    display' ((p,kv):xs) = p == (-1) & \case
+      True -> ("(" ++ show p ++ ", null)") ++ ", " ++ display' xs
+      False -> show (p,kv) ++ ", " ++ display' xs
+

--- a/test/Test/Data/Mutable/Set.hs
+++ b/test/Test/Data/Mutable/Set.hs
@@ -29,13 +29,10 @@ mutSetTests = testGroup "Mutable set tests" group
 group :: [TestTree]
 group =
   -- Tests of the form [accessor (mutator)]
-  [ testProperty "∀ x. member (sing x) x = True" memberSing1
-  , testProperty "∀ x,y/=x. member (sing x) y = False" memberSing2
-  , testProperty "∀ x. member (insert s x) x = True" memberInsert1
+  [ testProperty "∀ x. member (insert s x) x = True" memberInsert1
   , testProperty "∀ x,y/=x. member (insert s x) y = member s y" memberInsert2
   , testProperty "∀ x. member (delete s x) x = False" memberDelete1
   , testProperty "∀ x,y/=x. member (delete s x) y = member s y" memberDelete2
-  , testProperty "∀ x. size (sing x) = 1" sizeSing
   , testProperty "∀ s, x \\in s. size (insert s x) = size s" sizeInsert1
   , testProperty "∀ s, x \\notin s. size (insert s x) = size s + 1" sizeInsert2
   , testProperty "∀ s, x \\in s. size (delete s x) = size s - 1" sizeDelete1
@@ -50,7 +47,7 @@ type SetTester = Set.Set Int #-> Unrestricted (TestT IO ())
 -- | A random list
 nonemptyList :: Gen [Int]
 nonemptyList = do
-  size <- Gen.int $ Range.linearFrom 1 1 1000
+  size <- Gen.int $ Range.linearFrom 0 0 1000
   let size' = Range.singleton size
   Gen.list size' $ Gen.int $ Range.linearFrom 0 (-100) 100
 
@@ -70,27 +67,6 @@ getSnd (a, b) = lseq a (move b)
 
 -- # Tests
 --------------------------------------------------------------------------------
-
-memberSing1 :: Property
-memberSing1 = property $ do
-  val <- forAll value
-  let tester = memberSingTest val
-  test $ unUnrestricted Linear.$ Set.singleton val tester
-
-memberSingTest :: Int -> SetTester
-memberSingTest val set =
-  testEqual (Unrestricted True) (getSnd Linear.$ Set.member set val)
-
-memberSing2 :: Property
-memberSing2 = property $ do
-  val1 <- forAll value
-  val2 <- forAll $ Gen.filter (/= val1) value
-  let tester = memberSing2Test val2
-  test $ unUnrestricted Linear.$ Set.singleton val1 tester
-
-memberSing2Test :: Int -> SetTester
-memberSing2Test val2 set =
-  testEqual (Unrestricted False) (getSnd Linear.$ Set.member set val2)
 
 memberInsert1 :: Property
 memberInsert1 = property $ do
@@ -151,14 +127,6 @@ memberDelete2Test val1 val2 set = fromRead (Set.member set val2)
       testEqual
         (move memberVal2)
         (getSnd Linear.$ Set.member (Set.delete set val1) val2)
-
-sizeSing :: Property
-sizeSing = property $ do
-  val <- forAll value
-  test $ unUnrestricted Linear.$ Set.singleton val sizeSingTest
-
-sizeSingTest :: SetTester
-sizeSingTest set = testEqual (Unrestricted 1) (getSnd (Set.size set))
 
 sizeInsert1 :: Property
 sizeInsert1 = property $ do


### PR DESCRIPTION
Rewrote hashmaps in a much better style with an empty constructor and fixed several deep and confusing bugs.

Fixes #118 