### PR TITLE
Make sure that *.Linear modules only export linear functions

### DIFF
--- a/examples/Foreign/List.hs
+++ b/examples/Foreign/List.hs
@@ -12,7 +12,7 @@ module Foreign.List where
 import qualified Data.List as List
 import Foreign.Marshal.Pure (Pool, Box)
 import qualified Foreign.Marshal.Pure as Manual
-import Prelude.Linear hiding (map, foldl, foldr)
+import Prelude.Linear hiding (foldl, foldr)
 
 -- XXX: we keep the last Cons in Memory here. A better approach would be to
 -- always keep a Box instead.

--- a/src/Control/Optics/Linear/Internal.hs
+++ b/src/Control/Optics/Linear/Internal.hs
@@ -107,7 +107,7 @@ set :: Optic_ (->) a b s t -> b -> s -> t
 set (Optical l) x = l (const x)
 
 match :: Optic_ (Market a b) a b s t -> s #-> Either t a
-match (Optical l) = snd (runMarket (l (Market id Right)))
+match (Optical l) = P.snd (runMarket (l (Market id Right)))
 
 build :: Optic_ (Linear.CoKleisli (Const b)) a b s t -> b #-> t
 build (Optical l) x = Linear.runCoKleisli (l (Linear.CoKleisli getConst')) (Const x)

--- a/src/Data/Array/Destination.hs
+++ b/src/Data/Array/Destination.hs
@@ -20,7 +20,7 @@ import Data.Vector.Mutable (MVector)
 import qualified Data.Vector.Mutable as MVector
 import GHC.Exts (RealWorld)
 import qualified Prelude as Prelude
-import Prelude.Linear hiding (replicate)
+import Prelude.Linear
 import System.IO.Unsafe
 import qualified Unsafe.Linear as Unsafe
 
@@ -63,8 +63,8 @@ fill = Unsafe.toLinear2 unsafeFill
     -- length function on destination.
   where
     unsafeFill a (DArray ds) =
-      if MVector.length ds /= 1 then
-        error "Destination.fill: requires a destination of size 1"
+      if MVector.length ds Prelude./= 1 then
+        Prelude.error "Destination.fill: requires a destination of size 1"
       else
         unsafeDupablePerformIO Prelude.$ MVector.write ds 0 a
 

--- a/src/Data/Array/Polarized/Pull.hs
+++ b/src/Data/Array/Polarized/Pull.hs
@@ -33,7 +33,7 @@ import Data.Array.Polarized.Pull.Internal
 -- In particular, PullArrays are incredibly unfriendly in returned-value
 -- position at the moment, moreso than they should be
 import qualified Data.Functor.Linear as Data
-import Prelude.Linear hiding (zip, zipWith, foldr, foldMap, reverse)
+import Prelude.Linear hiding (foldr)
 import Data.Vector (Vector)
 import qualified Data.Vector as Vector
 import qualified Unsafe.Linear as Unsafe

--- a/src/Data/Array/Polarized/Pull/Internal.hs
+++ b/src/Data/Array/Polarized/Pull/Internal.hs
@@ -12,7 +12,6 @@ import Prelude.Linear
 import qualified Prelude
 import Data.Vector (Vector)
 import qualified Data.Vector as Vector
-import Data.Monoid.Linear
 
 import qualified Unsafe.Linear as Unsafe
 
@@ -44,13 +43,13 @@ singleton = Unsafe.toLinear (\x -> fromFunction (\_ -> x) 1)
 -- Zip both pull arrays together.
 zip :: Array a #-> Array b #-> Array (a,b)
 zip (Array g n) (Array h m)
-  | n /= m    = error "Polarized.zip: size mismatch"
+  | n Prelude./= m = Prelude.error "Polarized.zip: size mismatch"
   | otherwise = fromFunction (\k -> (g k, h k)) n
 
 -- | Concatenate two pull arrays.
 append :: Array a #-> Array a #-> Array a
 append (Array f m) (Array g n) = Array h (m + n)
-  where h k = if k < m
+  where h k = if k Prelude.< m
                  then f k
                  else g (k-m)
 
@@ -79,8 +78,8 @@ findLength (Array f n) = (n, Array f n)
 fromFunction :: (Int -> a) -> Int -> Array a
 fromFunction f n = Array f' n
   where f' k
-          | k < 0 = error "Pull.Array: negative index"
-          | k >= n = error "Pull.Array: index too large"
+          | k Prelude.< 0 = Prelude.error "Pull.Array: negative index"
+          | k Prelude.>= n = Prelude.error "Pull.Array: index too large"
           | otherwise = f k
 -- XXX: this is used internally to ensure out of bounds errors occur, but
 -- is unnecessary if the input function can be assumed to already have bounded
@@ -97,7 +96,10 @@ toVector (Array f n) = Vector.generate n f
 -- 'split' is total: if @n@ is larger than the length of @v@, then @vr@ is
 -- empty.
 split :: Int -> Array a #-> (Array a, Array a)
-split k (Array f n) = (fromFunction f (min k n), fromFunction (\x -> f (x+k)) (max (n-k) 0))
+split k (Array f n) =
+  ( fromFunction f (Prelude.min k n)
+  , fromFunction (\x -> f (x+k)) (Prelude.max (n-k) 0)
+  )
 
 -- | Reverse a pull array.
 reverse :: Array a #-> Array a

--- a/src/Data/Array/Polarized/Push.hs
+++ b/src/Data/Array/Polarized/Push.hs
@@ -18,7 +18,6 @@ import qualified Data.Functor.Linear as Data
 import Data.Vector (Vector)
 import Prelude.Linear
 import qualified Prelude
-import Data.Monoid.Linear
 
 -- TODO: the below isn't really true yet since no friendly way of constructing
 -- a PushArray directly is given yet (see issue #62), but the spirit holds.

--- a/src/Data/Either/Linear.hs
+++ b/src/Data/Either/Linear.hs
@@ -4,7 +4,8 @@
 
 -- | This module contains useful functions for working with 'Either's.
 module Data.Either.Linear
-  ( either
+  ( Either(..)
+  , either
   , lefts
   , rights
   , fromLeft

--- a/src/Data/Maybe/Linear.hs
+++ b/src/Data/Maybe/Linear.hs
@@ -3,7 +3,8 @@
 
 -- | This module provides linear functions on the standard 'Maybe' type.
 module Data.Maybe.Linear
-  ( maybe
+  ( Maybe(..)
+  , maybe
   , fromMaybe
   , maybeToList
   , catMaybes

--- a/src/Data/Monoid/Linear.hs
+++ b/src/Data/Monoid/Linear.hs
@@ -17,13 +17,15 @@ module Data.Monoid.Linear
   -- * Endo
   , Endo(..), appEndo
   , NonLinear(..)
-  , module Data.Semigroup
+  , All(All), getAll
+  , Any(Any), getAny
+  , Dual(Dual), getDual
   )
   where
 
 import Prelude.Linear.Internal.Simple
-import Data.Semigroup hiding (Semigroup(..), Endo(..))
-import qualified Data.Semigroup as Prelude
+import Data.Semigroup (All(All), Any(Any), Dual(Dual))
+
 import GHC.Types hiding (Any)
 import qualified Prelude
 
@@ -68,15 +70,25 @@ instance (Semigroup a, Semigroup b) => Semigroup (a,b) where
   (a,x) <> (b,y) = (a <> b, x <> y)
 instance (Monoid a, Monoid b) => Monoid (a,b)
 
+getDual :: Dual a #-> a
+getDual (Dual a) = a
+
 instance Semigroup a => Semigroup (Dual a) where
   Dual x <> Dual y = Dual (y <> x)
 instance Monoid a => Monoid (Dual a)
+
+getAll :: All #-> Bool
+getAll (All a) = a
 
 instance Semigroup All where
   All False <> All False = All False
   All False <> All True = All False
   All True  <> All False = All False
   All True  <> All True = All True
+
+getAny :: Any #-> Bool
+getAny (Any a) = a
+
 instance Semigroup Any where
   Any False <> Any False = Any False
   Any False <> Any True = Any True

--- a/src/Data/Num/Linear.hs
+++ b/src/Data/Num/Linear.hs
@@ -149,6 +149,7 @@ liftU2 f x y = lifted f (move x) (move y)
 -- A newtype wrapper to give the underlying monoid for an additive structure.
 newtype Adding a = Adding a
   deriving Prelude.Semigroup via NonLinear (Adding a)
+  deriving newtype (Consumable, Movable, Dupable)
 
 getAdded :: Adding a #-> a
 getAdded (Adding x) = x
@@ -162,6 +163,7 @@ instance AddIdentity a => Monoid (Adding a)
 -- A newtype wrapper to give the underlying monoid for a multiplicative structure.
 newtype Multiplying a = Multiplying a
   deriving Prelude.Semigroup via NonLinear (Multiplying a)
+  deriving newtype (Consumable, Movable, Dupable)
 
 getMultiplied :: Multiplying a #-> a
 getMultiplied (Multiplying x) = x

--- a/src/Data/Ord/Linear.hs
+++ b/src/Data/Ord/Linear.hs
@@ -6,6 +6,7 @@
 
 module Data.Ord.Linear
   ( Ord(..)
+  , Ordering(..)
   , min
   , max
   , compare

--- a/src/Data/Unrestricted/Linear.hs
+++ b/src/Data/Unrestricted/Linear.hs
@@ -91,6 +91,7 @@ import GHC.TypeLits
 import GHC.Types hiding (Any)
 import Data.Monoid.Linear
 import qualified Prelude
+import qualified Data.Semigroup as Prelude
 import qualified Unsafe.Linear as Unsafe
 
 
@@ -318,12 +319,12 @@ void :: (Data.Functor f, Consumable a) => f a #-> f ()
 void = Data.fmap consume
 
 -- Some stock instances
-deriving instance Consumable a => Consumable (Sum a)
-deriving instance Dupable a => Dupable (Sum a)
-deriving instance Movable a => Movable (Sum a)
-deriving instance Consumable a => Consumable (Product a)
-deriving instance Dupable a => Dupable (Product a)
-deriving instance Movable a => Movable (Product a)
+deriving instance Consumable a => Consumable (Prelude.Sum a)
+deriving instance Dupable a => Dupable (Prelude.Sum a)
+deriving instance Movable a => Movable (Prelude.Sum a)
+deriving instance Consumable a => Consumable (Prelude.Product a)
+deriving instance Dupable a => Dupable (Prelude.Product a)
+deriving instance Movable a => Movable (Prelude.Product a)
 deriving instance Consumable All
 deriving instance Dupable All
 deriving instance Movable All

--- a/src/Data/Vector/Mutable/Linear.hs
+++ b/src/Data/Vector/Mutable/Linear.hs
@@ -56,10 +56,12 @@ where
 
 import GHC.Exts hiding (fromList)
 import GHC.Stack
-import Prelude.Linear hiding (length, read)
+import qualified Prelude.Linear as Linear
+import Data.Unrestricted.Linear
+import Prelude hiding (read, length)
+import qualified Prelude as Prelude
 import qualified Unsafe.Linear as Unsafe
 import qualified Unsafe.MutableArray as Unsafe
-import qualified  Prelude
 
 -- # Core data types
 -------------------------------------------------------------------------------
@@ -80,7 +82,7 @@ constant :: HasCallStack =>
   Int -> a -> (Vector a #-> Unrestricted b) -> Unrestricted b
 constant size x f
   | size <= 0 = error ("Trying to construct a vector of size " ++ show size)
-  | otherwise = f $ Vec (size, size) (Unsafe.newMutArr size x)
+  | otherwise = f Linear.$ Vec (size, size) (Unsafe.newMutArr size x)
 
 -- XXX: long line below
 -- | Allocator from a non-empty list (and error on empty lists)
@@ -90,7 +92,7 @@ fromList xs@(x:_) (f :: Vector a #-> Unrestricted b) =
   constant (Prelude.length xs) x buildThenRun
   where
     buildThenRun :: Vector a #-> Unrestricted b
-    buildThenRun vec = f $ doWrites (zip xs [0..]) vec
+    buildThenRun vec = f Linear.$ doWrites (zip xs [0..]) vec
 
     doWrites :: [(a,Int)] -> Vector a #-> Vector a
     doWrites [] vec = vec

--- a/src/Foreign/Marshal/Pure.hs
+++ b/src/Foreign/Marshal/Pure.hs
@@ -87,8 +87,9 @@ import Foreign.Marshal.Utils
 import Foreign.Ptr
 import Foreign.Storable
 import Foreign.Storable.Tuple ()
-import Prelude (($), return, (<*>))
-import Prelude.Linear hiding (($))
+import Prelude
+import qualified Prelude.Linear as Linear
+import Data.Unrestricted.Linear
 import System.IO.Unsafe
 import qualified Unsafe.Linear as Unsafe
 
@@ -208,20 +209,20 @@ class (KnownRepresentable (AsKnown a)) => Representable a where
 -- tuples of Representable (not only KnownRepresentable) are Representable.
 instance Representable Word where
   type AsKnown Word = Word
-  toKnown = id
-  ofKnown = id
+  toKnown = Linear.id
+  ofKnown = Linear.id
 instance Representable Int where
   type AsKnown Int = Int
-  toKnown = id
-  ofKnown = id
+  toKnown = Linear.id
+  ofKnown = Linear.id
 instance Representable (Ptr a) where
   type AsKnown (Ptr a) = Ptr a
-  toKnown = id
-  ofKnown = id
+  toKnown = Linear.id
+  ofKnown = Linear.id
 instance Representable () where
   type AsKnown () = ()
-  toKnown = id
-  ofKnown = id
+  toKnown = Linear.id
+  ofKnown = Linear.id
 instance
   (Representable a, Representable b)
   => Representable (a, b) where
@@ -282,7 +283,7 @@ data Pool where
 -- Implementing a doubly-linked list with `Ptr`
 
 data DLL a = DLL { prev :: Ptr (DLL a), elt :: Ptr a, next :: Ptr (DLL a) }
-  deriving Eq
+  deriving Prelude.Eq
 
 -- XXX: probably replaceable by storable-generic
 instance Storable (DLL a) where
@@ -376,8 +377,8 @@ instance Storable (Box a) where
 instance KnownRepresentable (Box a) where
 instance Representable (Box a) where
   type AsKnown (Box a) = Box a
-  ofKnown = id
-  toKnown = id
+  ofKnown = Linear.id
+  toKnown = Linear.id
 
 -- TODO: a way to store GC'd data using a StablePtr
 

--- a/src/Prelude/Linear.hs
+++ b/src/Prelude/Linear.hs
@@ -52,12 +52,23 @@ module Prelude.Linear
   , dup
   , dup2
   , dup3
+  , module Data.Eq.Linear
   , module Data.Num.Linear
   , module Data.Either.Linear
   , module Data.Bool.Linear
   , module Data.Maybe.Linear
-    -- * Re-exports from the standard 'Prelude' for convenience
-  , module Prelude
+  , module Data.Ord.Linear
+  , module Data.Monoid.Linear
+  -- * Re-exports from Prelude
+  , Prelude.Char
+  , Prelude.String
+  , Prelude.FilePath
+  , Prelude.Int
+  , Prelude.Integer
+  , Prelude.Float
+  , Prelude.Double
+  , Prelude.Word
+  , Prelude.otherwise
   ) where
 
 import qualified Data.Functor.Linear as Data
@@ -67,30 +78,9 @@ import Data.Num.Linear
 import Data.Bool.Linear
 import Data.Either.Linear
 import Data.Maybe.Linear
-import Prelude hiding
-  ( ($)
-  , id
-  , const
-  , seq
-  , curry
-  , uncurry
-  , flip
-  , foldl
-  , foldr
-  , (.)
-  , maybe
-  , either
-  , (||)
-  , (&&)
-  , not
-  , Functor(..)
-  , Applicative(..)
-  , Monad(..)
-  , Traversable(..)
-  , Semigroup(..)
-  , Monoid(..)
-  , Num(..)
-  )
+import Data.Eq.Linear
+import Data.Ord.Linear
+import qualified Prelude
 import GHC.Exts (FUN)
 import Prelude.Linear.Internal.Simple
 

--- a/src/System/IO/Linear.hs
+++ b/src/System/IO/Linear.hs
@@ -61,7 +61,8 @@ import qualified Control.Exception as System (throwIO, catch, mask_)
 import qualified Control.Monad.Linear as Control
 import qualified Data.Functor.Linear as Data
 import GHC.Exts (State#, RealWorld)
-import Prelude.Linear hiding (IO)
+import qualified Prelude
+import Prelude.Linear
 import qualified Unsafe.Linear as Unsafe
 import qualified System.IO as System
 
@@ -105,7 +106,7 @@ fromSystemIO = Unsafe.coerce
 -- 'Unrestricted'.
 fromSystemIOU :: System.IO a -> IO (Unrestricted a)
 fromSystemIOU action =
-  fromSystemIO (Unrestricted <$> action)
+  fromSystemIO (Unrestricted Prelude.<$> action)
 
 -- | Convert a linear IO action to a "System.IO" action.
 toSystemIO :: IO a #-> System.IO a
@@ -119,7 +120,7 @@ toSystemIO = Unsafe.coerce -- basically just subtyping
 -- main = Linear.withLinearIO $ do ...
 -- @
 withLinearIO :: IO (Unrestricted a) -> System.IO a
-withLinearIO action = (\x -> unUnrestricted x) <$> (toSystemIO action)
+withLinearIO action = (\x -> unUnrestricted x) Prelude.<$> (toSystemIO action)
 
 -- * Monadic interface
 

--- a/src/System/IO/Resource.hs
+++ b/src/System/IO/Resource.hs
@@ -59,7 +59,7 @@ module System.IO.Resource
     -- $files
   , Handle
     -- ** File I/O
-  , openFile 
+  , openFile
     -- ** Working with Handles
   , hClose
   , hGetChar
@@ -89,7 +89,7 @@ import qualified Data.IntMap.Strict as IntMap
 import Data.IntMap.Strict (IntMap)
 import Data.Text (Text)
 import qualified Data.Text.IO as Text
-import Prelude.Linear hiding (IO)
+import Prelude.Linear
 import qualified Prelude as P
 import qualified System.IO.Linear as Linear
 import qualified System.IO as System
@@ -117,7 +117,7 @@ run (RIO action) = do
         (restore (Linear.withLinearIO (action rrm)))
         (do -- release stray resources
            ReleaseMap releaseMap <- System.readIORef rrm
-           safeRelease P.$ Unrestricted.fmap snd P.$ IntMap.toList releaseMap))
+           safeRelease P.$ Unrestricted.fmap P.snd P.$ IntMap.toList releaseMap))
       -- Remarks: resources are guaranteed to be released on non-exceptional
       -- return. So, contrary to a standard bracket/ResourceT implementation, we
       -- only release exceptions in the release map upon exception.
@@ -257,12 +257,12 @@ unsafeAcquire acquire release = RIO $ \rrm -> Linear.mask_ (do
     releaseKey releaseMap =
       case IntMap.null releaseMap of
         True -> 0
-        False -> fst (IntMap.findMax releaseMap) + 1
+        False -> P.fst (IntMap.findMax releaseMap) + 1
 
 -- | Given a "System.IO" computation on an unsafe resource,
 -- lift it to @RIO@ computaton on the acquired resource.
 -- That is function of type @a -> IO b@ turns into a function of type
--- @UnsafeResource a #-> RIO (Unrestricted b)@ 
+-- @UnsafeResource a #-> RIO (Unrestricted b)@
 -- along with threading the @UnsafeResource a@.
 --
 -- Note that the result @b@ can be used non-linearly.


### PR DESCRIPTION
I created this PR after my comment on #127:

> When I import a *.Linear module, I expect to only get linear functions. and the data types those functions work on. It is surprising to me that I can import Prelude.Linear and it contains non-linear functions.
> In some cases using *.Linear modules require some data types from base to be imported (eg. Data.Maybe.Linear does not export Maybe (..), or Data.Ord.Linear does not export Ordering), which is a bit annoying.

The main changes are

* `Prelude` re-export from `Prelude.Linear` is removed. Instead I only exported common data types like `Int` and `Bool`.
* Now `Data.Maybe.Linear`, `Data.Either.Linear` and `Data.Ord.Linear` exports `Maybe(..)`, `Either(..)` and `Ordering(..)` respectively.
* `Data.Semigroup.Linear` used to export non-linear destructors for newtype wrappers like `Sum`. I implemented linear versions of them manually.

The rest is pretty much just fixing the import lists and qualifying some names. I tried to not make any controversial changes, so let me know if you prefer anything different. However, this PR does cause the API to change quite a bit, sometimes in unexpected ways (eg. now `Prelude.Linear.Eq` is `Data.Eq.Linear.Eq` instead of `Prelude.Eq`); but I do not think we guarantee backwards compatibility yet.