### PR TITLE
Fix build error caused by conflicting changes

### DIFF
--- a/test/Test/Data/Mutable/Array.hs
+++ b/test/Test/Data/Mutable/Array.hs
@@ -225,11 +225,10 @@ resizeRef = property $ do
   x <- forAll value
   let expected = take n $ l ++ repeat x
       actual =
-        Linear.forget unUnrestricted . Array.fromList l $ \arr ->
+        unUnrestricted Linear.. Array.fromList l Linear.$ \arr ->
           Array.resize n x arr
             Linear.& Array.toList
             Linear.& getSnd
-            Linear.& move
   actual === expected
 
 -- https://github.com/tweag/linear-base/pull/135


### PR DESCRIPTION
It looks like merging #152 and #154  at the same time caused the master fail to typecheck. I'll make sure that the branches are up-to-date before merging from now on.