### PR TITLE
Internal HashMap improvements

### DIFF
--- a/examples/Simple/TopSort.hs
+++ b/examples/Simple/TopSort.hs
@@ -52,7 +52,7 @@ topsort = reverse . postOrder . fmap (  \(n,nbrs) -> (n,(nbrs,0))  )
     postOrder :: [(Node, ([Node], Int))] -> [Node]
     postOrder [] = []
     postOrder (xs) = let nodes = map fst xs in
-      unur Linear.$ HMap.empty (HMap.Size (length xs * 2)) Linear.$
+      unur Linear.$ HMap.empty (length xs * 2) Linear.$
         \hm -> postOrderHM nodes (HMap.insertAll xs hm)
 
 

--- a/src/Data/Set/Mutable/Linear.hs
+++ b/src/Data/Set/Mutable/Linear.hs
@@ -42,7 +42,7 @@ type Keyed a = Linear.Keyed a
 
 empty :: Keyed a => Int -> (Set a #-> Ur b) #-> Ur b
 empty s (f :: Set a #-> Ur b) =
-  Linear.empty (Linear.Size s) (\hm -> f (Set hm))
+  Linear.empty s (\hm -> f (Set hm))
 
 fromList :: (HasCallStack, Keyed a) => [a] -> (Set a #-> Ur b) #-> Ur b
 fromList xs f = empty ((length xs) * 2 + 1) (f Linear.. insertAll xs)

--- a/test/Test/Data/Mutable/HashMap.hs
+++ b/test/Test/Data/Mutable/HashMap.hs
@@ -68,7 +68,7 @@ testOnAnyHM propHmtest = property $ do
   hmtest <- propHmtest
   let test = hmtest Linear.. randHM
   let initSize = maxSize `div` 50
-  assert $ unur Linear.$ HashMap.empty (HashMap.Size initSize) test
+  assert $ unur Linear.$ HashMap.empty initSize test
 
 testKVPairExists :: (Int, String) -> HMTest
 testKVPairExists (k, v) hmap =


### PR DESCRIPTION
This PR (hopefully objectively) improves HashMap's internals so that our planned improvements on #164 can be implemented with less changes to the code.

It has three standalone changes each have a separate commit. Unfortunately they all change the same area of the code, so I decided to create a single commit instead of having to solve merge conflicts next. But, ideally, you should be able to review each PR (from older to newer) relatively independently.

The commits have detailed messages about the changes. The only API change is removing the `Size` wrapper which only affects the `empty` function, without causing any behaviour change.

The same tests still pass, but it is a tricky piece of code and I am not 100% sure about the correctness yet. I will spend some time on adding some more tests in a separate PR.