### PR TITLE
Implement Data.{List,Foldable}.Linear

### DIFF
--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -31,7 +31,9 @@ library
     Data.Either.Linear
     Data.Eq.Linear
     Data.Functor.Linear
+    Data.Foldable.Linear
     Data.HashMap.Linear
+    Data.List.Linear
     Data.Maybe.Linear
     Data.Monoid.Linear
     Data.Num.Linear

--- a/src/Control/Monad/Linear/Internal.hs
+++ b/src/Control/Monad/Linear/Internal.hs
@@ -112,10 +112,8 @@ ap f x = f >>= (\f' -> fmap f' x)
 -- | Fold from left to right with a linear monad.
 -- This is a linear version of 'NonLinear.foldM'.
 foldM :: forall m a b. Monad m => (b #-> a #-> m b) -> b #-> [a] #-> m b
-foldM f z0 xs = foldr f' return xs z0
-  where
-    f' :: a #-> (b #-> m b) #-> b #-> m b
-    f' x k z = f z x >>= k
+foldM _ i [] = return i
+foldM f i (x:xs) = f i x >>= \i' -> foldM f i' xs
 
 -----------------------------------------------
 -- Deriving Data.XXX in terms of Control.XXX --

--- a/src/Data/Foldable/Linear.hs
+++ b/src/Data/Foldable/Linear.hs
@@ -1,0 +1,160 @@
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Data.Foldable.Linear where
+
+import qualified Prelude as Prelude
+import Prelude (Maybe(..), Either(..), Int, Ordering (..))
+import Prelude.Linear.Internal.Simple
+import Data.Unrestricted.Linear
+import Data.Eq.Linear
+import Data.Ord.Linear
+import Data.Bool.Linear
+import Data.Num.Linear
+import Data.Maybe.Linear
+import Data.List.NonEmpty (NonEmpty (..))
+import Data.Functor.Linear
+import Data.Monoid.Linear
+import Data.Ord (Down(Down))
+
+class Foldable t where
+    {-# MINIMAL foldMap | foldr #-}
+
+    fold :: Monoid m => t m #-> m
+    fold = foldMap id
+
+    foldMap' :: Monoid m => (a #-> m) -> t a #-> m
+    foldMap' f = foldl' (\acc a -> acc <> f a) mempty
+
+    foldMap :: Monoid m => (a #-> m) -> t a #-> m
+    {-# INLINE foldMap #-}
+    foldMap f = foldr ((<>) . f) mempty
+
+    foldr :: (a #-> b #-> b) -> b #-> t a #-> b
+    foldr f z t = appEndo (foldMap (Endo . f) t) z
+
+    foldr' :: forall a b. (a #-> b #-> b) -> b #-> t a -> b
+    foldr' f z0 xs = foldl f' id xs z0
+      where
+        f' :: (b #-> b) #-> a #-> b #-> b
+        f' k x z = k $! f x z
+
+    foldl :: (b #-> a #-> b) -> b #-> t a #-> b
+    foldl f z t = appEndo (getDual (foldMap (Dual . Endo . flip f) t)) z
+      where
+        getDual :: Dual a #-> a
+        getDual (Dual a) = a
+
+    foldl' :: forall a b. (b #-> a #-> b) -> b #-> t a #-> b
+    foldl' f z0 xs = foldr f' id xs z0
+       where
+         f' :: a #-> (b #-> b) #-> b #-> b
+         f' x k z = k $! f z x
+
+    foldr1 :: forall a. (a #-> a #-> a) -> t a #-> a
+    foldr1 f xs = fromMaybe (Prelude.errorWithoutStackTrace "foldr1: empty structure")
+                    (foldr mf Nothing xs)
+      where
+        mf :: a #-> Maybe a #-> Maybe a
+        mf x Nothing = Just x
+        mf x (Just y) = Just (f x y)
+
+    foldl1 :: forall a. (a #-> a #-> a) -> t a #-> a
+    foldl1 f xs = fromMaybe (Prelude.errorWithoutStackTrace "foldl1: empty structure")
+                    (foldl mf Nothing xs)
+      where
+        mf :: Maybe a #-> a #-> Maybe a
+        mf Nothing y = Just y
+        mf (Just x) y = Just (f x y)
+
+    toList :: t a #-> [a]
+    toList = foldr (:) []
+
+    -- | This is likely not very useful and only here to preserve the symmetry
+    -- between 'Prelude.Foldable'.
+    null :: Consumable a => t a #-> Bool
+    null = foldr (\x a -> (x, a) `lseq` False) True
+
+    length :: Consumable a => t a #-> Int
+    length = foldl' (\c a -> a `lseq` c + 1) 0
+
+    -- | This is likely not very useful and only here to preserve the symmetry
+    -- between 'Prelude.Foldable'.
+    elem :: Prelude.Eq a => a -> t a #-> Bool
+    elem x = any (== x)
+
+    minimum :: (Dupable a, Prelude.Ord a) => t a #-> a
+    minimum = minimumBy compare
+
+    maximum :: (Dupable a, Prelude.Ord a) => t a #-> a
+    maximum = maximumBy compare
+
+instance {-# OVERLAPPABLE #-} (Foldable t, Consumable a) => Consumable (t a) where
+  consume = foldl' (flip lseq) ()
+
+instance Foldable [] where
+  foldr f z = \case
+    [] -> z
+    x:xs -> f x (foldr f z xs)
+
+instance Foldable Maybe where
+  foldMap _ Nothing = mempty
+  foldMap f (Just s) = f s
+
+instance Foldable NonEmpty where
+  foldMap f (x:|xs) = f x <> foldMap f xs
+
+instance Consumable a => Foldable (Either a) where
+  foldMap f (Left l) = l `lseq` mempty
+  foldMap f (Right r) = f r
+
+maximumBy :: (Foldable t, Dupable a) => (a #-> a #-> Ordering) -> t a #-> a
+maximumBy cmp = foldl1 (\x y ->
+  dup (x, y) & \case
+    ((x1, y1), (x2, y2)) -> cmp x1 y1 & \case
+      GT -> y2 `lseq` x2
+      EQ -> x2 `lseq` y2
+      LT -> x2 `lseq` y2
+  )
+
+minimumBy :: (Foldable t, Dupable a) => (a #-> a #-> Ordering) -> t a #-> a
+minimumBy cmp = maximumBy (\x y -> cmp x y & \case
+    GT -> LT
+    EQ -> EQ
+    LT -> GT
+  )
+
+-- | __NOTE:__ This does not short-circuit, and always consumes the
+-- entire container.
+any :: Foldable t => (a #-> Bool) -> t a #-> Bool
+any p = foldl' (\b a -> b || p a) False
+
+-- | __NOTE:__ This does not short-circuit, and always consumes the
+-- entire container.
+all :: Foldable t => (a #-> Bool) -> t a #-> Bool
+all p = foldl' (\b a -> b && p a) True
+
+-- | __NOTE:__ This does not short-circuit, and always consumes the
+-- entire container.
+and :: Foldable t => t Bool #-> Bool
+and = foldl' (&&) True
+
+-- | __NOTE:__ This does not short-circuit, and always consumes the
+-- entire container.
+or :: Foldable t => t Bool #-> Bool
+or = foldl' (||) False
+
+traverse_ :: (Foldable t, Applicative f, Consumable b)
+          => (a #-> f b) -> t a #-> f ()
+traverse_ f = foldr (\x k -> f x *> k) (pure ())
+
+sequence_ :: (Foldable t, Applicative f, Consumable a)
+          => t (f a) #-> f ()
+sequence_ = traverse_ id
+
+foldMapDefault :: (Traversable t, Monoid m, Consumable (t ())) => (a #-> m) -> t a #-> m
+foldMapDefault f xs = sequence ((\a -> (f a, ())) <$> xs) & \case
+  (m, t) -> t `lseq` m

--- a/src/Data/Functor/Linear.hs
+++ b/src/Data/Functor/Linear.hs
@@ -22,6 +22,7 @@ module Data.Functor.Linear
   , Applicative(..)
   , (<$>)
   , (<$)
+  , (*>)
   , Const(..)
     -- * Linear traversable hierarchy
     -- $ traversable
@@ -30,6 +31,7 @@ module Data.Functor.Linear
   )
   where
 
+import Prelude.Linear.Internal.Simple
 import Data.Functor.Linear.Internal
 import Data.Functor.Linear.Internal.Traversable
 import Data.Functor.Const
@@ -39,3 +41,6 @@ import Data.Unrestricted.Linear
 -- and consume the functor @f b@.
 (<$) :: (Functor f, Consumable b) => a -> f b #-> f a
 a <$ fb = fmap (`lseq` a) fb
+
+(*>) :: (Applicative f, Consumable a) => f a #-> f b #-> f b
+fa *> fb = (id <$ fa) <*> fb

--- a/src/Data/List/Linear.hs
+++ b/src/Data/List/Linear.hs
@@ -4,7 +4,22 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Data.List.Linear
-  where
+  ( -- * Basic functions
+    map
+  , filter
+  , uncons
+  , reverse
+  , length
+  , splitAt
+  , span
+    -- * Zipping lists
+  , zip
+  , zip'
+  , zip3
+  , zipWith
+  , zipWith'
+  , zipWith3
+  ) where
 
 import qualified Unsafe.Linear as Unsafe
 import qualified Prelude as Prelude
@@ -14,6 +29,9 @@ import Prelude.Linear.Internal.Simple
 import Data.Unrestricted.Linear
 import Data.Functor.Linear
 import Data.List.NonEmpty (NonEmpty ((:|)))
+
+-- # Basic functions
+--------------------------------------------------
 
 map :: (a #-> b) -> [a] #-> [b]
 map = fmap
@@ -29,35 +47,6 @@ filter p (x:xs) =
       if p x'
       then x'' : filter p xs
       else x'' `lseq` filter p xs
-
-zip :: forall a b c. (Consumable a, Consumable b) => [a] #-> [b] #-> [(a, b)]
-zip = zipWith (,)
-
--- | Same as 'zip', but returns the leftovers instead of consuming them.
-zip' :: forall a b c. [a] #-> [b] #-> ([(a, b)], Maybe (Either (NonEmpty a) (NonEmpty b)))
-zip' = zipWith' (,)
-
-zip3 :: forall a b c. (Consumable a, Consumable b, Consumable c) => [a] #-> [b] #-> [c] #-> [(a, b, c)]
-zip3 = zipWith3 (,,)
-
-zipWith :: forall a b c. (Consumable a, Consumable b) => (a#->b#->c) -> [a] #-> [b] #-> [c]
-zipWith f [] ys = ys `lseq` []
-zipWith f xs [] = xs `lseq` []
-zipWith f (x:xs) (y:ys) = f x y : zipWith f xs ys
-
--- | Same as 'zipWith', but returns the leftovers instead of consuming them.
-zipWith' :: (a#->b#->c) -> [a] #-> [b] #-> ([c], Maybe (Either (NonEmpty a) (NonEmpty b)))
-zipWith' f [] [] = ([], Nothing)
-zipWith' f (a:as) [] = ([], Just (Left (a :| as)))
-zipWith' f [] (b:bs) = ([], Just (Right (b :| bs)))
-zipWith' f (a:as) (b:bs) = zipWith' f as bs & \case
-  (cs, rest) -> (f a b : cs, rest)
-
-zipWith3 :: forall a b c d. (Consumable a, Consumable b, Consumable c) => (a#->b#->c#->d) -> [a] #-> [b] #-> [c] #-> [d]
-zipWith3 f [] ys zs = (ys, zs) `lseq` []
-zipWith3 f xs [] zs = (xs, zs) `lseq` []
-zipWith3 f xs ys [] = (xs, ys) `lseq` []
-zipWith3 f (x:xs) (y:ys) (z:zs) = f x y z : zipWith3 f xs ys zs
 
 uncons :: [a] #-> Maybe (a, [a])
 uncons [] = Nothing
@@ -77,5 +66,51 @@ length [] = (0, [])
 length (x:xs) = length xs & \case
   (l, xs') -> (l+1, x:xs')
 
+--  'splitAt' @n xs@ returns a tuple where first element is @xs@ prefix of
+-- length @n@ and second element is the remainder of the list.
 splitAt :: Int -> [a] #-> ([a], [a])
 splitAt i = Unsafe.toLinear (Prelude.splitAt i)
+
+-- | 'span', applied to a predicate @p@ and a list @xs@, returns a tuple where
+-- first element is longest prefix (possibly empty) of @xs@ of elements that
+-- satisfy @p@ and second element is the remainder of the list.
+span :: Dupable a => (a #-> Bool) -> [a] #-> ([a], [a])
+span _ [] = ([], [])
+span f (x:xs) = dup x & \case
+  (x', x'') ->
+    if f x'
+    then span f xs & \case (ts, fs) -> (x'':ts, fs)
+    else ([x''], xs)
+
+-- # Zipping Lists
+--------------------------------------------------
+
+zip :: (Consumable a, Consumable b) => [a] #-> [b] #-> [(a, b)]
+zip = zipWith (,)
+
+-- | Same as 'zip', but returns the leftovers instead of consuming them.
+zip' :: [a] #-> [b] #-> ([(a, b)], Maybe (Either (NonEmpty a) (NonEmpty b)))
+zip' = zipWith' (,)
+
+zip3 :: (Consumable a, Consumable b, Consumable c) => [a] #-> [b] #-> [c] #-> [(a, b, c)]
+zip3 = zipWith3 (,,)
+
+zipWith :: (Consumable a, Consumable b) => (a#->b#->c) -> [a] #-> [b] #-> [c]
+zipWith _ [] ys = ys `lseq` []
+zipWith _ xs [] = xs `lseq` []
+zipWith f (x:xs) (y:ys) = f x y : zipWith f xs ys
+
+-- | Same as 'zipWith', but returns the leftovers instead of consuming them.
+zipWith' :: (a#->b#->c) -> [a] #-> [b] #-> ([c], Maybe (Either (NonEmpty a) (NonEmpty b)))
+zipWith' _ [] [] = ([], Nothing)
+zipWith' _ (a:as) [] = ([], Just (Left (a :| as)))
+zipWith' _ [] (b:bs) = ([], Just (Right (b :| bs)))
+zipWith' f (a:as) (b:bs) = zipWith' f as bs & \case
+  (cs, rest) -> (f a b : cs, rest)
+
+zipWith3 :: forall a b c d. (Consumable a, Consumable b, Consumable c) => (a#->b#->c#->d) -> [a] #-> [b] #-> [c] #-> [d]
+zipWith3 _ [] ys zs = (ys, zs) `lseq` []
+zipWith3 _ xs [] zs = (xs, zs) `lseq` []
+zipWith3 _ xs ys [] = (xs, ys) `lseq` []
+zipWith3 f (x:xs) (y:ys) (z:zs) = f x y z : zipWith3 f xs ys zs
+

--- a/src/Data/List/Linear.hs
+++ b/src/Data/List/Linear.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Data.List.Linear
+  where
+
+import qualified Unsafe.Linear as Unsafe
+import qualified Prelude as Prelude
+import Prelude (Bool, Maybe(..), Either(..), Int)
+import Data.Num.Linear
+import Prelude.Linear.Internal.Simple
+import Data.Unrestricted.Linear
+import Data.Functor.Linear
+import Data.List.NonEmpty (NonEmpty ((:|)))
+
+map :: (a #-> b) -> [a] #-> [b]
+map = fmap
+
+-- | @filter p xs@ returns a list with elements satisfying the predicate.
+-- 'Dupable' constraint is there because after apply the predicate to the
+-- elements, we possibly need to use the same element in the result.
+--
+-- See also: 'Data.Maybe.Linear.mapMaybe'
+filter :: Dupable a => (a #-> Bool) -> [a] #-> [a]
+filter _ [] = []
+filter p (x:xs) =
+  dup x & \case
+    (x', x'') ->
+      if p x'
+      then x'' : filter p xs
+      else x'' `lseq` filter p xs
+
+zip :: forall a b c. (Consumable a, Consumable b) => [a] #-> [b] #-> [(a, b)]
+zip = zipWith (,)
+
+-- | Same as 'zip', but returns the leftovers instead of consuming them.
+zip' :: forall a b c. [a] #-> [b] #-> ([(a, b)], Maybe (Either (NonEmpty a) (NonEmpty b)))
+zip' = zipWith' (,)
+
+zip3 :: forall a b c. (Consumable a, Consumable b, Consumable c) => [a] #-> [b] #-> [c] #-> [(a, b, c)]
+zip3 = zipWith3 (,,)
+
+zipWith :: forall a b c. (Consumable a, Consumable b) => (a#->b#->c) -> [a] #-> [b] #-> [c]
+zipWith f [] ys = ys `lseq` []
+zipWith f xs [] = xs `lseq` []
+zipWith f (x:xs) (y:ys) = f x y : zipWith f xs ys
+
+-- | Same as 'zipWith', but returns the leftovers instead of consuming them.
+zipWith' :: (a#->b#->c) -> [a] #-> [b] #-> ([c], Maybe (Either (NonEmpty a) (NonEmpty b)))
+zipWith' f [] [] = ([], Nothing)
+zipWith' f (a:as) [] = ([], Just (Left (a :| as)))
+zipWith' f [] (b:bs) = ([], Just (Right (b :| bs)))
+zipWith' f (a:as) (b:bs) = zipWith' f as bs & \case
+  (cs, rest) -> (f a b : cs, rest)
+
+zipWith3 :: forall a b c d. (Consumable a, Consumable b, Consumable c) => (a#->b#->c#->d) -> [a] #-> [b] #-> [c] #-> [d]
+zipWith3 f [] ys zs = (ys, zs) `lseq` []
+zipWith3 f xs [] zs = (xs, zs) `lseq` []
+zipWith3 f xs ys [] = (xs, ys) `lseq` []
+zipWith3 f (x:xs) (y:ys) (z:zs) = f x y z : zipWith3 f xs ys zs
+
+uncons :: [a] #-> Maybe (a, [a])
+uncons [] = Nothing
+uncons (x:xs) = Just (x, xs)
+
+reverse :: [a] #-> [a]
+reverse l = rev l []
+  where
+    rev :: [a] #-> [a] #-> [a]
+    rev [] a = a
+    rev (x:xs) a = rev xs (x:a)
+
+-- | Return a new list with the same elements alongside with
+-- its length.
+length :: [a] #-> (Int, [a])
+length [] = (0, [])
+length (x:xs) = length xs & \case
+  (l, xs') -> (l+1, x:xs')
+
+splitAt :: Int -> [a] #-> ([a], [a])
+splitAt i = Unsafe.toLinear (Prelude.splitAt i)

--- a/src/Data/List/Linear.hs
+++ b/src/Data/List/Linear.hs
@@ -19,10 +19,8 @@ map :: (a #-> b) -> [a] #-> [b]
 map = fmap
 
 -- | @filter p xs@ returns a list with elements satisfying the predicate.
--- 'Dupable' constraint is there because after apply the predicate to the
--- elements, we possibly need to use the same element in the result.
 --
--- See also: 'Data.Maybe.Linear.mapMaybe'
+-- See 'Data.Maybe.Linear.mapMaybe' if you do not want the 'Dupable' constraint.
 filter :: Dupable a => (a #-> Bool) -> [a] #-> [a]
 filter _ [] = []
 filter p (x:xs) =

--- a/src/Data/Vector/Mutable/Linear.hs
+++ b/src/Data/Vector/Mutable/Linear.hs
@@ -90,7 +90,7 @@ fromList xs@(x:_) (f :: Vector a #-> Unrestricted b) =
   constant (Prelude.length xs) x buildThenRun
   where
     buildThenRun :: Vector a #-> Unrestricted b
-    buildThenRun vec = f $ doWrites (zip xs [0..]) vec
+    buildThenRun vec = f $ doWrites (Prelude.zip xs [0..]) vec
 
     doWrites :: [(a,Int)] -> Vector a #-> Vector a
     doWrites [] vec = vec

--- a/src/Prelude/Linear.hs
+++ b/src/Prelude/Linear.hs
@@ -27,11 +27,13 @@ module Prelude.Linear
     ($)
   , (&)
   , (<*)
+  , flip
   , foldl
   , foldr
   , const
   , id
   , seq
+  , ($!)
   , curry
   , uncurry
   , (.)
@@ -67,14 +69,16 @@ import Data.Num.Linear
 import Data.Bool.Linear
 import Data.Either.Linear
 import Data.Maybe.Linear
+import Data.Foldable.Linear
 import Prelude hiding
   ( ($)
   , id
   , const
   , seq
+  , flip
+  , ($!)
   , curry
   , uncurry
-  , flip
   , foldl
   , foldr
   , (.)
@@ -91,20 +95,7 @@ import Prelude hiding
   , Monoid(..)
   , Num(..)
   )
-import GHC.Exts (FUN)
 import Prelude.Linear.Internal.Simple
-
--- XXX: temporary: with multiplicity polymorphism functions expecting a
--- non-linear arrow would allow a linear arrow passed, so this would be
--- redundant
--- | Convenience operator when a higher-order function expects a non-linear
--- arrow but we have a linear arrow
-forget :: (a #-> b) #-> a -> b
-forget f x = f x
-
--- | Replacement for the flip function with generalized multiplicities.
-flip :: FUN r (FUN p a (FUN q b c)) (FUN q b (FUN p a c))
-flip f b a = f a b
 
 -- | Linearly typed replacement for the standard '(Prelude.<*)' function.
 (<*) :: (Data.Applicative f, Consumable b) => f a #-> f b #-> f a


### PR DESCRIPTION
This PR implements the linear versions of `Data.List` and `Data.Foldable` modules. I am not a fan of the API yet, so this PR is just to open the discussion. Here are some notes:

* I found that there are usually a few ways to handle leftovers. Let's think about the function `any`:

  ```
  # Applies the predicate to all elements. After the first `True`, the rest is only to consume.
  any :: Foldable t => (a #-> Bool) -> t a #-> Bool
  # Applies the predicate until the first `True`, then uses the `Consumable` instance.
  any :: Consumable a => (a #-> Bool) -> t a #-> Bool
  # Applies the predicate until the first `True`, and return the leftovers.
  any :: (a #-> Bool) -> t a #-> (Bool, [a])
  ```

  From those three, the last one is the most generic, but unfortunately also the most confusing one. Especially when `t` is `[]`. I think it would be better to go with the generic one, but somehow make it clear that the return value is the leftovers. I am not sure how to do that, but maybe an explicit data type might work.

  I think I had this issue because I tried to replicate `Data.Foldable` function-by-function. But most functions there are not very useful in a linear context, such as `null`, `length` or `elem`. So, maybe it would be better to only implement some subset of functions on `Data.Foldable` and change `Data.List` functions type signatures to be more useful in a linear context.

* Especially `Data.List` comes with a lot of rewrite rules and annotations to make sure that the operations fuse. Replicating those might end up being a lot of work, especially since I do not completely understand how they work. In some cases we can't even `Unsafe.toLinear` them since our semantics are a bit different (we need to call `lseq` to forget the unused elements). So, this PR just implements the simplest versions.

* I do not think the linear `Foldable` can be derived from linear `Traversable`; as opposed to their base counterparts. I think the main reason is that `Foldable` gives you a way to get rid of the container, while `Traversable` doesn't. So, I could not implement `foldMapDefault` using only `Data.Traversable`. The closest I got was this:

  ```
  foldMapDefault :: (Traversable t, Monoid m, Consumable (t ())) => (a #-> m) -> t a #-> m
  foldMapDefault f xs = sequence ((\a -> (f a, ())) <$> xs)
    & \case (m, t) -> t `lseq` m
  ```

  which requires that ugly extra `Consumable (t ())` constraint. I think we can still make `Foldable` a superclass of `Traversable`, but I hesitated doing it without a discussion.

Do you think this is the right direction?
