### PR TITLE
 Implement toList and toListLazy for mutable arrays and vectors 

### DIFF
--- a/src/Data/Array/Mutable/Linear.hs
+++ b/src/Data/Array/Mutable/Linear.hs
@@ -59,7 +59,6 @@ where
 
 import Data.Unrestricted.Linear
 import GHC.Stack
-import qualified Data.Functor.Linear as Control
 import Data.Array.Mutable.Unlifted.Linear (Array#)
 import qualified Data.Array.Mutable.Unlifted.Linear as Unlifted
 import Prelude.Linear ((&))
@@ -174,16 +173,9 @@ resize newSize seed (Array arr :: Array a)
       wrap (# old, new #) = old `Unlifted.lseq` Array new
 
 
--- XXX: Replace with toVec
-toList :: Array a #-> (Array a, Ur [a])
-toList arr = size arr & \case
-  (arr', Ur len) -> toListWalk (len - 1) arr' (Ur [])
-  where
-  toListWalk :: Int -> Array a #-> Ur [a] -> (Array a, Ur [a])
-  toListWalk ix arr accum
-    | ix < 0 = (arr, accum)
-    | otherwise = read arr ix & \case
-        (arr', Ur x) -> toListWalk (ix - 1) arr' ((x:) Control.<$> accum)
+-- | Return the array elements as a lazy list.
+toList :: Array a #-> Ur [a]
+toList (Array arr) = Unlifted.toList arr
 
 -- # Instances
 -------------------------------------------------------------------------------

--- a/src/Data/HashMap/Linear.hs
+++ b/src/Data/HashMap/Linear.hs
@@ -45,7 +45,6 @@ import Data.Unrestricted.Linear
 import Prelude.Linear hiding ((+), lookup, read)
 import Prelude ((+))
 import qualified Prelude
-import qualified Unsafe.Linear as Unsafe
 import GHC.Stack
 
 -- # Implementation Notes
@@ -257,21 +256,3 @@ lookup (HashMap (Size s) ct arr) k =
 instance Consumable (HashMap k v) where
   consume :: HashMap k v #-> ()
   consume (HashMap _ _ arr) = consume arr
-
--- # This is provided for debugging only.
-instance (Show k, Show v) => Show (HashMap k v) where
-  show (HashMap _ _ robinArr) = toList robinArr & \case
-    (arr, Ur xs) -> display (lseq arr xs)
-
-display :: (Show k, Show v) => [RobinVal k v] #-> String
-display = Unsafe.toLinear wrapper
-  where
-    wrapper :: (Show k, Show v) => [RobinVal k v] -> String
-    wrapper xs = "[" ++ display' xs ++ "]"
-
-    display' :: (Show k, Show v) => [RobinVal k v] -> String
-    display' [] = ""
-    display' ((p,kv):xs) = p == (-1) & \case
-      True -> ("(" ++ show p ++ ", null)") ++ ", " ++ display' xs
-      False -> show (p,kv) ++ ", " ++ display' xs
-

--- a/test/Test/Data/Mutable/Array.hs
+++ b/test/Test/Data/Mutable/Array.hs
@@ -65,6 +65,7 @@ group =
   , testProperty "∀ a,s,x. len (resize s x a) = s" lenResizeSeed
   -- Tests against a reference implementation
   , testProperty "∀ a,s,x. resize s x a = take s (toList a ++ repeat x)" resizeRef
+  , testProperty "toList . fromList = id" refToListFromList
   -- Regression tests
   , testProperty "do not reorder reads and writes" readAndWriteTest
   , testProperty "do not evaluate values unnecesesarily" strictnessTest
@@ -227,8 +228,13 @@ resizeRef = property $ do
         unur Linear.. Array.fromList l Linear.$ \arr ->
           Array.resize n x arr
             Linear.& Array.toList
-            Linear.& getSnd
   actual === expected
+
+refToListFromList :: Property
+refToListFromList = property $ do
+  xs <- forAll list
+  let Ur actual = Array.fromList xs Array.toList
+  xs === actual
 
 -- https://github.com/tweag/linear-base/pull/135
 readAndWriteTest :: Property


### PR DESCRIPTION
Depends on #179. As part of #165,

It turns out, there is two different flavours of `toList` functions.

* 'toList' returns a new list alongside with the array. In order to do that, it has to read the entire array before returning; this can not done lazily since the underlying mutable array might change.
* 'toListLazy' converts an array to a lazy list, consuming the array in the process. It can do it lazily, since it does not give the array back, therefore guaranteeing in won't be changed.

Vector's 'toList' and 'toListLazy' functions also have the same constraint above.

In order to implement the vector changes, it also adds `unsafeRead` and `unsafeWrite` functions to the vector interface.