### PR TITLE
Fix a laziness bug on Data.Array.Mutable.Linear

### DIFF
--- a/src/Data/Array/Mutable/Linear.hs
+++ b/src/Data/Array/Mutable/Linear.hs
@@ -120,7 +120,8 @@ read = Unsafe.toLinear readUnsafe
     readUnsafe :: Array a -> Int -> (Array a, Unrestricted a)
     readUnsafe arr@(Array size mutArr) ix
       | indexInRange size ix =
-          (arr, Unrestricted $ Unsafe.readMutArr mutArr ix)
+          let val = Unsafe.readMutArr mutArr ix
+          in  val `seq` (arr, Unrestricted val)
       | otherwise = error "Read index out of bounds."
 
 -- | Using first element as seed, resize to a constant array

--- a/src/Data/Array/Mutable/Linear.hs
+++ b/src/Data/Array/Mutable/Linear.hs
@@ -120,8 +120,8 @@ read = Unsafe.toLinear readUnsafe
     readUnsafe :: Array a -> Int -> (Array a, Unrestricted a)
     readUnsafe arr@(Array size mutArr) ix
       | indexInRange size ix =
-          let val = Unsafe.readMutArr mutArr ix
-          in  val `seq` (arr, Unrestricted val)
+          let !val = Unsafe.readMutArr mutArr ix
+          in  (arr, Unrestricted val)
       | otherwise = error "Read index out of bounds."
 
 -- | Using first element as seed, resize to a constant array

--- a/test/Test/Data/Mutable/Array.hs
+++ b/test/Test/Data/Mutable/Array.hs
@@ -64,7 +64,7 @@ group =
   , testProperty "∀ a,i,x. len (write a i x) = len a" lenWrite
   , testProperty "∀ a,s. len (resize s a) = s" lenResize
   , testProperty "∀ a,s,x. len (resizeSeed s x a) = s" lenResizeSeed
-  -- unit tests
+  -- Regression tests
   , testProperty "do not reorder reads and writes" readAndWriteTest
   ]
 


### PR DESCRIPTION
This patch fixes an issue where using a previously read value from an array in a write causing an infinite loop.

Here is an example:

```haskell
{-# LANGUAGE LinearTypes #-}

module Main where

import Data.Function ((&))
import qualified Prelude.Linear as L
import qualified Data.Array.Mutable.Linear as Array
import Prelude.Linear (Unrestricted(..))

processArr :: Array.Array () #-> Unrestricted ()
processArr arr =
  Array.read arr 0 L.& \(arr', Unrestricted before) ->
    Array.write arr' 0 (before `seq` ()) L.& \arr'' ->
      Array.read arr'' 0 L.& \(arr''', after) ->
          arr''' `L.lseq` after

main :: IO ()
main =
   Array.fromList [()] processArr
     & \(Unrestricted a) -> print a
```

The `seq` call there is just to explicitly show the dependency. I found this issue while writing a bigger application where I was simply incrementing an `Int` inside an `Array`.

I _think_ what happens here is that the `before` thunk (which contains a `Unsafe.readMutArr` call inside), is not evaluated until the `print` statement. However, before it can do that, the relevant cell in the array is replaced with ``before `seq` ()`` by the `write`. So, we're unknowingly tying the knot there.

This PR tries to fix the issue with evaluating the value before returning from the `read`. Other possible solutions I can think of is evaluating the value before `write`'s instead, or doing the same on the lower level `Data.MutableArray` module.

However, I think there might be other similar problems hidden there; my brain hurts when I try to think about storing more complex unevaluated thunks inside `Array`'s. Please let me know if there is a better solution.