### PR TITLE
Make {Array,Vector}.Mutable.Linear lazier

### DIFF
--- a/src/Data/Array/Mutable/Linear.hs
+++ b/src/Data/Array/Mutable/Linear.hs
@@ -127,7 +127,7 @@ read = Unsafe.toLinear readUnsafe
 -- | Using first element as seed, resize to a constant array
 resize :: HasCallStack => Int -> Array a #-> Array a
 resize newSize (Array _ mutArr) =
-  let (# a #) = Unsafe.readMutArr mutArr 0
+  let !(# a #) = Unsafe.readMutArr mutArr 0
   in  Array newSize (Unsafe.newMutArr newSize a)
 
 -- | Resize to a new constant array given a seed value

--- a/src/Data/Array/Mutable/Linear.hs
+++ b/src/Data/Array/Mutable/Linear.hs
@@ -120,14 +120,15 @@ read = Unsafe.toLinear readUnsafe
     readUnsafe :: Array a -> Int -> (Array a, Unrestricted a)
     readUnsafe arr@(Array size mutArr) ix
       | indexInRange size ix =
-          let !val = Unsafe.readMutArr mutArr ix
-          in  (arr, Unrestricted val)
+          let !(# a #) = Unsafe.readMutArr mutArr ix
+          in  (arr, Unrestricted a)
       | otherwise = error "Read index out of bounds."
 
 -- | Using first element as seed, resize to a constant array
 resize :: HasCallStack => Int -> Array a #-> Array a
 resize newSize (Array _ mutArr) =
-  Array newSize (Unsafe.newMutArr newSize (Unsafe.readMutArr mutArr 0))
+  let (# a #) = Unsafe.readMutArr mutArr 0
+  in  Array newSize (Unsafe.newMutArr newSize a)
 
 -- | Resize to a new constant array given a seed value
 resizeSeed :: HasCallStack => Int -> a -> Array a #-> Array a

--- a/src/Data/Vector/Mutable/Linear.hs
+++ b/src/Data/Vector/Mutable/Linear.hs
@@ -126,7 +126,9 @@ read = Unsafe.toLinear readUnsafe
   where
     readUnsafe :: Vector a -> Int -> (Vector a, a)
     readUnsafe v@(Vec (len, _) mutArr) ix
-      | indexInRange len ix = (v, Unsafe.readMutArr mutArr ix)
+      | indexInRange len ix =
+          let !(# a #) = Unsafe.readMutArr mutArr ix
+          in  (v, a)
       | otherwise = error "Read index not in range."
 
 -- # Instances

--- a/src/Unsafe/MutableArray.hs
+++ b/src/Unsafe/MutableArray.hs
@@ -57,9 +57,13 @@ writeMutArr mutArr (I# ix) val =
 
 -- | Read from a given mutable array arr, given an index
 -- in [0, size(arr)-1]
-readMutArr :: MutArr# a -> Int -> a
+--
+-- This returns an unboxed tuple to give the callee the
+-- ability to evaluate the function call without evaluating
+-- the final result.
+readMutArr :: MutArr# a -> Int -> (# a #)
 readMutArr mutArr (I# ix) =
-  case doRead of (# _, a #) -> a
+  case doRead of (# _, a #) -> (# a #)
   where
     doRead = runRW# $ \stateRW -> readArray# mutArr ix stateRW
 
@@ -69,7 +73,8 @@ readMutArr mutArr (I# ix) =
 -- fails for a size smaller than the size of the given array.
 resizeMutArr :: MutArr# a -> Int -> MutArr# a
 resizeMutArr mutArr newSize =
-  resizeMutArrSeed mutArr (readMutArr mutArr 0) newSize
+  let (# a #) = readMutArr mutArr 0
+  in  resizeMutArrSeed mutArr a newSize
 
 -- | Grow a mutable array. This is given an array, a given larger size,
 -- and it returns a larger array of the given size using the seed value

--- a/src/Unsafe/MutableArray.hs
+++ b/src/Unsafe/MutableArray.hs
@@ -73,7 +73,7 @@ readMutArr mutArr (I# ix) =
 -- fails for a size smaller than the size of the given array.
 resizeMutArr :: MutArr# a -> Int -> MutArr# a
 resizeMutArr mutArr newSize =
-  let (# a #) = readMutArr mutArr 0
+  let !(# a #) = readMutArr mutArr 0
   in  resizeMutArrSeed mutArr a newSize
 
 -- | Grow a mutable array. This is given an array, a given larger size,


### PR DESCRIPTION
Closes #142.

This PR changes wraps the result of `Unsafe.MutableArray.read` with an
unboxed tuple, so the array lookup can be evaluated without evaluating
the result.

Because of that, now `Data.{Array,Vector}.Mutable.Linear.read` functions
does not unnecessarily force the return value.

I added a test case about strictness issue just for `Array`'s. Because
Vector's `read` function returns the result linearly as opposed to
`Array` which wraps it with an `Unrestricted`. I think this is another
error, so I'll fix that with a separate PR:

```
read :: HasCallStack => Vector a #-> Int -> (Vector a, a)
read :: HasCallStack => Array a #-> Int -> (Array a, Unrestricted a)
```

---

While implementing this, I also noticed that the issue fixed in #135 also applies
to vectors, so this PR also fixes that while adding a test case.