### PR TITLE
Implement mutable vectors using arrays

### DIFF
--- a/src/Data/Vector/Mutable/Linear.hs
+++ b/src/Data/Vector/Mutable/Linear.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE LinearTypes #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -47,9 +48,11 @@ module Data.Vector.Mutable.Linear
     fromList,
     -- * Mutators
     write,
+    unsafeWrite,
     snoc,
     -- * Accessors
     read,
+    unsafeRead,
     length,
   )
 where
@@ -58,93 +61,105 @@ import GHC.Exts hiding (fromList)
 import GHC.Stack
 import Prelude.Linear hiding (length, read)
 import qualified Unsafe.Linear as Unsafe
-import qualified Unsafe.MutableArray as Unsafe
-import qualified  Prelude
+import Data.Array.Mutable.Linear (Array)
+import qualified Data.Array.Mutable.Linear as Array
+import qualified Prelude
 
 -- # Core data types
 -------------------------------------------------------------------------------
 
-type MutArr a = MutableArray# RealWorld a
-
 -- | A dynamic mutable vector.
 data Vector a where
-  -- | Vec (current length, memory allocated) marray
-  Vec :: (Int, Int) -> MutArr a -> Vector a
+  Vec :: Int -- ^ Current length
+      -> Array a -- ^ Underlying array
+      #-> Vector a
 
 -- # API: Construction, Mutation, Queries
 -------------------------------------------------------------------------------
 
--- | Allocate a constant vector of a given non-zero size (and error on a bad
+empty :: (Vector a #-> Unrestricted b) -> Unrestricted b
+empty f = Array.empty (\arr -> f (Vec 0 arr))
+
+-- | Allocate a constant vector of a given non-negative size (and error on a bad
 -- size)
-constant :: HasCallStack =>
-  Int -> a -> (Vector a #-> Unrestricted b) -> Unrestricted b
+constant :: Int -> a -> (Vector a #-> Unrestricted b) -> Unrestricted b
 constant size x f
-  | size <= 0 = error ("Trying to construct a vector of size " ++ show size)
-  | otherwise = f $ Vec (size, size) (Unsafe.newMutArr size x)
+  | size < 0 = error ("Trying to construct a vector of size " ++ show size)
+  | otherwise = fromList (replicate size x) f
 
--- XXX: long line below
--- | Allocator from a non-empty list (and error on empty lists)
+-- | Creates a vector from a list.
 fromList :: HasCallStack => [a] -> (Vector a #-> Unrestricted b) -> Unrestricted b
-fromList [] _ = error "Trying to allocate a vector from an empty list"
-fromList xs@(x:_) (f :: Vector a #-> Unrestricted b) =
-  constant (Prelude.length xs) x buildThenRun
-  where
-    buildThenRun :: Vector a #-> Unrestricted b
-    buildThenRun vec = f $ doWrites (zip xs [0..]) vec
-
-    doWrites :: [(a,Int)] -> Vector a #-> Vector a
-    doWrites [] vec = vec
-    doWrites ((a,ix):ws) vec = doWrites ws (write vec ix a)
+fromList xs f =
+  Array.fromList xs Prelude.$ \arr ->
+    Array.size arr & \(arr', Unrestricted i) ->
+      f (Vec i arr')
 
 -- | Length of the vector
-length :: Vector a #-> (Vector a, Int)
-length = Unsafe.toLinear unsafeLength
-  where
-    unsafeLength :: Vector a -> (Vector a, Int)
-    unsafeLength v@(Vec (len, _) _) = (v, len)
+length :: Vector a #-> (Vector a, Unrestricted Int)
+length (Vec len arr) =
+  (Vec len arr, Unrestricted len)
+
+-- | Capacity of the vector
+capacity :: Vector a #-> (Vector a, Unrestricted Int)
+capacity (Vec len arr) =
+  Array.size arr & \(arr', cap) ->
+    (Vec len arr', cap)
 
 -- | Insert at the end of the vector
-snoc :: HasCallStack => Vector a #-> a -> Vector a
-snoc (Vec (len, size) ma) x
-  | len < size = write (Vec (len + 1, size) ma) len x
-  | otherwise = write (unsafeResize (size * 2) (Vec (len + 1, size) ma)) len x
+snoc :: HasCallStack => a -> Vector a #-> Vector a
+snoc val vec =
+  length vec
+    & \(vec, Unrestricted len) -> ensureCapacity (len+1) vec
+    & \(Vec len arr) -> Vec (len+1) arr
+    & write len val
 
--- | Write to an element already written to before.  Note: this will not write
--- to elements beyond the current length of the array and will error instead.
-write :: HasCallStack => Vector a #-> Int -> a -> Vector a
-write = Unsafe.toLinear writeUnsafe
-  where
-    writeUnsafe :: Vector a -> Int -> a -> Vector a
-    writeUnsafe v@(Vec (len, _) mutArr) ix val
-      | indexInRange len ix = case Unsafe.writeMutArr mutArr ix val of () -> v
-      | otherwise = error "Write index not in range."
+-- | Ensure that the vector has capacity for at least given number of items.
+-- Grows the underlying array if necessary.
+ensureCapacity :: Int -> Vector a #-> Vector a
+ensureCapacity target vec =
+  capacity vec & \(Vec len arr, Unrestricted cap) ->
+    Vec
+      len
+      (if target <= cap
+       then arr
+       else Array.growBy cap (error "index out of bounds") arr
+      )
 
--- | Read from a vector, with an in-range index and error for an index that is
--- out of range (with the usual range @0..length-1@).
-read :: HasCallStack => Vector a #-> Int -> (Vector a, a)
-read = Unsafe.toLinear readUnsafe
-  where
-    readUnsafe :: Vector a -> Int -> (Vector a, a)
-    readUnsafe v@(Vec (len, _) mutArr) ix
-      | indexInRange len ix =
-          let !(# a #) = Unsafe.readMutArr mutArr ix
-          in  (v, a)
-      | otherwise = error "Read index not in range."
+-- | Indexes an vector. Fails if the index is out-of-bounds.
+read :: HasCallStack => Int -> Vector a #-> (Vector a, Unrestricted a)
+read ix vec =
+  assertIndexInRange ix vec
+    & unsafeRead ix
+
+-- | Same as 'read', but does not do bounds-checking.
+unsafeRead :: Int -> Vector a #-> (Vector a, Unrestricted a)
+unsafeRead ix (Vec len arr) =
+  Array.read ix arr & \(arr', val) ->
+    (Vec len arr', val)
+
+-- | Writes to the given array index. Fails if the index is out-of-bounds.
+write :: Int -> a -> Vector a #-> Vector a
+write ix val vec =
+  assertIndexInRange ix vec
+    & unsafeWrite ix val
+
+-- | Same as 'write', but does not do bounds-checking.
+unsafeWrite :: HasCallStack => Int -> a -> Vector a #-> Vector a
+unsafeWrite ix val (Vec len arr) =
+  Vec len (Array.write ix val arr)
 
 -- # Instances
 -------------------------------------------------------------------------------
 
 instance Consumable (Vector a) where
-  consume (Vec _ _) = ()
+  consume (Vec _ arr) = consume arr
 
 -- # Internal library
 -------------------------------------------------------------------------------
 
--- | Resize the vector with larger non-negative size
-unsafeResize :: HasCallStack => Int -> Vector a -> Vector a
-unsafeResize newSize (Vec (len, _) ma) =
-  Vec (len, newSize) (Unsafe.resizeMutArr ma newSize)
-
--- | Argument order: indexInRange len ix
-indexInRange :: Int -> Int -> Bool
-indexInRange size ix = 0 <= ix && ix < size
+assertIndexInRange :: Int -> Vector a #-> Vector a
+assertIndexInRange ix vec =
+  length vec & \(vec', Unrestricted len) ->
+    if 0 <= ix && ix < len
+    then vec'
+    else vec' `lseq` error ("index out of bounds:" ++ show len)

--- a/src/Data/Vector/Mutable/Linear.hs
+++ b/src/Data/Vector/Mutable/Linear.hs
@@ -134,7 +134,7 @@ read ix vec =
 -- | Same as 'read', but does not do bounds-checking.
 unsafeRead :: Int -> Vector a #-> (Vector a, Unrestricted a)
 unsafeRead ix (Vec len arr) =
-  Array.read ix arr & \(arr', val) ->
+  Array.unsafeRead ix arr & \(arr', val) ->
     (Vec len arr', val)
 
 -- | Writes to the given array index. Fails if the index is out-of-bounds.
@@ -146,7 +146,7 @@ write ix val vec =
 -- | Same as 'write', but does not do bounds-checking.
 unsafeWrite :: HasCallStack => Int -> a -> Vector a #-> Vector a
 unsafeWrite ix val (Vec len arr) =
-  Vec len (Array.write ix val arr)
+  Vec len (Array.unsafeWrite ix val arr)
 
 -- # Instances
 -------------------------------------------------------------------------------


### PR DESCRIPTION
This PR refactors `Data.Vector.Mutable.Linear` to use `Data.Array.Mutable.Linear` instead of `Unsafe.MutableArray`. I also did a few refactors around the Array code.

In summary:

* I exposed `unsafeRead` and `unsafeWrite` functions from vectors and array to reduce unnecessary bounds-checking in vector code.
* I changed the type signatures so that the linear collection is the last parameter as opposed to the first. This might be controversial , but IMO it makes it nicer to compose the functions, eg:

```haskell
Vector.fromList l
  $ \vec ->
    vec
      Linear.& Vector.length
      Linear.& \(vec, Unrestricted oldLength) -> Vector.snoc 42 vec
      Linear.& Vector.length
      Linear.& getSnd
      Linear.& \(Unrestricted newLength) -> Unrestricted $ newLength === oldLength + 1
```

* `Array` had a few resize functions with counter-intutive semantics. I replaced them with three functions: `allocBeside`, `growBy` and `shrinkTo`. Let me know if you prefer something else.
* `MutableArray`, `Array` and `Vector` used to require at least one element inside. I removed this constraint. It seems like `MutableArray` can have 0 length, and therefore there is no reason `Array` and `Vector` to have that restriction.

So I'm sorry if this PR is a bit all around the place. I suggest you review the modules in this order:

* `Unsafe.MutableArray`
* `Data.Array.Mutable.Linear`
* `Data.Vector.Mutable.Linear.`
* tests
* `Data.HashMap.Linear` (only contains changes because of the parameter order change)