### PR TITLE
Make 'size' and 'member' functions return Unrestricted values

### DIFF
--- a/src/Data/Array/Mutable/Linear.hs
+++ b/src/Data/Array/Mutable/Linear.hs
@@ -111,8 +111,8 @@ fromList list (f :: Array a #-> Ur b) =
 -- # Mutations and Reads
 -------------------------------------------------------------------------------
 
-size :: Array a #-> (Array a, Int)
-size (Array size' arr) =  (Array size' arr, size')
+size :: Array a #-> (Array a, Ur Int)
+size (Array size' arr) =  (Array size' arr, Ur size')
 
 -- | Writes a value to an index of an Array. The index should be less than the
 -- arrays size, otherwise this errors.
@@ -170,8 +170,8 @@ resize newSize seed (Array _ mut)
 -- XXX: Replace with toVec
 toList :: Array a #-> (Array a, Ur [a])
 toList arr = size arr & \case
-  (arr', len) -> move len & \case
-    Ur len' -> toListWalk (len' - 1) arr' (Ur [])
+  (arr', Ur len) ->
+    toListWalk (len - 1) arr' (Ur [])
   where
   toListWalk :: Int -> Array a #-> Ur [a] -> (Array a, Ur [a])
   toListWalk ix arr accum

--- a/src/Data/HashMap/Linear.hs
+++ b/src/Data/HashMap/Linear.hs
@@ -231,15 +231,15 @@ probeFrom (k, p) ix (HashMap sz@(Size s) ct arr) = read arr ix & \case
 -- # Querying
 --------------------------------------------------
 
-size :: HashMap k v #-> (HashMap k v, Int)
-size (HashMap sz ct@(Count c) arr) = (HashMap sz ct arr, c)
+size :: HashMap k v #-> (HashMap k v, Ur Int)
+size (HashMap sz ct@(Count c) arr) = (HashMap sz ct arr, Ur c)
 
-member :: Keyed k => HashMap k v #-> k -> (HashMap k v, Bool)
+member :: Keyed k => HashMap k v #-> k -> (HashMap k v, Ur Bool)
 member (HashMap (Size s) ct arr) k =
   probeFrom (k,0) ((hash k) `mod` s) (HashMap (Size s) ct arr) & \case
-    (h, IndexToUpdate _ _) -> (h, True)
-    (h, IndexToInsert _ _) -> (h, False)
-    (h, IndexToSwap _ _) -> (h, False)
+    (h, IndexToUpdate _ _) -> (h, Ur True)
+    (h, IndexToInsert _ _) -> (h, Ur False)
+    (h, IndexToSwap _ _) -> (h, Ur False)
 
 lookup :: Keyed k => HashMap k v #-> k -> (HashMap k v, Ur (Maybe v))
 lookup (HashMap (Size s) ct arr) k =

--- a/src/Data/Set/Mutable/Linear.hs
+++ b/src/Data/Set/Mutable/Linear.hs
@@ -61,17 +61,13 @@ delete (Set hmap) a = Set (Linear.delete hmap a)
 -- # Accessors
 -------------------------------------------------------------------------------
 
-size :: Keyed a => Set a #-> (Set a, Int)
-size (Set hmap) = fromHashMapSize (Linear.size hmap)
-  where
-    fromHashMapSize :: (Linear.HashMap a (), Int) #-> (Set a, Int)
-    fromHashMapSize (hmap, size) = (Set hmap, size)
+size :: Keyed a => Set a #-> (Set a, Ur Int)
+size (Set hm) =
+  Linear.size hm Linear.& \(hm', s) -> (Set hm', s)
 
-member :: Keyed a => Set a #-> a -> (Set a, Bool)
-member (Set hmap) a = fromHashMapMember (Linear.member hmap a)
-  where
-    fromHashMapMember :: (Linear.HashMap a (), Bool) #-> (Set a, Bool)
-    fromHashMapMember (hmap, bool) = (Set hmap, bool)
+member :: Keyed a => Set a #-> a -> (Set a, Ur Bool)
+member (Set hm) a =
+  Linear.member hm a Linear.& \(hm', b) -> (Set hm', b)
 
 
 -- # Typeclass Instances

--- a/src/Data/Vector/Mutable/Linear.hs
+++ b/src/Data/Vector/Mutable/Linear.hs
@@ -82,8 +82,7 @@ data Vector a where
 fromArray :: HasCallStack => Array a #-> Vector a
 fromArray arr =
   Array.size arr
-    & \(arr', size') -> move size'
-    & \(Ur s) -> Vec s arr'
+    & \(arr', Ur size') -> Vec size' arr'
 
 -- Allocate an empty vector
 empty :: (Vector a #-> Ur b) #-> Ur b
@@ -104,17 +103,16 @@ fromList :: HasCallStack => [a] -> (Vector a #-> Ur b) #-> Ur b
 fromList xs f = Array.fromList xs (f . fromArray)
 
 -- | Number of elements inside the vector
-size :: Vector a #-> (Vector a, Int)
-size (Vec size' arr) = (Vec size' arr, size')
+size :: Vector a #-> (Vector a, Ur Int)
+size (Vec size' arr) = (Vec size' arr, Ur size')
 
 -- | Insert at the end of the vector
 snoc :: HasCallStack => Vector a #-> a -> Vector a
 snoc (Vec size' arr) x =
-  Array.size arr & \(arr', cap') ->
-    move cap' & \(Ur cap) ->
-      if size' < cap
-      then write (Vec (size' + 1) arr') size' x
-      else write (unsafeResize ((max size' 1) * 2) (Vec (size' + 1) arr')) size' x
+  Array.size arr & \(arr', Ur cap) ->
+    if size' < cap
+    then write (Vec (size' + 1) arr') size' x
+    else write (unsafeResize ((max size' 1) * 2) (Vec (size' + 1) arr')) size' x
 
 -- | Write to an element already written to before.  Note: this will not write
 -- to elements beyond the current size of the array and will error instead.

--- a/test/Test/Data/Mutable/Array.hs
+++ b/test/Test/Data/Mutable/Array.hs
@@ -186,7 +186,7 @@ lenAlloc = property $ do
 
 lenAllocTest :: Int -> ArrayTester
 lenAllocTest size arr =
-  compInts (move size) (move Linear.$ getSnd Linear.$ Array.size arr)
+  compInts (move size) (getSnd Linear.$ Array.size arr)
 
 lenWrite :: Property
 lenWrite = property $ do
@@ -200,7 +200,7 @@ lenWrite = property $ do
 lenWriteTest :: Int -> Int -> Int -> ArrayTester
 lenWriteTest size val ix arr =
   compInts (move size)
-    (move Linear.$ getSnd Linear.$ Array.size (Array.write arr ix val))
+    (getSnd Linear.$ Array.size (Array.write arr ix val))
 
 lenResizeSeed :: Property
 lenResizeSeed = property $ do
@@ -215,7 +215,7 @@ lenResizeSeedTest :: Int -> Int -> ArrayTester
 lenResizeSeedTest newSize val arr =
   compInts
     (move newSize)
-    (move Linear.$ getSnd Linear.$ Array.size (Array.resize newSize val arr))
+    (getSnd Linear.$ Array.size (Array.resize newSize val arr))
 
 resizeRef :: Property
 resizeRef = property $ do

--- a/test/Test/Data/Mutable/HashMap.hs
+++ b/test/Test/Data/Mutable/HashMap.hs
@@ -79,7 +79,7 @@ testKVPairExists (k, v) hmap =
     fromLookup (Ur (Just v')) = Ur (v' == v)
 
 testKeyMember :: Int -> HMTest
-testKeyMember key hmap = move Linear.$ getSnd Linear.$ HashMap.member hmap key
+testKeyMember key hmap = getSnd Linear.$ HashMap.member hmap key
 
 testKeyNotMember :: Int -> HMTest
 testKeyNotMember key hmap = Linear.fmap Linear.not (testKeyMember key hmap)
@@ -206,10 +206,9 @@ sizeInsert = testOnAnyHM $ do
 checkSizeAfterInsert :: (Int, String) -> HMTest
 checkSizeAfterInsert (k, v) hmap = withSize Linear.$ HashMap.size hmap
   where
-    withSize :: (HMap, Int) #-> Ur Bool
+    withSize :: (HMap, Ur Int) #-> Ur Bool
     withSize (hmap, oldSize) =
-      checkSize (move oldSize)
-        Linear.$ move
+      checkSize oldSize
         Linear.$ getSnd
         Linear.$ HashMap.size
         Linear.$ HashMap.insert hmap k v
@@ -228,10 +227,9 @@ deleteSize = testOnAnyHM $ do
 checkSizeAfterDelete :: Int -> HMTest
 checkSizeAfterDelete key hmap = fromSize (HashMap.size hmap)
   where
-    fromSize :: (HMap, Int) #-> Ur Bool
+    fromSize :: (HMap, Ur Int) #-> Ur Bool
     fromSize (hmap, orgSize) =
-      compSizes (move orgSize)
-        Linear.$ move
+      compSizes orgSize
         Linear.$ getSnd
         Linear.$ HashMap.size (HashMap.delete hmap key)
     compSizes :: Ur Int #-> Ur Int #-> Ur Bool

--- a/test/Test/Data/Mutable/Set.hs
+++ b/test/Test/Data/Mutable/Set.hs
@@ -14,6 +14,7 @@ where
 import qualified Data.Set.Mutable.Linear as Set
 import Data.Unrestricted.Linear
 import Hedgehog
+import qualified Data.Functor.Linear as Data
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 import qualified Prelude.Linear as Linear
@@ -62,8 +63,8 @@ testEqual :: (Show a, Eq a) =>
 testEqual (Ur x) (Ur y) = Ur (x === y)
 
 -- XXX: This is a terrible name
-getSnd :: (Consumable a, Movable b) => (a, b) #-> Ur b
-getSnd (a, b) = lseq a (move b)
+getSnd :: Consumable a => (a, b) #-> b
+getSnd (a, b) = lseq a b
 
 -- # Tests
 --------------------------------------------------------------------------------
@@ -92,10 +93,10 @@ memberInsert2 = property $ do
 memberInsert2Test :: Int -> Int -> SetTester
 memberInsert2Test val1 val2 set = fromRead (Set.member set val2)
   where
-    fromRead :: (Set.Set Int, Bool) #-> Ur (TestT IO ())
+    fromRead :: (Set.Set Int, Ur Bool) #-> Ur (TestT IO ())
     fromRead (set, memberVal2) =
       testEqual
-        (move memberVal2)
+        memberVal2
         (getSnd (Set.member (Set.insert set val1) val2))
 
 memberDelete1 :: Property
@@ -122,10 +123,10 @@ memberDelete2 = property $ do
 memberDelete2Test :: Int -> Int -> SetTester
 memberDelete2Test val1 val2 set = fromRead (Set.member set val2)
   where
-    fromRead :: (Set.Set Int, Bool) #-> Ur (TestT IO ())
+    fromRead :: (Set.Set Int, Ur Bool) #-> Ur (TestT IO ())
     fromRead (set, memberVal2) =
       testEqual
-        (move memberVal2)
+        memberVal2
         (getSnd Linear.$ Set.member (Set.delete set val1) val2)
 
 sizeInsert1 :: Property
@@ -138,10 +139,10 @@ sizeInsert1 = property $ do
 sizeInsert1Test :: Int -> SetTester
 sizeInsert1Test val set = fromRead (Set.size set)
   where
-    fromRead :: (Set.Set Int, Int) #-> Ur (TestT IO ())
+    fromRead :: (Set.Set Int, Ur Int) #-> Ur (TestT IO ())
     fromRead (set, sizeOriginal) =
       testEqual
-        (move sizeOriginal)
+        sizeOriginal
         (getSnd Linear.$ (Set.size (Set.insert set val)))
 
 sizeInsert2 :: Property
@@ -154,10 +155,10 @@ sizeInsert2 = property $ do
 sizeInsert2Test :: Int -> SetTester
 sizeInsert2Test val set = fromRead (Set.size set)
   where
-    fromRead :: (Set.Set Int, Int) #-> Ur (TestT IO ())
+    fromRead :: (Set.Set Int, Ur Int) #-> Ur (TestT IO ())
     fromRead (set, sizeOriginal) =
       testEqual
-        (move (sizeOriginal Linear.+ 1))
+        ((Linear.+ 1) Data.<$> sizeOriginal)
         (getSnd Linear.$ (Set.size (Set.insert set val)))
 
 sizeDelete1 :: Property
@@ -170,10 +171,10 @@ sizeDelete1 = property $ do
 sizeDelete1Test :: Int -> SetTester
 sizeDelete1Test val set = fromRead (Set.size set)
   where
-    fromRead :: (Set.Set Int, Int) #-> Ur (TestT IO ())
+    fromRead :: (Set.Set Int, Ur Int) #-> Ur (TestT IO ())
     fromRead (set, sizeOriginal) =
       testEqual
-        (move (sizeOriginal Linear.- 1))
+        ((Linear.- 1) Data.<$> sizeOriginal)
         (getSnd Linear.$ (Set.size (Set.delete set val)))
 
 sizeDelete2 :: Property
@@ -186,8 +187,8 @@ sizeDelete2 = property $ do
 sizeDelete2Test :: Int -> SetTester
 sizeDelete2Test val set = fromRead (Set.size set)
   where
-    fromRead :: (Set.Set Int, Int) #-> Ur (TestT IO ())
+    fromRead :: (Set.Set Int, Ur Int) #-> Ur (TestT IO ())
     fromRead (set, sizeOriginal) =
       testEqual
-        (move sizeOriginal)
+        sizeOriginal
         (getSnd Linear.$ (Set.size (Set.delete set val)))

--- a/test/Test/Data/Mutable/Vector.hs
+++ b/test/Test/Data/Mutable/Vector.hs
@@ -16,7 +16,6 @@ module Test.Data.Mutable.Vector
 where
 
 import qualified Data.Vector.Mutable.Linear as Vector
-import qualified Data.Functor.Linear as Linear
 import Data.Unrestricted.Linear
 import Hedgehog
 import qualified Hedgehog.Gen as Gen
@@ -156,13 +155,10 @@ readSnoc2 = property $ do
 readSnoc2Test :: Int -> VectorTester
 readSnoc2Test val vec = fromLen (Vector.size vec)
   where
-    fromLen :: (Vector.Vector Int, Int) #-> Ur (TestT IO ())
-    fromLen (vec,len) = fromLen' (vec, move len)
-
-    fromLen' ::
+    fromLen ::
       (Vector.Vector Int, Ur Int) #->
       Ur (TestT IO ())
-    fromLen' (vec, Ur len) =
+    fromLen (vec, Ur len) =
       compInts (getSnd (Vector.read (Vector.snoc vec val) len)) (move val)
 
 lenConst :: Property
@@ -173,7 +169,7 @@ lenConst = property $ do
 
 lenConstTest :: Int -> VectorTester
 lenConstTest size vec =
-  compInts (move size) (move Linear.. getSnd Linear.$ Vector.size vec)
+  compInts (move size) (getSnd Linear.$ Vector.size vec)
 
 lenWrite :: Property
 lenWrite = property $ do
@@ -188,7 +184,7 @@ lenWriteTest :: Int -> Int -> Int -> VectorTester
 lenWriteTest size val ix vec =
   compInts
     (move size)
-    (move Linear.. getSnd Linear.$ Vector.size (Vector.write vec ix val))
+    (getSnd Linear.$ Vector.size (Vector.write vec ix val))
 
 lenSnoc :: Property
 lenSnoc = property $ do
@@ -198,13 +194,13 @@ lenSnoc = property $ do
  test $ unur Linear.$ Vector.fromList l tester
 
 lenSnocTest :: Int -> VectorTester
-lenSnocTest val vec = fromLen Linear.$ Linear.fmap move (Vector.size vec)
+lenSnocTest val vec = fromLen Linear.$ Vector.size vec
   where
     fromLen ::
       (Vector.Vector Int, Ur Int) #->
       Ur (TestT IO ())
     fromLen (vec, Ur len) =
-      compInts (move (len+1)) (move (getSnd (Vector.size (Vector.snoc vec val))))
+      compInts (move (len+1)) (getSnd (Vector.size (Vector.snoc vec val)))
 
 -- https://github.com/tweag/linear-base/pull/135
 readAndWriteTest :: Property


### PR DESCRIPTION
Closes https://github.com/tweag/linear-base/issues/175.

This PR wraps the return value of `size` and `member` functions  across the linear mutable collections with `Unrestricted`. The issue linked above has the details.

If #178 is merged before this one, I'd be happy to rename `Unrestricted` with `Ur`, should be simple.