### PR TITLE
Fix link to LICENSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ making pull requests.
 
 ## Licence
 
-See our [Licence](https://github.com/tweag/linear-base/blob/doc-overview/LICENSE).
+See our [Licence](https://github.com/tweag/linear-base/blob/master/LICENSE).
 
 Copyright © Tweag I/O
 


### PR DESCRIPTION
It used to point to a file in a non-existing branch. This makes it point to master instead.