### PR TITLE
Implement mutable vectors using arrays

### DIFF
--- a/src/Data/Array/Mutable/Linear.hs
+++ b/src/Data/Array/Mutable/Linear.hs
@@ -135,7 +135,6 @@ unsafeWrite (Array size arr) ix val =
   case Unsafe.writeMutArr arr ix val of
     () -> Array size arr
 
-
 -- | Read an index from an Array. The index should be less than the arrays size,
 -- otherwise this errors.
 read :: HasCallStack => Array a #-> Int -> (Array a, Unrestricted a)

--- a/src/Data/HashMap/Linear.hs
+++ b/src/Data/HashMap/Linear.hs
@@ -39,7 +39,7 @@ module Data.HashMap.Linear
   )
 where
 
-import Data.Array.Mutable.Linear
+import Data.Array.Mutable.Linear hiding (size)
 import Data.Hashable
 import Data.Unrestricted.Linear
 import Prelude.Linear hiding ((+), lookup, read)

--- a/src/Data/Vector/Mutable/Linear.hs
+++ b/src/Data/Vector/Mutable/Linear.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StrictData #-}
@@ -58,26 +59,35 @@ where
 import GHC.Exts hiding (fromList)
 import GHC.Stack
 import Prelude.Linear hiding (length, read)
-import qualified Unsafe.Linear as Unsafe
-import qualified Unsafe.MutableArray as Unsafe
-import qualified  Prelude
+import Data.Array.Mutable.Linear (Array)
+import qualified Data.Array.Mutable.Linear as Array
 
 -- # Core data types
 -------------------------------------------------------------------------------
 
-type MutArr a = MutableArray# RealWorld a
-
 -- | A dynamic mutable vector.
 data Vector a where
-  -- | Vec (current length, memory allocated) marray
-  Vec :: (Int, Int) -> MutArr a -> Vector a
+  -- | Vec current length, memory allocated) marray
+  Vec ::
+    -- ^ Current size
+    Int ->
+    -- ^ Underlying array (has size equal to or larger than the vectors)
+    Array a #->
+    Vector a
 
 -- # API: Construction, Mutation, Queries
 -------------------------------------------------------------------------------
 
+-- | Allocator from an array
+fromArray :: HasCallStack => Array a #-> Vector a
+fromArray arr =
+  Array.length arr
+    & \(arr', size') -> move size'
+    & \(Unrestricted size) -> Vec size arr'
+
 -- Allocate an empty vector
 empty :: (Vector a #-> Unrestricted b) #-> Unrestricted b
-empty f = f (Vec (0, 0) (Unsafe.newMutArr 0 undefined))
+empty f = Array.fromList [] (f . fromArray)
 
 -- | Allocate a constant vector of a given non-negative size (and error on a
 -- bad size)
@@ -87,76 +97,59 @@ constant size x f
   | size < 0 =
       (error ("Trying to construct a vector of size " ++ show size) :: x #-> x)
       (f undefined)
-  | otherwise = f (Vec (size, size) (Unsafe.newMutArr size x))
+  | otherwise = Array.alloc size x (f . fromArray)
 
 -- | Allocator from a list
 fromList :: HasCallStack => [a] -> (Vector a #-> Unrestricted b) #-> Unrestricted b
-fromList xs (f :: Vector a #-> Unrestricted b) =
-  constant
-    (Prelude.length xs)
-    (error "invariant violation: uninitialized vector position")
-    (\vec -> f (build' vec))
-  where
-    build' :: Vector a #-> Vector a
-    build' = doWrites (zip xs [0..])
-
-    doWrites :: [(a,Int)] -> Vector a #-> Vector a
-    doWrites [] vec = vec
-    doWrites ((a,ix):ws) vec = doWrites ws (write vec ix a)
+fromList xs f = Array.fromList xs (f . fromArray)
 
 -- | Length of the vector
 length :: Vector a #-> (Vector a, Int)
-length = Unsafe.toLinear unsafeLength
-  where
-    unsafeLength :: Vector a -> (Vector a, Int)
-    unsafeLength v@(Vec (len, _) _) = (v, len)
+length (Vec len arr) = (Vec len arr, len)
 
 -- | Insert at the end of the vector
 snoc :: HasCallStack => Vector a #-> a -> Vector a
-snoc (Vec (len, size) ma) x
-  | len < size = write (Vec (len + 1, size) ma) len x
-  | otherwise = write (unsafeResize (max size 1 * 2) (Vec (len + 1, size) ma)) len x
+snoc (Vec size arr) x =
+  Array.length arr & \(arr', cap') ->
+    move cap' & \(Unrestricted cap) ->
+      if size < cap
+      then write (Vec (size + 1) arr') size x
+      else write (unsafeResize (max size 1 * 2) (Vec (size + 1) arr')) size x
 
 -- | Write to an element already written to before.  Note: this will not write
 -- to elements beyond the current length of the array and will error instead.
 write :: HasCallStack => Vector a #-> Int -> a -> Vector a
-write = Unsafe.toLinear writeUnsafe
-  where
-    writeUnsafe :: Vector a -> Int -> a -> Vector a
-    writeUnsafe v@(Vec (len, _) mutArr) ix val
-      | indexInRange len ix = case Unsafe.writeMutArr mutArr ix val of () -> v
-      | otherwise = error "Write index not in range."
+write (Vec size arr) ix val
+  | indexInRange size ix = Vec size (Array.unsafeWrite arr ix val)
+  | otherwise = arr `lseq` error "Write index not in range."
 
 -- | Read from a vector, with an in-range index and error for an index that is
 -- out of range (with the usual range @0..length-1@).
 read :: HasCallStack => Vector a #-> Int -> (Vector a, Unrestricted a)
-read = Unsafe.toLinear readUnsafe
-  where
-    readUnsafe :: Vector a -> Int -> (Vector a, Unrestricted a)
-    readUnsafe v@(Vec (len, _) mutArr) ix
-      | indexInRange len ix =
-          let !(# a #) = Unsafe.readMutArr mutArr ix
-          in  (v, Unrestricted a)
-      | otherwise = error "Read index not in range."
+read (Vec size arr) ix
+  | indexInRange size ix =
+      Array.unsafeRead arr ix
+        & \(arr', val) -> (Vec size arr', val)
+  | otherwise = arr `lseq` error "Read index not in range."
 
 -- # Instances
 -------------------------------------------------------------------------------
 
 instance Consumable (Vector a) where
-  consume (Vec _ _) = ()
+  consume (Vec _ arr) = consume arr
 
 -- # Internal library
 -------------------------------------------------------------------------------
 
--- | Resize the vector with larger non-negative size
-unsafeResize :: HasCallStack => Int -> Vector a -> Vector a
-unsafeResize newSize (Vec (len, _) ma) =
+-- | Resize the vector to a non-negative size
+unsafeResize :: HasCallStack => Int -> Vector a #-> Vector a
+unsafeResize newSize (Vec len ma) =
   Vec
-    (len, newSize)
-    (Unsafe.resizeMutArr
-      ma
-      (error "access to uninitialized vector index")
+    (min len newSize)
+    (Array.resize
       newSize
+      (error "access to uninitialized vector index")
+      ma
     )
 
 -- | Argument order: indexInRange len ix

--- a/src/Data/Vector/Mutable/Linear.hs
+++ b/src/Data/Vector/Mutable/Linear.hs
@@ -52,13 +52,13 @@ module Data.Vector.Mutable.Linear
     snoc,
     -- * Accessors
     read,
-    length,
+    size,
   )
 where
 
 import GHC.Exts hiding (fromList)
 import GHC.Stack
-import Prelude.Linear hiding (length, read)
+import Prelude.Linear hiding (read)
 import Data.Array.Mutable.Linear (Array)
 import qualified Data.Array.Mutable.Linear as Array
 
@@ -67,7 +67,6 @@ import qualified Data.Array.Mutable.Linear as Array
 
 -- | A dynamic mutable vector.
 data Vector a where
-  -- | Vec current length, memory allocated) marray
   Vec ::
     -- ^ Current size
     Int ->
@@ -78,12 +77,13 @@ data Vector a where
 -- # API: Construction, Mutation, Queries
 -------------------------------------------------------------------------------
 
--- | Allocator from an array
+-- | Create a 'Vector' from an 'Array'. Result will have the size and capacity
+-- equal to the size of the given array.
 fromArray :: HasCallStack => Array a #-> Vector a
 fromArray arr =
-  Array.length arr
+  Array.size arr
     & \(arr', size') -> move size'
-    & \(Unrestricted size) -> Vec size arr'
+    & \(Unrestricted s) -> Vec s arr'
 
 -- Allocate an empty vector
 empty :: (Vector a #-> Unrestricted b) #-> Unrestricted b
@@ -93,43 +93,43 @@ empty f = Array.fromList [] (f . fromArray)
 -- bad size)
 constant :: HasCallStack =>
   Int -> a -> (Vector a #-> Unrestricted b) #-> Unrestricted b
-constant size x f
-  | size < 0 =
-      (error ("Trying to construct a vector of size " ++ show size) :: x #-> x)
+constant size' x f
+  | size' < 0 =
+      (error ("Trying to construct a vector of size " ++ show size') :: x #-> x)
       (f undefined)
-  | otherwise = Array.alloc size x (f . fromArray)
+  | otherwise = Array.alloc size' x (f . fromArray)
 
 -- | Allocator from a list
 fromList :: HasCallStack => [a] -> (Vector a #-> Unrestricted b) #-> Unrestricted b
 fromList xs f = Array.fromList xs (f . fromArray)
 
--- | Length of the vector
-length :: Vector a #-> (Vector a, Int)
-length (Vec len arr) = (Vec len arr, len)
+-- | Number of elements inside the vector
+size :: Vector a #-> (Vector a, Int)
+size (Vec size' arr) = (Vec size' arr, size')
 
 -- | Insert at the end of the vector
 snoc :: HasCallStack => Vector a #-> a -> Vector a
-snoc (Vec size arr) x =
-  Array.length arr & \(arr', cap') ->
+snoc (Vec size' arr) x =
+  Array.size arr & \(arr', cap') ->
     move cap' & \(Unrestricted cap) ->
-      if size < cap
-      then write (Vec (size + 1) arr') size x
-      else write (unsafeResize (max size 1 * 2) (Vec (size + 1) arr')) size x
+      if size' < cap
+      then write (Vec (size' + 1) arr') size' x
+      else write (unsafeResize ((max size' 1) * 2) (Vec (size' + 1) arr')) size' x
 
 -- | Write to an element already written to before.  Note: this will not write
--- to elements beyond the current length of the array and will error instead.
+-- to elements beyond the current size of the array and will error instead.
 write :: HasCallStack => Vector a #-> Int -> a -> Vector a
-write (Vec size arr) ix val
-  | indexInRange size ix = Vec size (Array.unsafeWrite arr ix val)
+write (Vec size' arr) ix val
+  | indexInRange size' ix = Vec size' (Array.unsafeWrite arr ix val)
   | otherwise = arr `lseq` error "Write index not in range."
 
 -- | Read from a vector, with an in-range index and error for an index that is
--- out of range (with the usual range @0..length-1@).
+-- out of range (with the usual range @0..size-1@).
 read :: HasCallStack => Vector a #-> Int -> (Vector a, Unrestricted a)
-read (Vec size arr) ix
-  | indexInRange size ix =
+read (Vec size' arr) ix
+  | indexInRange size' ix =
       Array.unsafeRead arr ix
-        & \(arr', val) -> (Vec size arr', val)
+        & \(arr', val) -> (Vec size' arr', val)
   | otherwise = arr `lseq` error "Read index not in range."
 
 -- # Instances
@@ -141,17 +141,18 @@ instance Consumable (Vector a) where
 -- # Internal library
 -------------------------------------------------------------------------------
 
--- | Resize the vector to a non-negative size
+-- | Resize the vector to a non-negative size. In-range elements are preserved,
+-- the possible new elements are bottoms.
 unsafeResize :: HasCallStack => Int -> Vector a #-> Vector a
-unsafeResize newSize (Vec len ma) =
+unsafeResize newSize (Vec size' ma) =
   Vec
-    (min len newSize)
+    (min size' newSize)
     (Array.resize
       newSize
       (error "access to uninitialized vector index")
       ma
     )
 
--- | Argument order: indexInRange len ix
+-- | Argument order: indexInRange size ix
 indexInRange :: Int -> Int -> Bool
-indexInRange size ix = 0 <= ix && ix < size
+indexInRange size' ix = 0 <= ix && ix < size'

--- a/test/Test/Data/Mutable/Array.hs
+++ b/test/Test/Data/Mutable/Array.hs
@@ -186,7 +186,7 @@ lenAlloc = property $ do
 
 lenAllocTest :: Int -> ArrayTester
 lenAllocTest size arr =
-  compInts (move size) (move Linear.$ getSnd Linear.$ Array.length arr)
+  compInts (move size) (move Linear.$ getSnd Linear.$ Array.size arr)
 
 lenWrite :: Property
 lenWrite = property $ do
@@ -200,7 +200,7 @@ lenWrite = property $ do
 lenWriteTest :: Int -> Int -> Int -> ArrayTester
 lenWriteTest size val ix arr =
   compInts (move size)
-    (move Linear.$ getSnd Linear.$ Array.length (Array.write arr ix val))
+    (move Linear.$ getSnd Linear.$ Array.size (Array.write arr ix val))
 
 lenResizeSeed :: Property
 lenResizeSeed = property $ do
@@ -215,7 +215,7 @@ lenResizeSeedTest :: Int -> Int -> ArrayTester
 lenResizeSeedTest newSize val arr =
   compInts
     (move newSize)
-    (move Linear.$ getSnd Linear.$ Array.length (Array.resize newSize val arr))
+    (move Linear.$ getSnd Linear.$ Array.size (Array.resize newSize val arr))
 
 resizeRef :: Property
 resizeRef = property $ do

--- a/test/Test/Data/Mutable/Vector.hs
+++ b/test/Test/Data/Mutable/Vector.hs
@@ -154,7 +154,7 @@ readSnoc2 = property $ do
   test $ unUnrestricted Linear.$ Vector.fromList l tester
 
 readSnoc2Test :: Int -> VectorTester
-readSnoc2Test val vec = fromLen (Vector.length vec)
+readSnoc2Test val vec = fromLen (Vector.size vec)
   where
     fromLen :: (Vector.Vector Int, Int) #-> Unrestricted (TestT IO ())
     fromLen (vec,len) = fromLen' (vec, move len)
@@ -173,7 +173,7 @@ lenConst = property $ do
 
 lenConstTest :: Int -> VectorTester
 lenConstTest size vec =
-  compInts (move size) (move Linear.. getSnd Linear.$ Vector.length vec)
+  compInts (move size) (move Linear.. getSnd Linear.$ Vector.size vec)
 
 lenWrite :: Property
 lenWrite = property $ do
@@ -188,7 +188,7 @@ lenWriteTest :: Int -> Int -> Int -> VectorTester
 lenWriteTest size val ix vec =
   compInts
     (move size)
-    (move Linear.. getSnd Linear.$ Vector.length (Vector.write vec ix val))
+    (move Linear.. getSnd Linear.$ Vector.size (Vector.write vec ix val))
 
 lenSnoc :: Property
 lenSnoc = property $ do
@@ -198,13 +198,13 @@ lenSnoc = property $ do
  test $ unUnrestricted Linear.$ Vector.fromList l tester
 
 lenSnocTest :: Int -> VectorTester
-lenSnocTest val vec = fromLen Linear.$ Linear.fmap move (Vector.length vec)
+lenSnocTest val vec = fromLen Linear.$ Linear.fmap move (Vector.size vec)
   where
     fromLen ::
       (Vector.Vector Int, Unrestricted Int) #->
       Unrestricted (TestT IO ())
     fromLen (vec, Unrestricted len) =
-      compInts (move (len+1)) (move (getSnd (Vector.length (Vector.snoc vec val))))
+      compInts (move (len+1)) (move (getSnd (Vector.size (Vector.snoc vec val))))
 
 -- https://github.com/tweag/linear-base/pull/135
 readAndWriteTest :: Property


### PR DESCRIPTION
This PR implements mutable vectors in terms of mutable arrays; removing the duplicated logic and some unsafe calls. The existing tests pass, and the module still provides the same interface.

Here are the major changes:

* Mutable arrays now expose `readUnsafe` and `writeUnsafe` functions which omit bounds-checking.
* Mutable vectors now only store their size instead of a tuple of `(size, capacity)`. The `capacity` now can be obtained from the size of the underlying array.

Closes https://github.com/tweag/linear-base/issues/144. Also, a prerequisite of https://github.com/tweag/linear-base/issues/165.