### PR TITLE
Renamed Unrestricted to Ur

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -10,7 +10,7 @@ Linear base consists of the following:
 
 * fundamental data structures, functions and classes that arise
   naturally from wanting to do any linear development (e.g.,
-  `Unrestricted` and `Consumable`),
+  `Ur` and `Consumable`),
 * tools ported from [`base`] and from other critical haskell
   libraries, like `lens`,
 * new APIs for using system resources, e.g., file I/O in

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -71,7 +71,7 @@ inlined1 x = x
 useSubfunction :: Array a #-> Array a
 useSubfunction arr = fromRead (read arr 0)
   where
-    fromRead :: (Array a, Unrestricted a) #-> Array a
+    fromRead :: (Array a, Ur a) #-> Array a
     fromRead = undefined
 ```
 
@@ -89,16 +89,16 @@ Moveable`.
 
 ## Design patterns
 
-### `f :: X -> (SomeType #-> Unrestricted b) -> b` functions
+### `f :: X -> (SomeType #-> Ur b) -> b` functions
 
 This function limits the **scope** of using `SomeType` by taking
-a scope function of type `(SomeType #-> Unrestricted b)`
+a scope function of type `(SomeType #-> Ur b)`
 as its second argument and using it with a value of type `SomeType` to
-produce an `Unrestricted b`.
+produce an `Ur b`.
 
 The `SomeType` cannot escape by having it be inside the type `b` 
 in some way. This is because the `SomeType` is bound linearly in the scope
-function and `Unrestricted` holds its value with a non-linear constructor
+function and `Ur` holds its value with a non-linear constructor
 arrow.
 
 Now, if `f` is the only function that can make a `SomeType`,

--- a/examples/Foreign/Heap.hs
+++ b/examples/Foreign/Heap.hs
@@ -45,8 +45,8 @@ mergeN (Heap k1 a1 h1) (Heap k2 a2 h2) pool =
   where
     --- XXX: this is a good example of why we need a working `case` and/or
     --- `let`.
-    testAndRebuild :: Unrestricted k #-> a #-> Box (List (NEHeap k a)) #-> Unrestricted k #-> a #-> Box (List (NEHeap k a)) #-> Pool #-> NEHeap k a
-    testAndRebuild (Unrestricted k1') a1' h1' (Unrestricted k2') a2' h2' =
+    testAndRebuild :: Ur k #-> a #-> Box (List (NEHeap k a)) #-> Ur k #-> a #-> Box (List (NEHeap k a)) #-> Pool #-> NEHeap k a
+    testAndRebuild (Ur k1') a1' h1' (Ur k2') a2' h2' =
       if k1' <= k2'
         then helper k1' a1' k2' a2' h1' h2'
         else helper k2' a2' k1' a1' h2' h1'
@@ -138,7 +138,7 @@ toList :: (Manual.Representable k, Manual.Representable a, Movable k, Ord k) => 
 toList h pool = foldl (\l k a -> (k,a):l) [] h pool
 
 sort :: forall k a. (Manual.Representable k, Manual.Representable a, Movable k, Ord k, Movable a) => [(k, a)] -> [(k,a)]
-sort l = unUnrestricted $ Manual.withPool (\pool -> move $ sort' l (dup pool))
+sort l = unur $ Manual.withPool (\pool -> move $ sort' l (dup pool))
     -- XXX: can we avoid this call to `move`?
   where
     sort' :: [(k, a)] -> (Pool, Pool) #-> [(k,a)]

--- a/examples/Simple/FileIO.hs
+++ b/examples/Simple/FileIO.hs
@@ -73,7 +73,7 @@ printFirstLineAfterClose fpath = do
 -- * Linear first line printing
 --------------------------------------------
 
-linearGetFirstLine :: FilePath -> RIO (Unrestricted Text)
+linearGetFirstLine :: FilePath -> RIO (Ur Text)
 linearGetFirstLine fp = Control.do
   handle <- Linear.openFile fp System.ReadMode
   (t, handle') <- Linear.hGetLine handle
@@ -119,7 +119,7 @@ type LinHandle = Linear.Handle
 -- Notice the continuation has a non-linear arrow,
 -- i.e., (() -> RIO b). For simplicity, we don't use
 -- a more general type, like the following:
--- (>>==) :: RIO (Unrestricted a) #-> (a -> RIO b) #-> RIO b
+-- (>>==) :: RIO (Ur a) #-> (a -> RIO b) #-> RIO b
 (>>==) :: RIO () #-> (() -> RIO b) #-> RIO b
 (>>==) ma f = ma Control.>>= (\() -> f ())
 
@@ -131,7 +131,7 @@ inject = Control.return
 -- * The explicit example
 -------------------------------------------------
 
-getFirstLineExplicit :: FilePath -> RIO (Unrestricted Text)
+getFirstLineExplicit :: FilePath -> RIO (Ur Text)
 getFirstLineExplicit path =
   (openFileForReading path)
     >>#= readOneLine
@@ -139,10 +139,10 @@ getFirstLineExplicit path =
   where
     openFileForReading :: FilePath -> RIO LinHandle
     openFileForReading fp = Linear.openFile fp System.ReadMode
-    readOneLine :: LinHandle #-> RIO (Unrestricted Text, LinHandle)
+    readOneLine :: LinHandle #-> RIO (Ur Text, LinHandle)
     readOneLine = Linear.hGetLine
     closeAndReturnLine ::
-      (Unrestricted Text, LinHandle) #-> RIO (Unrestricted Text)
+      (Ur Text, LinHandle) #-> RIO (Ur Text)
     closeAndReturnLine (unrText, handle) =
       Linear.hClose handle >>#= (\() -> inject unrText)
 

--- a/examples/Simple/TopSort.hs
+++ b/examples/Simple/TopSort.hs
@@ -52,13 +52,13 @@ topsort = reverse . postOrder . fmap (  \(n,nbrs) -> (n,(nbrs,0))  )
     postOrder :: [(Node, ([Node], Int))] -> [Node]
     postOrder [] = []
     postOrder (xs) = let nodes = map fst xs in
-      unUnrestricted Linear.$ HMap.empty (HMap.Size (length xs * 2)) Linear.$
+      unur Linear.$ HMap.empty (HMap.Size (length xs * 2)) Linear.$
         \hm -> postOrderHM nodes (HMap.insertAll xs hm)
 
 
-postOrderHM :: [Node] -> InDegGraph #-> Unrestricted [Node]
+postOrderHM :: [Node] -> InDegGraph #-> Ur [Node]
 postOrderHM nodes dag = findSources nodes (computeInDeg nodes dag) & \case
-  (dag, Unrestricted sources) -> pluckSources sources [] dag
+  (dag, Ur sources) -> pluckSources sources [] dag
  where
    -- O(V + N)
   computeInDeg :: [Node] -> InDegGraph #-> InDegGraph
@@ -67,59 +67,59 @@ postOrderHM nodes dag = findSources nodes (computeInDeg nodes dag) & \case
   -- Increment in-degree of all neighbors
   incChildren :: InDegGraph #-> Node -> InDegGraph
   incChildren dag node = HMap.lookup dag node & \case
-     (dag, Unrestricted Nothing) -> dag
-     (dag, Unrestricted (Just (xs,i))) -> incNodes (move xs) dag
+     (dag, Ur Nothing) -> dag
+     (dag, Ur (Just (xs,i))) -> incNodes (move xs) dag
     where
-      incNodes :: Unrestricted [Node] #-> InDegGraph #-> InDegGraph
-      incNodes (Unrestricted ns) dag = Linear.foldl incNode dag ns
+      incNodes :: Ur [Node] #-> InDegGraph #-> InDegGraph
+      incNodes (Ur ns) dag = Linear.foldl incNode dag ns
 
       incNode :: InDegGraph #-> Node -> InDegGraph
       incNode dag node = HMap.lookup dag node & \case
-        (dag', Unrestricted Nothing) -> dag'
-        (dag', Unrestricted (Just (n,d))) ->
+        (dag', Ur Nothing) -> dag'
+        (dag', Ur (Just (n,d))) ->
           HMap.insert dag' node (n,d+1)
         --HMap.alter dag (\(Just (n,d)) -> Just (n,d+1)) node
 
 
 -- pluckSources sources postOrdSoFar dag
-pluckSources :: [Node] -> [Node] -> InDegGraph #-> Unrestricted [Node]
+pluckSources :: [Node] -> [Node] -> InDegGraph #-> Ur [Node]
 pluckSources [] postOrd dag = lseq dag (move postOrd)
 pluckSources (s:ss) postOrd dag = HMap.lookup dag s & \case
-  (dag, Unrestricted Nothing) -> pluckSources ss (s:postOrd) dag
-  (dag, Unrestricted (Just (xs,i))) -> walk xs dag & \case
-      (dag', Unrestricted newSrcs) ->
+  (dag, Ur Nothing) -> pluckSources ss (s:postOrd) dag
+  (dag, Ur (Just (xs,i))) -> walk xs dag & \case
+      (dag', Ur newSrcs) ->
         pluckSources (newSrcs ++ ss) (s:postOrd) dag'
   where
     -- decrement degree of children, save newly made sources
-    walk :: [Node] -> InDegGraph #-> (InDegGraph, Unrestricted [Node])
+    walk :: [Node] -> InDegGraph #-> (InDegGraph, Ur [Node])
     walk children dag =
       second (Data.fmap catMaybes) (mapAccum decDegree children dag)
 
     -- Decrement the degree of a node, save it if it is now a source
-    decDegree :: Node -> InDegGraph #-> (InDegGraph, Unrestricted (Maybe Node))
+    decDegree :: Node -> InDegGraph #-> (InDegGraph, Ur (Maybe Node))
     decDegree node dag = HMap.lookup dag node & \case
-        (dag', Unrestricted Nothing) -> (dag', Unrestricted Nothing)
-        (dag', Unrestricted (Just (n,d))) ->
+        (dag', Ur Nothing) -> (dag', Ur Nothing)
+        (dag', Ur (Just (n,d))) ->
           checkSource node (HMap.insert dag' node (n,d-1))
 
 
 -- Given a list of nodes, determines which are sources
-findSources :: [Node] -> InDegGraph #-> (InDegGraph, Unrestricted [Node])
+findSources :: [Node] -> InDegGraph #-> (InDegGraph, Ur [Node])
 findSources nodes dag =
   second (Data.fmap catMaybes) (mapAccum checkSource nodes dag)
 
 
 -- | Check if a node is a source, and if so return it
-checkSource :: Node -> InDegGraph #-> (InDegGraph, Unrestricted (Maybe Node))
+checkSource :: Node -> InDegGraph #-> (InDegGraph, Ur (Maybe Node))
 checkSource node dag = HMap.lookup dag node & \case
-  (dag, Unrestricted Nothing) -> (dag, Unrestricted Nothing)
-  (dag, Unrestricted (Just (xs,0))) ->  (dag, Unrestricted (Just node))
-  (dag, Unrestricted (Just (xs,n))) -> (dag, Unrestricted Nothing)
+  (dag, Ur Nothing) -> (dag, Ur Nothing)
+  (dag, Ur (Just (xs,0))) ->  (dag, Ur (Just node))
+  (dag, Ur (Just (xs,n))) -> (dag, Ur Nothing)
 
 
 mapAccum ::
-  (a -> b #-> (b, Unrestricted c)) -> [a] -> b #-> (b, Unrestricted [c])
-mapAccum f [] b =  (b, Unrestricted [])
+  (a -> b #-> (b, Ur c)) -> [a] -> b #-> (b, Ur [c])
+mapAccum f [] b =  (b, Ur [])
 mapAccum f (x:xs) b = mapAccum f xs b & \case
-  (b, Unrestricted cs) -> second (Data.fmap (:cs)) (f x b)
+  (b, Ur cs) -> second (Data.fmap (:cs)) (f x b)
 

--- a/examples/Spec.hs
+++ b/examples/Spec.hs
@@ -23,12 +23,12 @@ import Prelude.Linear
 import Test.Hspec
 import Test.QuickCheck
 
-eqList :: forall a. (Manual.Representable a, Movable a, Eq a) => List a #-> List a #-> Unrestricted Bool
+eqList :: forall a. (Manual.Representable a, Movable a, Eq a) => List a #-> List a #-> Ur Bool
 eqList l1 l2 =
     eqUL (move (List.toList l1)) (move (List.toList l2))
   where
-    eqUL :: Unrestricted [a] #-> Unrestricted [a] #-> Unrestricted Bool
-    eqUL (Unrestricted as1) (Unrestricted as2) = Unrestricted (as1 == as2)
+    eqUL :: Ur [a] #-> Ur [a] #-> Ur Bool
+    eqUL (Ur as1) (Ur as2) = Ur (as1 == as2)
 
 data InjectedError = InjectedError
   deriving (Typeable, Show)
@@ -40,18 +40,18 @@ main = hspec P.$ do
   describe "Off-heap lists" P.$ do
     describe "ofList" P.$ do
       it "is invertible" P.$
-        property (\(l :: [Int]) -> unUnrestricted (Manual.withPool $ \pool ->
+        property (\(l :: [Int]) -> unur (Manual.withPool $ \pool ->
           let
-            check :: Unrestricted [Int] #-> Unrestricted Bool
-            check (Unrestricted l') = Unrestricted P.$ l' == l
+            check :: Ur [Int] #-> Ur Bool
+            check (Ur l') = Ur P.$ l' == l
           in
             check $ move (List.toList $ List.ofList l pool)))
 
     describe "map" P.$ do
       it "of identity is the identity" P.$
-        property (\(l :: [Int]) -> unUnrestricted (Manual.withPool $ \pool ->
+        property (\(l :: [Int]) -> unur (Manual.withPool $ \pool ->
           let
-            check :: (Pool, Pool, Pool) #-> Unrestricted Bool
+            check :: (Pool, Pool, Pool) #-> Ur Bool
             check (pool1, pool2, pool3) =
               eqList
                 (List.map (\x -> x) (List.ofList l pool1) pool2)

--- a/src/Data/Eq/Linear.hs
+++ b/src/Data/Eq/Linear.hs
@@ -12,7 +12,7 @@ module Data.Eq.Linear
   where
 
 import Data.Bool.Linear
-import qualified Prelude as Unrestricted
+import qualified Prelude as Ur
 import qualified Unsafe.Linear as Unsafe
 
 -- | Testing equality on values.
@@ -34,5 +34,5 @@ class Eq a where
 
 -- This is sound because we consume all parts of a data type when we inspect
 -- for equality
-instance Unrestricted.Eq a => Eq a where
-  (==) = Unsafe.toLinear2 (Unrestricted.==)
+instance Ur.Eq a => Eq a where
+  (==) = Unsafe.toLinear2 (Ur.==)

--- a/src/Data/Num/Linear.hs
+++ b/src/Data/Num/Linear.hs
@@ -138,13 +138,13 @@ instance (Movable a, Prelude.Num a) => Num (MovableNum a) where
 
 liftU :: (Movable a) => (a -> b) #-> (a #-> b)
 liftU f x = lifted f (move x)
-  where lifted :: (a -> b) #-> (Unrestricted a #-> b)
-        lifted g (Unrestricted a) = g a
+  where lifted :: (a -> b) #-> (Ur a #-> b)
+        lifted g (Ur a) = g a
 
 liftU2 :: (Movable a, Movable b) => (a -> b -> c) #-> (a #-> b #-> c)
 liftU2 f x y = lifted f (move x) (move y)
-  where lifted :: (a -> b -> c) #-> (Unrestricted a #-> Unrestricted b #-> c)
-        lifted g (Unrestricted a) (Unrestricted b) = g a b
+  where lifted :: (a -> b -> c) #-> (Ur a #-> Ur b #-> c)
+        lifted g (Ur a) (Ur b) = g a b
 
 -- A newtype wrapper to give the underlying monoid for an additive structure.
 newtype Adding a = Adding a

--- a/src/Data/Ord/Linear.hs
+++ b/src/Data/Ord/Linear.hs
@@ -13,7 +13,7 @@ module Data.Ord.Linear
   where
 
 import Data.Eq.Linear
-import qualified Prelude as Unrestricted
+import qualified Prelude as Ur
 import Prelude (Bool(..))
 import Data.Ord (Ordering(..))
 import Data.Bool.Linear ( not )
@@ -80,23 +80,23 @@ class Eq a => Ord a where
 -- hence we unsafely coerce).
 
 -- | @max x y@ returns the largest input
-max :: (Dupable a, Unrestricted.Ord a) =>  a #-> a #-> a
-max = Unsafe.toLinear2 (Unrestricted.max)
+max :: (Dupable a, Ur.Ord a) =>  a #-> a #-> a
+max = Unsafe.toLinear2 (Ur.max)
 
 -- | @min x y@ returs the smallest input
-min :: (Dupable a, Unrestricted.Ord a) => a #-> a #-> a
-min = Unsafe.toLinear2 (Unrestricted.min)
+min :: (Dupable a, Ur.Ord a) => a #-> a #-> a
+min = Unsafe.toLinear2 (Ur.min)
 
 -- | @compare x y@ returns an @Ordering@ which is
 -- one of @GT@ (greater than), @EQ@ (equal), or @LT@ (less than)
 -- which should be understood as \"x is @(compare x y)@ y\".
-compare :: (Dupable a, Unrestricted.Ord a) => a #-> a #-> Ordering
-compare = Unsafe.toLinear2 Unrestricted.compare
+compare :: (Dupable a, Ur.Ord a) => a #-> a #-> Ordering
+compare = Unsafe.toLinear2 Ur.compare
 
 -- Note: the reason we coerce the unrestricted implementation
 -- is because it's optimized for many base types
-instance (Dupable a, Unrestricted.Ord a) => Ord a where
-  (<) = Unsafe.toLinear2 (Unrestricted.<)
-  (>) = Unsafe.toLinear2 (Unrestricted.>)
-  (>=) = Unsafe.toLinear2 (Unrestricted.>=)
-  (<=) = Unsafe.toLinear2 (Unrestricted.<=)
+instance (Dupable a, Ur.Ord a) => Ord a where
+  (<) = Unsafe.toLinear2 (Ur.<)
+  (>) = Unsafe.toLinear2 (Ur.>)
+  (>=) = Unsafe.toLinear2 (Ur.>=)
+  (<=) = Unsafe.toLinear2 (Ur.<=)

--- a/src/Data/Set/Mutable/Linear.hs
+++ b/src/Data/Set/Mutable/Linear.hs
@@ -40,11 +40,11 @@ type Keyed a = Linear.Keyed a
 -- # Constructors and Mutators
 -------------------------------------------------------------------------------
 
-empty :: Keyed a => Int -> (Set a #-> Unrestricted b) #-> Unrestricted b
-empty s (f :: Set a #-> Unrestricted b) =
+empty :: Keyed a => Int -> (Set a #-> Ur b) #-> Ur b
+empty s (f :: Set a #-> Ur b) =
   Linear.empty (Linear.Size s) (\hm -> f (Set hm))
 
-fromList :: (HasCallStack, Keyed a) => [a] -> (Set a #-> Unrestricted b) #-> Unrestricted b
+fromList :: (HasCallStack, Keyed a) => [a] -> (Set a #-> Ur b) #-> Ur b
 fromList xs f = empty ((length xs) * 2 + 1) (f Linear.. insertAll xs)
   where
     insertAll :: Keyed a => [a] -> Set a #-> Set a

--- a/src/Data/Vector/Mutable/Linear.hs
+++ b/src/Data/Vector/Mutable/Linear.hs
@@ -14,7 +14,7 @@
 -- 'snoc'.
 --
 -- To use mutable vectors, create a linear computation of type
--- @Vector a #-> Unrestricted b@ and feed it to 'constant' or 'fromList'.
+-- @Vector a #-> Ur b@ and feed it to 'constant' or 'fromList'.
 --
 -- == Example
 --
@@ -25,15 +25,15 @@
 -- > import qualified Data.Vector.Mutable.Linear as Vector
 -- >
 -- > isTrue :: Bool
--- > isTrue = unUnrestricted $ Vector.fromList [0..10] isFirstZero
+-- > isTrue = unur $ Vector.fromList [0..10] isFirstZero
 -- >
 -- > isFalse :: Bool
--- > isFalse = unUnrestricted $ Vector.fromList [1,2,3] isFirstZero
+-- > isFalse = unur $ Vector.fromList [1,2,3] isFirstZero
 -- >
--- > isFirstZero :: Vector.Vector Int #-> Unrestricted Bool
+-- > isFirstZero :: Vector.Vector Int #-> Ur Bool
 -- > isFirstZero arr = withReadingFirst (Vector.read arr 0)
 -- >   where
--- >     withReadingFirst :: (Vector.Vector Int, Int) #-> Unrestricted Bool
+-- >     withReadingFirst :: (Vector.Vector Int, Int) #-> Ur Bool
 -- >     withReadingFirst (arr, i) = lseq arr $ move (i === 0)
 -- >
 -- > (===) :: (Num a, Eq a) => a #-> a #-> Bool
@@ -83,16 +83,16 @@ fromArray :: HasCallStack => Array a #-> Vector a
 fromArray arr =
   Array.size arr
     & \(arr', size') -> move size'
-    & \(Unrestricted s) -> Vec s arr'
+    & \(Ur s) -> Vec s arr'
 
 -- Allocate an empty vector
-empty :: (Vector a #-> Unrestricted b) #-> Unrestricted b
+empty :: (Vector a #-> Ur b) #-> Ur b
 empty f = Array.fromList [] (f . fromArray)
 
 -- | Allocate a constant vector of a given non-negative size (and error on a
 -- bad size)
 constant :: HasCallStack =>
-  Int -> a -> (Vector a #-> Unrestricted b) #-> Unrestricted b
+  Int -> a -> (Vector a #-> Ur b) #-> Ur b
 constant size' x f
   | size' < 0 =
       (error ("Trying to construct a vector of size " ++ show size') :: x #-> x)
@@ -100,7 +100,7 @@ constant size' x f
   | otherwise = Array.alloc size' x (f . fromArray)
 
 -- | Allocator from a list
-fromList :: HasCallStack => [a] -> (Vector a #-> Unrestricted b) #-> Unrestricted b
+fromList :: HasCallStack => [a] -> (Vector a #-> Ur b) #-> Ur b
 fromList xs f = Array.fromList xs (f . fromArray)
 
 -- | Number of elements inside the vector
@@ -111,7 +111,7 @@ size (Vec size' arr) = (Vec size' arr, size')
 snoc :: HasCallStack => Vector a #-> a -> Vector a
 snoc (Vec size' arr) x =
   Array.size arr & \(arr', cap') ->
-    move cap' & \(Unrestricted cap) ->
+    move cap' & \(Ur cap) ->
       if size' < cap
       then write (Vec (size' + 1) arr') size' x
       else write (unsafeResize ((max size' 1) * 2) (Vec (size' + 1) arr')) size' x
@@ -125,7 +125,7 @@ write (Vec size' arr) ix val
 
 -- | Read from a vector, with an in-range index and error for an index that is
 -- out of range (with the usual range @0..size-1@).
-read :: HasCallStack => Vector a #-> Int -> (Vector a, Unrestricted a)
+read :: HasCallStack => Vector a #-> Int -> (Vector a, Ur a)
 read (Vec size' arr) ix
   | indexInRange size' ix =
       Array.unsafeRead arr ix

--- a/src/Foreign/Marshal/Pure.hs
+++ b/src/Foreign/Marshal/Pure.hs
@@ -30,7 +30,7 @@
 -- == The Interface
 --
 -- Run a computation that uses heap memory by passing a continuation to
--- 'withPool' of type @Pool #-> Unrestricted b@. Allocate and free with
+-- 'withPool' of type @Pool #-> Ur b@. Allocate and free with
 -- 'alloc' and 'deconstruct'. Make as many or as few pools you need, by
 -- using the 'Dupable' and 'Consumable' instances of  'Pool'.
 --
@@ -41,9 +41,9 @@
 -- > import qualified Foreign.Marshal.Pure as Manual
 -- >
 -- > three :: Int
--- > three = unUnrestricted (Manual.withPool nothingWith3)
+-- > three = unur (Manual.withPool nothingWith3)
 -- >
--- > nothingWith3 :: Pool #-> Unrestricted Int
+-- > nothingWith3 :: Pool #-> Ur Int
 -- > nothingWith3 pool = move (Manual.deconstruct (Manual.alloc 3 pool))
 --
 -- === What are 'Pool's?
@@ -138,14 +138,14 @@ instance
     case (storable @a, storable @b, storable @c) of
       (Dict, Dict, Dict) -> Dict
 
--- TODO: move to the definition of Unrestricted
-instance Storable a => Storable (Unrestricted a) where
+-- TODO: move to the definition of Ur
+instance Storable a => Storable (Ur a) where
   sizeOf _ = sizeOf (undefined :: a)
   alignment _ = alignment (undefined :: a)
-  peek ptr = Unrestricted <$> peek (castPtr ptr :: Ptr a)
-  poke ptr (Unrestricted a) = poke (castPtr ptr :: Ptr a) a
+  peek ptr = Ur <$> peek (castPtr ptr :: Ptr a)
+  poke ptr (Ur a) = poke (castPtr ptr :: Ptr a) a
 
-instance KnownRepresentable a => KnownRepresentable (Unrestricted a) where
+instance KnownRepresentable a => KnownRepresentable (Ur a) where
   storable | Dict <- storable @a = Dict
 
 -- Below is a KnownRepresentable instance for Maybe. The Storable instance is
@@ -334,11 +334,11 @@ freeAll start end = do
 -- TODO: document individual functions
 
 -- | Given a linear computation that manages memory, run that computation.
-withPool :: (Pool #-> Unrestricted b) #-> Unrestricted b
+withPool :: (Pool #-> Ur b) #-> Ur b
 withPool scope = Unsafe.toLinear performScope scope
     -- XXX: do ^ without `toLinear` by using linear IO
   where
-    performScope :: (Pool #-> Unrestricted b) -> Unrestricted b
+    performScope :: (Pool #-> Ur b) -> Ur b
     performScope scope' = unsafeDupablePerformIO $ do
       -- Initialise the pool
       backPtr <- malloc

--- a/src/Prelude/Linear.hs
+++ b/src/Prelude/Linear.hs
@@ -37,10 +37,10 @@ module Prelude.Linear
   , forget
   , Semigroup(..)
   , Monoid(..)
-    -- * Using 'Unrestricted' values in linear code
+    -- * Using 'Ur' values in linear code
     -- $ unrestricted
-  , Unrestricted(..)
-  , unUnrestricted
+  , Ur(..)
+  , unur
     -- * Doing non-linear operations inside linear functions
     -- $ comonoid
   , Consumable(..)

--- a/src/System/IO/Linear.hs
+++ b/src/System/IO/Linear.hs
@@ -101,10 +101,10 @@ fromSystemIO = Unsafe.coerce
 
 -- | Coerces a standard IO action to a linear IO action, allowing you to use
 -- the result of type @a@ in a non-linear manner by wrapping it inside
--- 'Unrestricted'.
-fromSystemIOU :: System.IO a -> IO (Unrestricted a)
+-- 'Ur'.
+fromSystemIOU :: System.IO a -> IO (Ur a)
 fromSystemIOU action =
-  fromSystemIO (Unrestricted <$> action)
+  fromSystemIO (Ur <$> action)
 
 -- | Convert a linear IO action to a "System.IO" action.
 toSystemIO :: IO a #-> System.IO a
@@ -117,8 +117,8 @@ toSystemIO = Unsafe.coerce -- basically just subtyping
 -- main :: IO ()
 -- main = Linear.withLinearIO $ do ...
 -- @
-withLinearIO :: IO (Unrestricted a) -> System.IO a
-withLinearIO action = (\x -> unUnrestricted x) <$> (toSystemIO action)
+withLinearIO :: IO (Ur a) -> System.IO a
+withLinearIO action = (\x -> unur x) <$> (toSystemIO action)
 
 -- * Monadic interface
 
@@ -162,10 +162,10 @@ instance Control.Monad IO where
 -- linear values can make linear values escape their scope and be used
 -- non-linearly.
 
-newIORef :: a -> IO (Unrestricted (IORef a))
+newIORef :: a -> IO (Ur (IORef a))
 newIORef a = fromSystemIOU (System.newIORef a)
 
-readIORef :: IORef a -> IO (Unrestricted a)
+readIORef :: IORef a -> IO (Ur a)
 readIORef r = fromSystemIOU (System.readIORef r)
 
 writeIORef :: IORef a -> a -> IO ()
@@ -183,7 +183,7 @@ throwIO e = fromSystemIO $ System.throwIO e
 
 catch
   :: Exception e
-  => IO (Unrestricted a) -> (e -> IO (Unrestricted a)) -> IO (Unrestricted a)
+  => IO (Ur a) -> (e -> IO (Ur a)) -> IO (Ur a)
 catch body handler =
   fromSystemIO $ System.catch (toSystemIO body) (\e -> toSystemIO (handler e))
 

--- a/test/Test/Data/Mutable/HashMap.hs
+++ b/test/Test/Data/Mutable/HashMap.hs
@@ -54,7 +54,7 @@ group =
 type HMap = HashMap.HashMap Int String
 
 -- | A test checks a boolean property on a hashmap and consumes it
-type HMTest = HMap #-> Unrestricted Bool
+type HMTest = HMap #-> Ur Bool
 
 
 maxSize :: Int
@@ -68,15 +68,15 @@ testOnAnyHM propHmtest = property $ do
   hmtest <- propHmtest
   let test = hmtest Linear.. randHM
   let initSize = maxSize `div` 50
-  assert $ unUnrestricted Linear.$ HashMap.empty (HashMap.Size initSize) test
+  assert $ unur Linear.$ HashMap.empty (HashMap.Size initSize) test
 
 testKVPairExists :: (Int, String) -> HMTest
 testKVPairExists (k, v) hmap =
   fromLookup Linear.$ getSnd Linear.$ HashMap.lookup hmap k
   where
-    fromLookup :: Unrestricted (Maybe String) #-> Unrestricted Bool
-    fromLookup (Unrestricted Nothing) = Unrestricted False
-    fromLookup (Unrestricted (Just v')) = Unrestricted (v' == v)
+    fromLookup :: Ur (Maybe String) #-> Ur Bool
+    fromLookup (Ur Nothing) = Ur False
+    fromLookup (Ur (Just v')) = Ur (v' == v)
 
 testKeyMember :: Int -> HMTest
 testKeyMember key hmap = move Linear.$ getSnd Linear.$ HashMap.member hmap key
@@ -89,14 +89,14 @@ testKeyMissing :: Int -> HMTest
 testKeyMissing key hmap =
   fromLookup Linear.$ getSnd Linear.$ HashMap.lookup hmap key
   where
-    fromLookup :: Unrestricted (Maybe String) #-> Unrestricted Bool
-    fromLookup (Unrestricted Nothing) = Unrestricted True
-    fromLookup (Unrestricted _) = Unrestricted False
+    fromLookup :: Ur (Maybe String) #-> Ur Bool
+    fromLookup (Ur Nothing) = Ur True
+    fromLookup (Ur _) = Ur False
 
 testLookupUnchanged :: (HMap #-> HMap) -> Int -> HMTest
 testLookupUnchanged f k hmap = fromLookup (HashMap.lookup hmap k)
   where
-    fromLookup :: (HMap, Unrestricted (Maybe String)) #-> Unrestricted Bool
+    fromLookup :: (HMap, Ur (Maybe String)) #-> Ur Bool
     fromLookup (hmap', look1) =
       compareMaybes look1 (getSnd Linear.$ HashMap.lookup (f hmap') k)
 
@@ -111,10 +111,10 @@ getSnd :: (Consumable a) => (a, b) #-> b
 getSnd (a, b) = lseq a b
 
 compareMaybes :: Eq a =>
-  Unrestricted (Maybe a) #->
-  Unrestricted (Maybe a) #->
-  Unrestricted Bool
-compareMaybes (Unrestricted a) (Unrestricted b) = Unrestricted (a == b)
+  Ur (Maybe a) #->
+  Ur (Maybe a) #->
+  Ur Bool
+compareMaybes (Ur a) (Ur b) = Ur (a == b)
 
 -- # Random Generation
 ----------------------------------------
@@ -206,16 +206,16 @@ sizeInsert = testOnAnyHM $ do
 checkSizeAfterInsert :: (Int, String) -> HMTest
 checkSizeAfterInsert (k, v) hmap = withSize Linear.$ HashMap.size hmap
   where
-    withSize :: (HMap, Int) #-> Unrestricted Bool
+    withSize :: (HMap, Int) #-> Ur Bool
     withSize (hmap, oldSize) =
       checkSize (move oldSize)
         Linear.$ move
         Linear.$ getSnd
         Linear.$ HashMap.size
         Linear.$ HashMap.insert hmap k v
-    checkSize :: Unrestricted Int #-> Unrestricted Int #-> Unrestricted Bool
-    checkSize (Unrestricted old) (Unrestricted new) =
-      Unrestricted ((old + 1) == new)
+    checkSize :: Ur Int #-> Ur Int #-> Ur Bool
+    checkSize (Ur old) (Ur new) =
+      Ur ((old + 1) == new)
 
 deleteSize :: Property
 deleteSize = testOnAnyHM $ do
@@ -228,12 +228,12 @@ deleteSize = testOnAnyHM $ do
 checkSizeAfterDelete :: Int -> HMTest
 checkSizeAfterDelete key hmap = fromSize (HashMap.size hmap)
   where
-    fromSize :: (HMap, Int) #-> Unrestricted Bool
+    fromSize :: (HMap, Int) #-> Ur Bool
     fromSize (hmap, orgSize) =
       compSizes (move orgSize)
         Linear.$ move
         Linear.$ getSnd
         Linear.$ HashMap.size (HashMap.delete hmap key)
-    compSizes :: Unrestricted Int #-> Unrestricted Int #-> Unrestricted Bool
-    compSizes (Unrestricted orgSize) (Unrestricted newSize) =
-      Unrestricted ((newSize + 1) == orgSize)
+    compSizes :: Ur Int #-> Ur Int #-> Ur Bool
+    compSizes (Ur orgSize) (Ur newSize) =
+      Ur ((newSize + 1) == orgSize)

--- a/test/Test/Data/Mutable/Set.hs
+++ b/test/Test/Data/Mutable/Set.hs
@@ -42,7 +42,7 @@ group =
 -- # Internal Library
 --------------------------------------------------------------------------------
 
-type SetTester = Set.Set Int #-> Unrestricted (TestT IO ())
+type SetTester = Set.Set Int #-> Ur (TestT IO ())
 
 -- | A random list
 nonemptyList :: Gen [Int]
@@ -56,13 +56,13 @@ value :: Gen Int
 value = Gen.int (Range.linear (-100) 100)
 
 testEqual :: (Show a, Eq a) =>
-  Unrestricted a #->
-  Unrestricted a #->
-  Unrestricted (TestT IO ())
-testEqual (Unrestricted x) (Unrestricted y) = Unrestricted (x === y)
+  Ur a #->
+  Ur a #->
+  Ur (TestT IO ())
+testEqual (Ur x) (Ur y) = Ur (x === y)
 
 -- XXX: This is a terrible name
-getSnd :: (Consumable a, Movable b) => (a, b) #-> Unrestricted b
+getSnd :: (Consumable a, Movable b) => (a, b) #-> Ur b
 getSnd (a, b) = lseq a (move b)
 
 -- # Tests
@@ -73,12 +73,12 @@ memberInsert1 = property $ do
   val <- forAll value
   l <- forAll nonemptyList
   let tester = memberInsert1Test val
-  test $ unUnrestricted Linear.$ Set.fromList l tester
+  test $ unur Linear.$ Set.fromList l tester
 
 memberInsert1Test :: Int -> SetTester
 memberInsert1Test val set =
   testEqual
-    (Unrestricted True)
+    (Ur True)
     (getSnd (Set.member (Set.insert set val) val))
 
 memberInsert2 :: Property
@@ -87,12 +87,12 @@ memberInsert2 = property $ do
   val2 <- forAll $ Gen.filter (/= val1) value
   l <- forAll nonemptyList
   let tester = memberInsert2Test val1 val2
-  test $ unUnrestricted Linear.$ Set.fromList l tester
+  test $ unur Linear.$ Set.fromList l tester
 
 memberInsert2Test :: Int -> Int -> SetTester
 memberInsert2Test val1 val2 set = fromRead (Set.member set val2)
   where
-    fromRead :: (Set.Set Int, Bool) #-> Unrestricted (TestT IO ())
+    fromRead :: (Set.Set Int, Bool) #-> Ur (TestT IO ())
     fromRead (set, memberVal2) =
       testEqual
         (move memberVal2)
@@ -103,12 +103,12 @@ memberDelete1 = property $ do
   val <- forAll value
   l <- forAll nonemptyList
   let tester = memberDelete1Test val
-  test $ unUnrestricted Linear.$ Set.fromList l tester
+  test $ unur Linear.$ Set.fromList l tester
 
 memberDelete1Test :: Int -> SetTester
 memberDelete1Test val set =
   testEqual
-    (Unrestricted False)
+    (Ur False)
     (getSnd (Set.member (Set.delete set val) val))
 
 memberDelete2 :: Property
@@ -117,12 +117,12 @@ memberDelete2 = property $ do
   val2 <- forAll $ Gen.filter (/= val1) value
   l <- forAll nonemptyList
   let tester = memberDelete2Test val1 val2
-  test $ unUnrestricted Linear.$ Set.fromList l tester
+  test $ unur Linear.$ Set.fromList l tester
 
 memberDelete2Test :: Int -> Int -> SetTester
 memberDelete2Test val1 val2 set = fromRead (Set.member set val2)
   where
-    fromRead :: (Set.Set Int, Bool) #-> Unrestricted (TestT IO ())
+    fromRead :: (Set.Set Int, Bool) #-> Ur (TestT IO ())
     fromRead (set, memberVal2) =
       testEqual
         (move memberVal2)
@@ -133,12 +133,12 @@ sizeInsert1 = property $ do
   l <- forAll nonemptyList
   val <- forAll $ Gen.filter (`elem` l) value
   let tester = sizeInsert1Test val
-  test $ unUnrestricted Linear.$ Set.fromList l tester
+  test $ unur Linear.$ Set.fromList l tester
 
 sizeInsert1Test :: Int -> SetTester
 sizeInsert1Test val set = fromRead (Set.size set)
   where
-    fromRead :: (Set.Set Int, Int) #-> Unrestricted (TestT IO ())
+    fromRead :: (Set.Set Int, Int) #-> Ur (TestT IO ())
     fromRead (set, sizeOriginal) =
       testEqual
         (move sizeOriginal)
@@ -149,12 +149,12 @@ sizeInsert2 = property $ do
   l <- forAll nonemptyList
   val <- forAll $ Gen.filter (not . (`elem` l)) value
   let tester = sizeInsert2Test val
-  test $ unUnrestricted Linear.$ Set.fromList l tester
+  test $ unur Linear.$ Set.fromList l tester
 
 sizeInsert2Test :: Int -> SetTester
 sizeInsert2Test val set = fromRead (Set.size set)
   where
-    fromRead :: (Set.Set Int, Int) #-> Unrestricted (TestT IO ())
+    fromRead :: (Set.Set Int, Int) #-> Ur (TestT IO ())
     fromRead (set, sizeOriginal) =
       testEqual
         (move (sizeOriginal Linear.+ 1))
@@ -165,12 +165,12 @@ sizeDelete1 = property $ do
   l <- forAll nonemptyList
   val <- forAll $ Gen.filter (`elem` l) value
   let tester = sizeDelete1Test val
-  test $ unUnrestricted Linear.$ Set.fromList l tester
+  test $ unur Linear.$ Set.fromList l tester
 
 sizeDelete1Test :: Int -> SetTester
 sizeDelete1Test val set = fromRead (Set.size set)
   where
-    fromRead :: (Set.Set Int, Int) #-> Unrestricted (TestT IO ())
+    fromRead :: (Set.Set Int, Int) #-> Ur (TestT IO ())
     fromRead (set, sizeOriginal) =
       testEqual
         (move (sizeOriginal Linear.- 1))
@@ -181,12 +181,12 @@ sizeDelete2 = property $ do
   l <- forAll nonemptyList
   val <- forAll $ Gen.filter (not . (`elem` l)) value
   let tester = sizeDelete2Test val
-  test $ unUnrestricted Linear.$ Set.fromList l tester
+  test $ unur Linear.$ Set.fromList l tester
 
 sizeDelete2Test :: Int -> SetTester
 sizeDelete2Test val set = fromRead (Set.size set)
   where
-    fromRead :: (Set.Set Int, Int) #-> Unrestricted (TestT IO ())
+    fromRead :: (Set.Set Int, Int) #-> Ur (TestT IO ())
     fromRead (set, sizeOriginal) =
       testEqual
         (move sizeOriginal)


### PR DESCRIPTION
This PR renames `Unrestricted` to `Ur` and closes #131. 

The discussion of how we arrived at this name is documented in the issue. Basically, `Unrestricted` is a really good name but too long. Since this data type is so fundamental to linear programming that any user will quickly become familiar with its definition, it's sensible to keep the name short for line length.

Remarks:
- In the spirit of keeping things short, I've changed qualified imports that were `Unrestricted` to `Ur`. Is this problematic or can we allow it since it will be so common? (I'm leaning towards the latter.)
- `unUnrestricted` has been renamed to `unUr`