### PR TITLE
Use Unrestricted on Array.toList and Vector.read

### DIFF
--- a/src/Data/Array/Mutable/Linear.hs
+++ b/src/Data/Array/Mutable/Linear.hs
@@ -58,9 +58,10 @@ where
 import Data.Unrestricted.Linear
 import GHC.Exts hiding (toList, fromList)
 import GHC.Stack
+import qualified Data.Functor.Linear as Control
 import qualified Unsafe.Linear as Unsafe
 import qualified Unsafe.MutableArray as Unsafe
-import Prelude.Linear ((&))
+import Prelude.Linear ((&), forget)
 import Prelude hiding (length, read)
 import qualified Prelude
 
@@ -136,22 +137,22 @@ resizeSeed newSize seed (Array _ _) =
   Array newSize (Unsafe.newMutArr newSize seed)
 
 -- XXX: Replace with toVec
-toList :: Array a #-> (Array a, [a])
+toList :: Array a #-> (Array a, Unrestricted [a])
 toList arr = length arr & \case
   (arr', len) -> move len & \case
-    Unrestricted len' -> toListWalk (len' - 1) arr' []
+    Unrestricted len' -> toListWalk (len' - 1) arr' (Unrestricted [])
   where
-  toListWalk :: Int -> Array a #-> [a] -> (Array a, [a])
+  toListWalk :: Int -> Array a #-> Unrestricted [a] -> (Array a, Unrestricted [a])
   toListWalk ix arr accum
     | ix < 0 = (arr, accum)
     | otherwise = read arr ix & \case
-        (arr', Unrestricted x) -> toListWalk (ix - 1) arr' (x:accum)
+        (arr', Unrestricted x) -> toListWalk (ix - 1) arr' ((x:) Control.<$> accum)
 
 -- # Instances
 -------------------------------------------------------------------------------
 
 instance Show a => Show (Array a) where
-  show = show . snd . (\x -> toList x)
+  show = show . forget unUnrestricted . snd . (\x -> toList x)
 
 instance Consumable (Array a) where
   consume :: Array a #-> ()

--- a/src/Data/HashMap/Linear.hs
+++ b/src/Data/HashMap/Linear.hs
@@ -263,7 +263,7 @@ instance Consumable (HashMap k v) where
 -- # This is provided for debugging only.
 instance (Show k, Show v) => Show (HashMap k v) where
   show (HashMap _ _ robinArr) = toList robinArr & \case
-    (arr, xs) -> display (lseq arr xs)
+    (arr, Unrestricted xs) -> display (lseq arr xs)
 
 display :: (Show k, Show v) => [RobinVal k v] #-> String
 display = Unsafe.toLinear wrapper

--- a/src/Data/Vector/Mutable/Linear.hs
+++ b/src/Data/Vector/Mutable/Linear.hs
@@ -121,14 +121,14 @@ write = Unsafe.toLinear writeUnsafe
 
 -- | Read from a vector, with an in-range index and error for an index that is
 -- out of range (with the usual range @0..length-1@).
-read :: HasCallStack => Vector a #-> Int -> (Vector a, a)
+read :: HasCallStack => Vector a #-> Int -> (Vector a, Unrestricted a)
 read = Unsafe.toLinear readUnsafe
   where
-    readUnsafe :: Vector a -> Int -> (Vector a, a)
+    readUnsafe :: Vector a -> Int -> (Vector a, Unrestricted a)
     readUnsafe v@(Vec (len, _) mutArr) ix
       | indexInRange len ix =
           let !(# a #) = Unsafe.readMutArr mutArr ix
-          in  (v, a)
+          in  (v, Unrestricted a)
       | otherwise = error "Read index not in range."
 
 -- # Instances


### PR DESCRIPTION
Mutable arrays and vectors are linear on the collection itself, not on the values. So, after we read a value it should be unrestricted. Returning the elements linearly restricts their usage unnecessarily, especially when the elements are not `Movable`.

Before:

```haskell
toList :: Array a #-> (Array a, [a])
read :: HasCallStack => Vector a #-> Int -> (Vector a, a)
```

After:

```haskell
toList :: Array a #-> (Array a, Unrestricted [a])
read :: HasCallStack => Vector a #-> Int -> (Vector a, Unrestricted a)
```

The rest of the PR is pretty much following the types. I decided to create a PR because the change was small. Happy to close it if there is a good reason for keeping the old behaviour.