### PR TITLE
Update nixpkgs

### DIFF
--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,7 +1,7 @@
 let
-  # 2020-08-22 master
-  rev = "d8e671676d91fa9d3ef64b69ba7680d07d79f7a7";
-  sha256 = "0bpf3qncb1qxg7dx4rgmwbhbi74lia6jdzjvmg8wvalc738p6wgw";
+  # 2020-08-31 master
+  rev = "6716867eb3e763818000eab04f378b86cadc2894";
+  sha256 = "19fnqwpq1rk4iibbgq04j9w72s4n31nlz7m26iqhqd5lh7p8sc42";
 in
 import (fetchTarball {
   inherit sha256;


### PR DESCRIPTION
This PR updates nixpkgs to the latest revision which includes a newer
GHC including the [fix][] to #123.

Closes #123.

[fix]: https://gitlab.haskell.org/ghc/ghc/-/commit/2f0bae734e2dc8737fbbb8465de7ded89c1121b6