### PR TITLE
Dependency updates

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,18 @@
+packages: *.cabal
+
+allow-newer: all
+
+-- If you update below, make sure to also update stack.yaml too
+
+source-repository-package
+  -- https://github.com/nick8325/quickcheck/pull/311
+  type: git
+  location: https://github.com/phadej/quickcheck.git
+  tag: d659a5e44b3304e7599321d506bf48d2e88389d0
+
+source-repository-package
+  -- https://github.com/hedgehogqa/haskell-hedgehog/pull/392
+  type: git
+  location: https://github.com/utdemir/haskell-hedgehog.git
+  tag: c98aa9e33bf6871098d6f4ac94eeaac10383d696
+  subdir: hedgehog

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,1 +1,1 @@
-import (fetchTarball "https://github.com/tweag/nixpkgs/archive/331f0ec32598e8a0984d9d5200f85535d28d7cbb.tar.gz")
+import (fetchTarball "https://github.com/nixos/nixpkgs/archive/96069f7d890b90cbf4e8b4b53e15b036210ac146.tar.gz")

--- a/shell.nix
+++ b/shell.nix
@@ -5,7 +5,9 @@ mkShell {
   LANG="C.UTF-8";
 
   buildInputs = [
-    haskell.compiler.ghcHEAD
+    (haskell.packages.ghcHEAD.ghcWithPackages (ps: [
+      cabal-install
+    ]))
     git
     nix
     stack

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
 # See https://hub.docker.com/r/tweag/linear-types/
-resolver: lts-16.2
+resolver: lts-16.8
 compiler: ghc-8.11
 allow-newer: true
 system-ghc: true
@@ -7,12 +7,16 @@ system-ghc: true
 packages:
 - '.'
 
+# If you update the extra-deps, make sure to also update cabal.project
 extra-deps:
-- git: https://github.com/facundominguez/quickcheck.git
-  commit: a498e7b41131cf7955b9e154ab26d37d1be10304
-- git: https://github.com/facundominguez/lifted-async.git
-  commit: 898eb485b21cc321058345998eedd8c409c326fd
-
+# https://github.com/nick8325/quickcheck/pull/311
+- git: https://github.com/phadej/quickcheck.git
+  commit: d659a5e44b3304e7599321d506bf48d2e88389d0
+# https://github.com/hedgehogqa/haskell-hedgehog/pull/392
+- git: https://github.com/utdemir/haskell-hedgehog.git
+  commit: c98aa9e33bf6871098d6f4ac94eeaac10383d696
+  subdirs:
+    - hedgehog
 nix:
   enable: true
   shell-file: shell-stack.nix


### PR DESCRIPTION
Copied from the commit messages:

> Update nixpkgs, stack resolver and extra-deps
>
>    * Use upstream nixpkgs instead of our fork (since the ghcHEAD is updated
>    there)
>    * Update stack resolver
>    * Remove lifted-async override since our change is now merged
>    * Use PR's for GHC 9 support from QuickCheck and Hedgehog repositories
>
> Support building with cabal-install
>
>    This commit adds a `cabal.project` file which has the required overrides
>    for upstream repositories. Unfortunately this causes some information
>    duplication.
>
>    It also adds `cabal-install` to nix-shell.

I belive this closes #125. At least it should, let me know if that requires
anything else.