### PR TITLE
Consume the continuation linearly when allocating linear collections

### DIFF
--- a/examples/Simple/TopSort.hs
+++ b/examples/Simple/TopSort.hs
@@ -52,7 +52,7 @@ topsort = reverse . postOrder . fmap (  \(n,nbrs) -> (n,(nbrs,0))  )
     postOrder :: [(Node, ([Node], Int))] -> [Node]
     postOrder [] = []
     postOrder (xs) = let nodes = map fst xs in
-      unUnrestricted Linear.$ HMap.empty (HMap.Size (length xs * 2)) $
+      unUnrestricted Linear.$ HMap.empty (HMap.Size (length xs * 2)) Linear.$
         \hm -> postOrderHM nodes (HMap.insertAll xs hm)
 
 

--- a/src/Data/HashMap/Linear.hs
+++ b/src/Data/HashMap/Linear.hs
@@ -115,7 +115,7 @@ data ProbeResult k where
 
 -- | Run a computation given an empty hashmap
 empty :: forall k v b.
-  Keyed k => Size -> (HashMap k v #-> Unrestricted b) -> Unrestricted b
+  Keyed k => Size -> (HashMap k v #-> Unrestricted b) #-> Unrestricted b
 empty sz@(Size s) scope =
   alloc
     s
@@ -124,10 +124,7 @@ empty sz@(Size s) scope =
       , error "reading error hashmap val"
       )
     )
-    scope'
-  where
-    scope' :: RobinArr k v #-> Unrestricted b
-    scope' arr = scope $ HashMap sz (Count 0) arr
+    (\arr -> scope (HashMap sz (Count 0) arr))
 
 -- | If the key is present, this update the value.
 -- If not, if there's enough space, insert a new pair.

--- a/src/Data/Set/Mutable/Linear.hs
+++ b/src/Data/Set/Mutable/Linear.hs
@@ -40,13 +40,11 @@ type Keyed a = Linear.Keyed a
 -- # Constructors and Mutators
 -------------------------------------------------------------------------------
 
-empty :: Keyed a => Int -> (Set a #-> Unrestricted b) -> Unrestricted b
-empty s (f :: Set a #-> Unrestricted b) = Linear.empty (Linear.Size s) f'
-  where
-    f' :: Linear.HashMap a () #-> Unrestricted b
-    f' hmap = f (Set hmap)
+empty :: Keyed a => Int -> (Set a #-> Unrestricted b) #-> Unrestricted b
+empty s (f :: Set a #-> Unrestricted b) =
+  Linear.empty (Linear.Size s) (\hm -> f (Set hm))
 
-fromList :: (HasCallStack, Keyed a) => [a] -> (Set a #-> Unrestricted b) -> Unrestricted b
+fromList :: (HasCallStack, Keyed a) => [a] -> (Set a #-> Unrestricted b) #-> Unrestricted b
 fromList xs f = empty ((length xs) * 2 + 1) (f Linear.. insertAll xs)
   where
     insertAll :: Keyed a => [a] -> Set a #-> Set a


### PR DESCRIPTION
Closes #150 .

This PR generalizes the collection allocation functions where we delimit the scope of the linear collection with a continuation by consuming the continuation linearly. This allows nesting those continuations. See #150 for an example where the previous signature fails.

While doing this change, I had to inline a few functions to make the typechecker checker happy, although I am not 100% sure why they did not work as-is. However, I hope those changes are not a big deal.

Another noteworthy issue is about the partial functions. Most allocation functions are partial, they panic on things like negative sizes. In those cases, we now can not simply ignore the continuation. So, I am doing this ugly trick in a few places:

```haskell
alloc :: HasCallStack => Int -> a -> (Array a #-> Unrestricted b) #-> Unrestricted b
alloc size x f
  | size > 0 = ...
  | otherwise =
    (error ("Trying to allocate an array of size " ++ show size) :: x #-> x)
    (f undefined)
```

That looks pretty hacky to me. I guess an alternative is to implement a new function like:

```haskell
consumeViaError :: String -> a #-> b
consumeViaError = error
```

But that doesn't look so nice either. Especially because the only reason to have it is the lack of inference of linear functions. I'd be happy to hear about alternative solutions here.