### PR TITLE
Edit pass on documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Linear base
-===========
+# Linear base
 
 [![License MIT](https://img.shields.io/badge/license-MIT-brightgreen.svg)](https://github.com/tweag/linear-base/blob/master/LICENSE)
 [![Build status](https://badge.buildkite.com/5b60ab93dadba234a95e04e6568985918552dcc9e7685ede0d.svg?branch=master)](https://buildkite.com/tweag-1/linear-base)
@@ -11,80 +10,54 @@ package that ships with GHC.
 
 The purpose of `linear-base` is to provide the minimal facilities you need to
 write _practical_ Linear Haskell code, i.e., Haskell code that uses the
-`-XLinearHaskell` language extension.
+`-XLinearTypes` language extension.
 
 ## Motivation
 
 _Why do you need `linear-base` to write linear projects?_
 
-1. If you are writing a linear function, you cannot use the standard
-  non-linear data types, functions and classes in `base`. Even simple uses of
-  `base` facilities break down. For instance, if `n` is a linearly bound `Int`,
-  the RHS of an definition cannot write `n + 1` --- this will not type check. We need
-  linear variants of `Num`, `Functor`s, `Monad`s, `($)`, etc.
+1. Data types, functions and classes in `base` are not linear types
+  aware. For instance, if `n` is a linearly-bound `Int`, the RHS of
+  a definition cannot write `n + 1` — this will not type check. We
+  need linear variants of `Num`, `Functor`s, `Monad`s, `($)`, etc.
 
-2. There are several primitive data structures, functions and classes
-  that can only be safely released with `-XLinearHaskell`.  For example, the
-  API for file IO released by `linear-base` is safe unlike the current API
-  which allows, say, reading from a closed file handle.  _Some of these are new
-  and exciting because they are not in `base`, e.g., `linear-base` releases a
-  safe API for mutable arrays allowing values to be updated in place!_
+2. This library exports new abstractions that leverage linear types
+  for resource safety or performance. For example, there are new APIs
+  for file and socket I/O as well as for safe in-place mutation of
+  arrays.
 
-## Getting Started
+## Getting started
 
-Since -XLinearTypes are not part of a GHC release, we need to use nix to get a
-version of GHC with support for linear types.
+`-XLinearTypes` is not yet part of any GHC release. We recommend using
+Stack and Nix together to pull in an experimental version of GHC into
+your project. Use [this `stack.yaml`](./stack.yaml) as a starting
+point for your project. To learn more about Stack+Nix integration, see
+[here](https://docs.haskellstack.org/en/stable/nix_integration/).
 
-1. In your stack project, add our [`shell-stack.nix`] and [`nixpkgs.nix`] files.
-2. Edit your `stack.yaml` to have the following fields.  _Use an appropriate
-   commit in the `extra-deps`._
+All source files with linear types need a language extension pragma at
+the top:
 
-```yaml
-resolver: lts-16.2
-compiler: ghc-8.11
-allow-newer: true
-system-ghc: true
-
-nix:
-  enable: true
-  shell-file: shell-stack.nix
-  path: ["nixpkgs=./nixpkgs.nix"]
-
-extra-deps:
-  - git: https://github.com/facundominguez/quickcheck.git
-    commit: a498e7b41131cf7955b9e154ab26d37d1be10304
-  - git: https://github.com/facundominguez/lifted-async.git
-    commit: 898eb485b21cc321058345998eedd8c409c326fd
-  - git: https://github.com/tweag/linear-base.git
-    commit: 705522f0bad3f1083bb3447b9f476f6f84d21410
 ```
-
-4. Add `linear-base` to your cabal file's `build-depends:` for the appropriate
-   library or executable.
-
-5. You're done! You can add `{-# LANGUAGE LinearTypes #-}` to the top of your
-   modules and build with `stack build` and test with `stack test` and so on.
-   To learn more about stack-nix integration, see
-   [here](https://docs.haskellstack.org/en/stable/nix_integration/).
+{-# LANGUAGE LinearTypes #-}
+```
 
 ## User Guide
 
-If you already know what `-XLinearHaskell` does and what the linear arrow
-`a #-> b` means, then read the [User Guide] and the [`/examples`] to know how to
-use `linear-base`.
+If you already know what `-XLinearHaskell` does and what the linear
+arrow `a #-> b` means, then read the [User Guide] and explore the
+[`examples/`](./examples) folder to know how to use `linear-base`.
 
 ## Learning about `-XLinearHaskell`
 
 If you're a Haskeller who hasn't written any Linear Haskell code, don't fear!
 There are plenty of excellent resources and examples to help you.
 
-### Tutorials and Examples
+### Tutorials and examples
 
- * See the [`/examples`] sub-folder. There is a README organizing the examples
-   and pointing out tutorials.
+ * See the [`examples/`](./examples) folder.
  * [Linear examples on watertight 3D models](https://github.com/gelisam/linear-examples)
 
-### Reading Material
+### Reading material
 
   * There is a [wiki page](https://gitlab.haskell.org/ghc/ghc/-/wikis/linear-types).
   * Key Blog posts
@@ -103,21 +76,18 @@ There are plenty of excellent resources and examples to help you.
 
 ## Contributing
 
-Linear base is maintained by [Tweag I/O].
+Linear base is maintained by [Tweag].
 
 To contribute please see the [Design Document] for instructions and advice on
 making pull requests.
 
 ## Licence
 
-See our [Licence](https://github.com/tweag/linear-base/blob/master/LICENSE).
+See the [Licence file](./LICENSE).
 
-Copyright © Tweag I/O
+Copyright © Tweag Holding and its affiliates.
 
-[Tweag I/O]: https://www.tweag.io/
+[Tweag]: https://www.tweag.io/
 [`base`]: https://hackage.haskell.org/package/base
-[`shell-stack.nix`]: https://github.com/tweag/linear-base/blob/master/shell-stack.nix
-[`nixpkgs.nix`]: https://github.com/tweag/linear-base/blob/master/nixpkgs.nix
-[User Guide]: https://github.com/tweag/linear-base/tree/master/docs/USER_GUIDE.md
-[Design Document]: https://github.com/tweag/linear-base/tree/master/docs/DESIGN.md
-[`/examples`]: https://github.com/tweag/linear-base/tree/master/examples
+[User Guide]: ./docs/USER_GUIDE.md
+[Design Document]: ./docs/DESIGN.md

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,107 +1,71 @@
 # Design
 
-The purpose of this document is to describe how `linear-base` is developed.
-_Please be familiar with the user guide before reading this document._
-
-This document describes
-
- * the overall architecture of linear base
- * the general implementation strategy
- * the ideas behind implementing key parts of linear base
- * rules and advice on contributing
-
-## Overall Architecture
+## Overall architecture
 
 Linear base is more than a copy of things from [`base`] with some function
 arrows being replaced by linear arrows. Moreover, the goal is __not__ exact
-compliance to base.
+compliance with `base`.
 
 Linear base consists of the following:
 
- * fundamental data structures, functions and classes that arise naturally from
-   wanting to do any linear development (e.g., `Unrestricted` and `Consumable`)
- * tools ported from [`base`] **and from other critical haskell libraries, like `lens`**
- * new APIs for using external resources, e.g., file IO in [`System.IO.Resource`]
- * new tools made possible with linear-types, like an API for mutable arrays
-   that doesn't use complicated monads ([`Data.Array.Mutable.Linear`]).
+* fundamental data structures, functions and classes that arise
+  naturally from wanting to do any linear development (e.g.,
+  `Unrestricted` and `Consumable`),
+* tools ported from [`base`] and from other critical haskell
+  libraries, like `lens`,
+* new APIs for using system resources, e.g., file I/O in
+  [`System.IO.Resource`],
+* new abstractions made possible by linear types, like monad-free
+  mutable arrays in ([`Data.Array.Mutable.Linear`]).
 
 There is a top-level `Prelude.Linear` that is meant to be imported _unqualified_.
 It does not include functors, monads, applicatives and so on because there are
 multiple sensible ways to give linear arrows to these things. See this [blog
 post] for details. This prelude includes:
 
-  * Linear variants of the standard `Prelude`
-  * The fundamental `Data.Unrestricted` data, functions and classes
-  * The `Num` and related classes and instances in the [`Num`] module
+* linear variants of definitions in `Prelude`,
+* a few pervasive utility definitions when programming with linear
+  types.
 
+## General implementation strategy
 
-## General Implementation Strategy
+This is the strategy that we've followed so far for developing
+`linear-base`:
 
-This is the strategy (that we've followed so far) for developing linear base:
+1. If the definition is simple enough that there's only one sensible
+   place to replace a function arrow by a linear arrow, do that.
+   Example:
 
-1. If the tool is simple enough that there's only one sensible place to replace
-a function arrow by a linear arrow, do that. Example:
+   ```haskell
+   foldr :: (a #-> b #-> b) -> b #-> [a] #-> b
+   foldr f z = \case
+     [] -> z
+     x:xs -> f x (foldr f z xs)
+   ```
 
-```haskell
-foldr :: (a #-> b #-> b) -> b #-> [a] #-> b
-foldr f z = \case
-  [] -> z
-  x:xs -> f x (foldr f z xs)
-```
+	Otherwise, implement each sensible variant of the definition in
+    dedicated modules. For instance, this is the case with
+    `Data.Functor`s and `Control.Functor`s (see this [blog post]).
 
-Otherwise, we need to implement each sensible variant of the tool and put it in a
-well-named module. This is the case with `Data.Functor`s and `Control.Functor`s
-(recall this [blog post]).
+2. The ideas behind new definitions that are just now possible with
+   linear types vary and each have unique concepts that are not
+   addressed by a general strategy. These should be documented below
+   if one of the following is true:
+   
+   * there is an overarching concept that extends beyond a handful of
+     modules. Or,
+   * There is an explicit departure away from the direction of `base`.
+     (E.g., we decide there should be different laws for some type
+     class already in `base`.)
 
-2. The ideas behind new tools that are just now possible with linear types vary
-and each have unique concepts that are not addressed by a general strategy.
-These should be documented below if one of the following is true:
+## Conventions
 
-  * There is an overarching concept that extends beyond a handful of modules
-  * There is an explicit departure away from the direction `base` takes on some
-    tool. (E.g., we decide there should be different laws for some typeclass
-    from `base`.)
+We have established the following conventions in this project:
 
-## How Key Pieces are Implemented
-
-### Num and similar classes
-
-We create a hierarchy of numeric type classes, like an additive Abelian
-group, all the way up to `Num`. Then (with some tricks) we derive instances of
-these classes for `Int`, `Double` and the numeric types. Link to the source:
-[`Num`].
-
-### Mutable Data Structures
-
-Mutable data structures release constructors that take continuations. The
-accessors linearly thread the data structure. The mutators linearly consume
-and return the data structure. These data structures are always consumable.
-
-```haskell
-allocate :: Int -> (DataStructure a #-> Unrestricted b) #-> Unrestricted b
-mutate :: Something -> DataStructure a #-> DataStructure a
-access :: Something -> DataStructure a #-> (DataStructure a, AccessInfo)
-instance Consumable (DataStructure a)
-```
-
-## Rules and Advice on Contributing
-
-In addition to [our contributing guide], we have these rules:
-
-A few simple conventions are required:
-
-  * Qualified imports that are meaningful and not abbreviations. So, for
-    instance, import `Data.Functor.Linear` as `Linear` and not as `F` for
-    functor.
-  * An export list for public modules.
-  * Module level documentation and haddock on key data definitions and top
-    level functions.
-
-General advice:
-
- * Sticking with the feel of the code already in linear base; make your work blend in.
- * Organize your code into simple sections.
- * Write tests for anything using unsafe functions (and tests in general).
+* use full words for Qualified imports, not abbreviations. For
+  instance, import `Data.Functor.Linear` as `Linear` and not as `F`
+  for functor.
+* All public modules have an export list.
 
 [functors]: https://www.tweag.io/posts/2020-01-16-data-vs-control.html
 [examples/Simple/FileIO.hs]: https://github.com/tweag/linear-base/tree/master/examples/Simple/FileIO.hs
@@ -110,5 +74,5 @@ General advice:
 [`base`]: https://hackage.haskell.org/package/base
 [`Data.Array.Mutable.Linear`]: https://github.com/tweag/linear-base/blob/master/src/Data/Array/Mutable/Linear.hs
 [blog post]: https://www.tweag.io/posts/2020-01-16-data-vs-control.html
-[our contributing guide]: https://github.com/tweag/.github/blob/master/CONTRIBUTING.md
+[contributor's guide]: ../CONTRIBUTING.md
 [`System.IO.Resource`]: https://github.com/tweag/linear-base/blob/master/src/System/IO/Resource.hs

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,9 +1,9 @@
 # User Guide
 
-This guide provides a minimal list of things you need
-to know to write practical linear code with linear-base.
+This guide provides a minimal list of things you need to know to write
+practical linear code with `linear-base`.
 
-## Naming Conventions & Layout
+## Naming conventions & layout
 
 Typically, variants of common haskell tools and facilities
 share the same name with a `Linear` postfix. For instance,
@@ -14,11 +14,11 @@ The module names follow the typical hierarchical module
 naming scheme with top-level names like `Control`, `Data`, `System`
 and so on.
 
-## Temporary Limitations
+## Temporary limitations
 
 ### Case statements are not linear
 
-The following program will **fail**:
+The following definition will **fail** to type check:
 
 ```haskell
 maybeFlip :: Int #-> Int #-> (a,a) -> a
@@ -27,13 +27,12 @@ maybeFlip i j (x,y) = case i < j of
   False -> y
 ```
 
-The scrutinee on (i.e., `x` in
-`case x of ...`) is considered to be consumed many times. It's a limitation of
-the current implementation of the typechecker.
+The scrutinee on (i.e., `x` in `case x of ...`) is considered to be
+consumed many times. It's a limitation of the current implementation
+of the type checker.
 
 For now, we can mimic a linear case statement using the
 `-XLambdaCase` language extension and the `(&)` from `Prelude.Linear`:
-
 
 ```haskell
 {-# LANGUAGE LambdaCase #-}
@@ -47,10 +46,9 @@ maybeFlip i j (x,y) =  i < j & \case
 
 The `(&)` operator is like `($)` with the argument order flipped.
 
-
 ### `let` and `where` bindings don't work
 
-The following will **! fail !**:
+The following will **fail** to type check:
 
 ```haskell
 idBad1 :: a #-> a
@@ -59,13 +57,12 @@ idBad1 x = y
     y = x
 
 idBad2 :: a #-> a
-idBad2 x =  let y = x in y
+idBad2 x = let y = x in y
 ```
 
-This is because GHC assumes that anything used in a where binding is consumed
-with multiplicity `Many`.
-
-So, inline these bindings or use sub-functions.
+This is because GHC assumes that anything used in a `where`-binding or
+`let`-binding is consumed with multiplicity `Many`. Workaround: inline
+these bindings or use sub-functions.
 
 ```haskell
 inlined1 :: a #-> a
@@ -80,9 +77,10 @@ useSubfunction arr = fromRead (read arr 0)
 
 ## Non-linear and linear code interactions
 
-All throughout linear haskell code, you will need to interface
-between non-linear and linear code. All the tools you need to do this
-are in [Data.Unrestricted] and are typically re-exported by [Prelude.Linear].
+Throughout linear code, you will need to interface between non-linear
+and linear code. All the tools you need to do this are in
+[`Data.Unrestricted`] and are typically re-exported by
+[`Prelude.Linear`].
 
 This is basically done through type classes. Types that can be used in
 a non-linear way even when they are bound in a linear function have
@@ -93,7 +91,7 @@ Moveable`.
 
 ### `f :: X -> (SomeType #-> Unrestricted b) -> b` functions
 
-This function limits the **scope** of using SomeType by taking
+This function limits the **scope** of using `SomeType` by taking
 a scope function of type `(SomeType #-> Unrestricted b)`
 as its second argument and using it with a value of type `SomeType` to
 produce an `Unrestricted b`.
@@ -107,16 +105,16 @@ Now, if `f` is the only function that can make a `SomeType`,
 then we have an API that completely controls the creation-to-deletion
 lifetime (i.e, the scope) of `SomeType` and ensures it is used linearly.
 
-## New Linear Things
+## New linear abstractions
 
-Here's a list of _new_ tools made possible by linear types:
+Here's a list of new abstractions made possible by linear types:
 
-  1. Mutable arrays, hashmaps, vectors, sets with a pure API
-     See `Data.Array.Mutable.Linear` for example.
-  2. Push and Pull arrays: a way to control when arrays are allocated
-  and force array fusion. See `Data.Array.Polarized`.
-  3. A linear API for system heap (not GC) allocation of values.
-     See `Foreign.Marshall.Pure`.
+1. Mutable arrays, hashmaps, vectors, sets with a pure API. See
+   `Data.Array.Mutable.Linear`.
+2. Push and Pull arrays: a way to control when arrays are allocated
+   and force array fusion. See `Data.Array.Polarized`.
+3. A linear API for system heap (not GC) allocation of values. See
+   `Foreign.Marshall.Pure`.
 
-[Data.Unrestricted]: https://github.com/tweag/linear-base/blob/master/src/Data/Unrestricted/Linear.hs
-[Prelude.Linear]: https://github.com/tweag/linear-base/blob/master/src/Prelude/Linear.hs
+[`Data.Unrestricted`]: ../src/Data/Unrestricted/Linear.hs
+[`Prelude.Linear`]: ../src/Prelude/Linear.hs


### PR DESCRIPTION
- replaced the word "tools", which has little to no precedent, with
  "definitions" or "abstractions",
- use relative links where possible,
- remove sections with low information,
- fix license link,
- consistent indentation,
- consistent headings and capitalization.