### PR TITLE
Reimplement resize and resizeSeed functions on linear arrays

### DIFF
--- a/src/Data/Array/Mutable/Linear.hs
+++ b/src/Data/Array/Mutable/Linear.hs
@@ -135,10 +135,12 @@ read = Unsafe.toLinear readUnsafe
 -- value; resize the array to the given size using the seed value to fill
 -- in the new cells when necessary and copying over all the unchanged cells.
 --
+-- @
 -- let b = resize n x a,
 --   then length b = n,
 --   and b[i] = a[i] for i < length a,
 --   and b[i] = x for length a <= i < n.
+-- @
 resize :: HasCallStack => Int -> a -> Array a #-> Array a
 resize newSize seed (Array _ mut) =
   Array newSize (Unsafe.resizeMutArrSeed mut seed newSize)

--- a/src/Data/Array/Mutable/Linear.hs
+++ b/src/Data/Array/Mutable/Linear.hs
@@ -43,11 +43,11 @@ module Data.Array.Mutable.Linear
     Array,
     -- * Performing Computations with Arrays
     alloc,
+    allocBeside,
     fromList,
     -- * Mutators
     write,
     resize,
-    resizeSeed,
     -- * Accessors
     read,
     length,
@@ -80,6 +80,13 @@ alloc :: HasCallStack =>
 alloc size x f
   | size > 0 = f (Array size (Unsafe.newMutArr size x))
   | otherwise = error $ "Trying to allocate an array of size " ++ show size
+
+-- | Allocate a constant array given a size and an initial value,
+-- using another array as a uniqueness proof.
+allocBeside :: Int -> a -> Array b #-> (Array b, Array a)
+allocBeside size val orig
+  | size > 0 = (orig, Array size (Unsafe.newMutArr size val))
+  | otherwise = orig `lseq` error ("Trying to allocate an array of size " ++ show size)
 
 -- | Allocate an array from a non-empty list (and error on empty lists)
 fromList :: HasCallStack =>
@@ -124,16 +131,17 @@ read = Unsafe.toLinear readUnsafe
           in  (arr, Unrestricted a)
       | otherwise = error "Read index out of bounds."
 
--- | Using first element as seed, resize to a constant array
-resize :: HasCallStack => Int -> Array a #-> Array a
-resize newSize (Array _ mutArr) =
-  let !(# a #) = Unsafe.readMutArr mutArr 0
-  in  Array newSize (Unsafe.newMutArr newSize a)
-
--- | Resize to a new constant array given a seed value
-resizeSeed :: HasCallStack => Int -> a -> Array a #-> Array a
-resizeSeed newSize seed (Array _ _) =
-  Array newSize (Unsafe.newMutArr newSize seed)
+-- | Resize an array. That is, given an array, a target size, and a seed
+-- value; resize the array to the given size using the seed value to fill
+-- in the new cells when necessary and copying over all the unchanged cells.
+--
+-- let b = resize n x a,
+--   then length b = n,
+--   and b[i] = a[i] for i < length a,
+--   and b[i] = x for length a <= i < n.
+resize :: HasCallStack => Int -> a -> Array a #-> Array a
+resize newSize seed (Array _ mut) =
+  Array newSize (Unsafe.resizeMutArrSeed mut seed newSize)
 
 -- XXX: Replace with toVec
 toList :: Array a #-> (Array a, [a])

--- a/src/Data/HashMap/Linear.hs
+++ b/src/Data/HashMap/Linear.hs
@@ -159,9 +159,10 @@ tryInsertAtIndex hmap ix kPSL v = probeFrom kPSL ix hmap & \case
 resizeMap :: Keyed k => HashMap k v #-> HashMap k v
 resizeMap (HashMap (Size s) _ arr) = extractPairs arr & \case
   (arr', Unrestricted kvs) ->
-    resizeSeed (s*2 + s`div`2) (-1, errKV) arr' & \case
-      arr'' ->
-        insertAll kvs (HashMap (Size (s*2 + s`div`2)) (Count 0) arr'')
+    allocBeside (s*2 + s`div`2) (-1, errKV) arr' & \case
+      (oldArr, arr'') ->
+        oldArr `lseq`
+          insertAll kvs (HashMap (Size (s*2 + s`div`2)) (Count 0) arr'')
   where
     errKV :: Keyed k => (k,v)
     errKV =

--- a/src/Unsafe/MutableArray.hs
+++ b/src/Unsafe/MutableArray.hs
@@ -68,29 +68,37 @@ readMutArr mutArr (I# ix) =
   where
     doRead = runRW# $ \stateRW -> readArray# mutArr ix stateRW
 
--- | Grow a mutable array. This is given an array, a given larger size,
--- and it returns a larger array of the given size using the first value
--- to fill in the new cells and copying over all the unchanged cells. This
--- fails for a size smaller than the size of the given array.
-resizeMutArr :: MutArr# a -> Int -> MutArr# a
-resizeMutArr mutArr newSize =
-  let !(# a #) = readMutArr mutArr 0
-  in  resizeMutArrSeed mutArr a newSize
-
--- | Grow a mutable array. This is given an array, a given larger size,
--- and it returns a larger array of the given size using the seed value
--- to fill in the new cells and copying over all the unchanged cells. This
--- fails for a size smaller than the size of the given array.
+-- | Resize a mutable array. That is given an array, a size, and it returns
+-- a new array of the given size using the seed value to fill in the new
+-- cells when necessary and copying over all the unchanged cells.
+--
+-- The size should be positive.
+--
+-- let b = resize a x n,
+--   then length b = n,
+--   and b[i] = a[i] for i < length a,
+--   and b[i] = x for length a <= i < n.
 resizeMutArrSeed :: MutArr# a -> a -> Int -> MutArr# a
 resizeMutArrSeed mutArr x newSize = case newMutArr newSize x of
   newArr -> case copyIntoMutArr mutArr newArr of
     () -> newArr
 
--- | Copy the first mutable array into the second, larger mutable array.
--- This fails if the second array is smaller than the first.
+-- | Same as 'resizeMutArraySeed', but using the first index of the initial
+-- array as the seed value.
+resizeMutArr :: MutArr# a -> Int -> MutArr# a
+resizeMutArr mutArr newSize =
+  let !(# a #) = readMutArr mutArr 0
+  in  resizeMutArrSeed mutArr a newSize
+
+-- | Copy the first mutable array into the second mutable array.
+-- Copies fewer elements if the second array is smaller than the first.
 copyIntoMutArr :: MutArr# a -> MutArr# a -> ()
 copyIntoMutArr src dest = case doCopy of _ -> ()
   where
-    doCopy = runRW# $ \stateRW -> copyMutableArray# src z dest z src_len stateRW
+    doCopy = runRW# $ \stateRW ->
+      copyMutableArray# src z dest z min_len stateRW
     (I# z) = 0 :: Int
-    src_len = sizeofMutableArray# src
+    I# min_len =
+      min
+        (I# (sizeofMutableArray# src))
+        (I# (sizeofMutableArray# dest))

--- a/src/Unsafe/MutableArray.hs
+++ b/src/Unsafe/MutableArray.hs
@@ -74,10 +74,12 @@ readMutArr mutArr (I# ix) =
 --
 -- The size should be positive.
 --
+-- @
 -- let b = resize a x n,
 --   then length b = n,
 --   and b[i] = a[i] for i < length a,
 --   and b[i] = x for length a <= i < n.
+-- @
 resizeMutArrSeed :: MutArr# a -> a -> Int -> MutArr# a
 resizeMutArrSeed mutArr x newSize = case newMutArr newSize x of
   newArr -> case copyIntoMutArr mutArr newArr of

--- a/src/Unsafe/MutableArray.hs
+++ b/src/Unsafe/MutableArray.hs
@@ -28,6 +28,7 @@ module Unsafe.MutableArray
 where
 
 import GHC.Exts
+import GHC.Stack
 
 -- # Unsafe wrappers
 ----------------------------
@@ -41,7 +42,7 @@ sizeMutArr arr  = I# (sizeofMutableArray# arr)
 
 -- | Given a size, try to allocate a mutable array
 -- of this size. The size should be greater than zero.
-newMutArr :: Int -> a -> MutArr# a
+newMutArr :: HasCallStack => Int -> a -> MutArr# a
 newMutArr (I# size) x =
   case newArray of
     (# _, array #) -> array
@@ -50,7 +51,7 @@ newMutArr (I# size) x =
 
 -- | Write to a given mutable array arr, given an
 -- index in [0, size(arr)-1] , and a value
-writeMutArr :: MutArr# a -> Int -> a -> ()
+writeMutArr :: HasCallStack => MutArr# a -> Int -> a -> ()
 writeMutArr mutArr (I# ix) val =
   case doWrite of _ -> ()
   where
@@ -62,7 +63,7 @@ writeMutArr mutArr (I# ix) val =
 -- This returns an unboxed tuple to give the callee the
 -- ability to evaluate the function call without evaluating
 -- the final result.
-readMutArr :: MutArr# a -> Int -> (# a #)
+readMutArr :: HasCallStack => MutArr# a -> Int -> (# a #)
 readMutArr mutArr (I# ix) =
   case doRead of (# _, a #) -> (# a #)
   where
@@ -80,7 +81,7 @@ readMutArr mutArr (I# ix) =
 --   and b[i] = a[i] for i < length a,
 --   and b[i] = x for length a <= i < n.
 -- @
-resizeMutArrSeed :: MutArr# a -> a -> Int -> MutArr# a
+resizeMutArrSeed :: HasCallStack => MutArr# a -> a -> Int -> MutArr# a
 resizeMutArrSeed mutArr x newSize = case newMutArr newSize x of
   newArr -> case copyIntoMutArr mutArr newArr of
     () -> newArr
@@ -89,7 +90,7 @@ resizeMutArrSeed mutArr x newSize = case newMutArr newSize x of
 -- array as the seed value.
 --
 -- Given array should be non-empty, and given size should be positive.
-resizeMutArr :: MutArr# a -> Int -> MutArr# a
+resizeMutArr :: HasCallStack => MutArr# a -> Int -> MutArr# a
 resizeMutArr mutArr newSize =
   let !(# a #) = readMutArr mutArr 0
   in  resizeMutArrSeed mutArr a newSize

--- a/src/Unsafe/MutableArray.hs
+++ b/src/Unsafe/MutableArray.hs
@@ -85,6 +85,8 @@ resizeMutArrSeed mutArr x newSize = case newMutArr newSize x of
 
 -- | Same as 'resizeMutArraySeed', but using the first index of the initial
 -- array as the seed value.
+--
+-- Given array should be non-empty, and given size should be positive.
 resizeMutArr :: MutArr# a -> Int -> MutArr# a
 resizeMutArr mutArr newSize =
   let !(# a #) = readMutArr mutArr 0

--- a/test/Test/Data/Mutable/Array.hs
+++ b/test/Test/Data/Mutable/Array.hs
@@ -200,22 +200,8 @@ lenWrite = property $ do
 
 lenWriteTest :: Int -> Int -> Int -> ArrayTester
 lenWriteTest size val ix arr =
-  compInts (move size) 
+  compInts (move size)
     (move Linear.$ getSnd Linear.$ Array.length (Array.write arr ix val))
-
-lenResize :: Property
-lenResize = property $ do
-  l <- forAll list
-  let size = length l
-  newSize <- forAll $ Gen.element [size..(size*4)]
-  let tester = lenResizeTest newSize
-  test $ unUnrestricted Linear.$ Array.fromList l tester
-
-lenResizeTest :: Int -> ArrayTester
-lenResizeTest newSize arr =
-  compInts
-    (move newSize)
-    (move Linear.$ getSnd Linear.$ Array.length (Array.resize newSize 42 arr))
 
 lenResizeSeed :: Property
 lenResizeSeed = property $ do

--- a/test/Test/Data/Mutable/Array.hs
+++ b/test/Test/Data/Mutable/Array.hs
@@ -236,8 +236,8 @@ resizeRef :: Property
 resizeRef = property $ do
   l <- forAll list
   n <- forAll $ Gen.int (Range.linear 0 (length l * 2))
-  let x = 42
-      expected = take n $ l ++ repeat x
+  x <- forAll value
+  let expected = take n $ l ++ repeat x
       actual =
         Linear.forget unUnrestricted . Array.fromList l $ \arr ->
           Array.resize n x arr


### PR DESCRIPTION
Closes #148.

This PR modifies the resize function on linear arrays to 

* Copy over the elements to the new array instead of returning a constant array
* Support shrinking

In order to provide the same abilities, it also introduces an `allocBeside` function for allocating a new array without a continuation using another array as a uniqueness proof.

See #148 for more details.