### PR TITLE
Add ability to shrink/slice vectors and arrays

### DIFF
--- a/src/Data/Array/Mutable/Linear.hs
+++ b/src/Data/Array/Mutable/Linear.hs
@@ -179,7 +179,7 @@ toList :: Array a #-> Ur [a]
 toList (Array arr) = Unlifted.toList arr
 
 -- | Copy a slice of the array, starting from given offset and copying given
--- number of elements.
+-- number of elements. Returns the pair (oldArray, slice).
 --
 -- Start offset + target size should be within the input array, and both should
 -- be non-negative.

--- a/src/Data/Vector/Mutable/Linear.hs
+++ b/src/Data/Vector/Mutable/Linear.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LinearTypes #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StrictData #-}
@@ -11,7 +12,8 @@
 -- | Mutable vectors with a linear API.
 --
 -- Vectors are arrays that grow automatically, that you can append to with
--- 'snoc'.
+-- 'push'. They never shrink automatically to reduce unnecessary copying,
+-- use 'shrinkToFit' to get rid of the wasted space.
 --
 -- To use mutable vectors, create a linear computation of type
 -- @Vector a #-> Ur b@ and feed it to 'constant' or 'fromList'.
@@ -50,11 +52,15 @@ module Data.Vector.Mutable.Linear
     -- * Mutators
     write,
     unsafeWrite,
-    snoc,
+    push,
+    pop,
+    slice,
+    shrinkToFit,
     -- * Accessors
     read,
     unsafeRead,
     size,
+    capacity,
     toList,
   )
 where
@@ -63,6 +69,15 @@ import GHC.Stack
 import Prelude.Linear hiding (read)
 import Data.Array.Mutable.Linear (Array)
 import qualified Data.Array.Mutable.Linear as Array
+
+-- # Constants
+-------------------------------------------------------------------------------
+
+-- | When growing the vector, capacity will be multiplied by this number.
+--
+-- This is usually chosen between 1.5 and 2; 2 being the most common.
+constGrowthFactor :: Int
+constGrowthFactor = 2
 
 -- # Core data types
 -------------------------------------------------------------------------------
@@ -81,6 +96,8 @@ data Vector a where
 
 -- | Create a 'Vector' from an 'Array'. Result will have the size and capacity
 -- equal to the size of the given array.
+--
+-- This is a constant time operation.
 fromArray :: HasCallStack => Array a #-> Vector a
 fromArray arr =
   Array.size arr
@@ -104,17 +121,35 @@ constant size' x f
 fromList :: HasCallStack => [a] -> (Vector a #-> Ur b) #-> Ur b
 fromList xs f = Array.fromList xs (f . fromArray)
 
--- | Number of elements inside the vector
+-- | Number of elements inside the vector.
 size :: Vector a #-> (Vector a, Ur Int)
 size (Vec size' arr) = (Vec size' arr, Ur size')
 
--- | Insert at the end of the vector
-snoc :: HasCallStack => Vector a #-> a -> Vector a
-snoc (Vec size' arr) x =
-  Array.size arr & \(arr', Ur cap) ->
-    if size' < cap
-    then write (Vec (size' + 1) arr') size' x
-    else write (unsafeResize ((max size' 1) * 2) (Vec (size' + 1) arr')) size' x
+-- | Capacity of a vector. In other words, the number of elements
+-- the vector can contain before it is copied to a bigger array.
+capacity :: Vector a #-> (Vector a, Ur Int)
+capacity (Vec s arr) =
+  Array.size arr & \(arr', cap) -> (Vec s arr', cap)
+
+-- | Insert at the end of the vector. This will grow the vector if there
+-- is no empty space.
+push :: Vector a #-> a -> Vector a
+push vec x =
+  growToFit 1 vec & \(Vec s arr) ->
+    write (Vec (s + 1) arr) s x
+
+-- | Pop from the end of the vector. This will never shrink the vector, use
+-- 'shrinkToFit' to remove the wasted space.
+pop :: Vector a #-> (Vector a, Ur (Maybe a))
+pop vec =
+  size vec & \case
+    (vec', Ur 0) ->
+      (vec', Ur Nothing)
+    (vec', Ur s) ->
+      read vec' (s-1) & \(Vec _ arr, Ur a) ->
+        ( Vec (s-1) arr
+        , Ur (Just a)
+        )
 
 -- | Write to an element . Note: this will not write to elements beyond the
 -- current size of the vector and will error instead.
@@ -153,6 +188,32 @@ toList (Vec s arr) =
   Array.toList arr & \(Ur xs) ->
     Ur (take s xs)
 
+-- | Resize the vector to not have any wasted memory (size == capacity). This
+-- returns a semantically identical vector.
+shrinkToFit :: Vector a #-> Vector a
+shrinkToFit vec =
+  capacity vec & \(vec', Ur cap) ->
+    size vec' & \(vec'', Ur s') ->
+      if cap > s'
+      then unsafeResize s' vec''
+      else vec''
+
+-- | Return a slice of the vector with given size, starting from an offset.
+--
+-- Start offset + target size should be within the input vector, and both should
+-- be non-negative.
+--
+-- This is a constant time operation if the start offset is 0. Use 'shrinkToFit'
+-- to remove the possible wasted space if necessary.
+slice :: Int -> Int -> Vector a #-> Vector a
+slice from newSize (Vec oldSize arr) =
+  if oldSize < from + newSize
+  then arr `lseq` error "Slice index out of bounds"
+  else if from == 0
+       then Vec newSize arr
+       else Array.slice from newSize arr & \(oldArr, newArr) ->
+              oldArr `lseq` fromArray newArr
+
 -- # Instances
 -------------------------------------------------------------------------------
 
@@ -161,6 +222,29 @@ instance Consumable (Vector a) where
 
 -- # Internal library
 -------------------------------------------------------------------------------
+
+-- | Grows the vector to the closest power of growthFactor to
+-- fit at least n more elements.
+growToFit :: HasCallStack => Int -> Vector a #-> Vector a
+growToFit n vec =
+  capacity vec & \(vec', Ur cap) ->
+    size vec' & \(vec'', Ur s') ->
+      if s' + n <= cap
+      then vec''
+      else
+        let -- Calculate the closest power of growth factor
+            -- larger than required size.
+            newSize =
+              constGrowthFactor
+                ^ (ceiling :: Double -> Int)
+                    (logBase
+                      (fromIntegral constGrowthFactor)
+                      (fromIntegral (s' + n))) -- this is always
+                                               -- > 0 because of
+                                               -- the if condition
+        in  unsafeResize
+              newSize
+              vec''
 
 -- | Resize the vector to a non-negative size. In-range elements are preserved,
 -- the possible new elements are bottoms.
@@ -177,3 +261,4 @@ unsafeResize newSize (Vec size' ma) =
 -- | Argument order: indexInRange size ix
 indexInRange :: Int -> Int -> Bool
 indexInRange size' ix = 0 <= ix && ix < size'
+

--- a/src/Unsafe/MutableArray.hs
+++ b/src/Unsafe/MutableArray.hs
@@ -1,0 +1,103 @@
+{-# OPTIONS_GHC -Wno-unbanged-strict-patterns #-}
+
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE BangPatterns #-}
+
+-- |
+-- This module defines convenient and unsafe wrappers around the MutableArray#
+-- API in GHC.Exts.
+--
+-- Please import this module qualified as Unsafe to signal that all
+-- functions from this module are unsafe and crash on inputs that
+-- fail their respective predcondition.
+module Unsafe.MutableArray
+  ( -- * Unsafe Wrappers around @MutableArray#@
+    MutArr#,
+    -- * Mutators and Constructors
+    newMutArr,
+    writeMutArr,
+    resizeMutArr,
+    copyIntoMutArr,
+    -- * Accessors
+    readMutArr,
+    sizeMutArr
+  )
+where
+
+import GHC.Exts
+import GHC.Stack
+
+-- # Unsafe wrappers
+----------------------------
+
+-- | A mutable array holding @a@s
+type MutArr# a = MutableArray# RealWorld a
+
+-- | Get the size of a mutable array
+sizeMutArr :: MutArr# a -> Int
+sizeMutArr arr  = I# (sizeofMutableArray# arr)
+
+-- | Given a size, try to allocate a mutable array
+-- of this size. The size should be non-negative.
+newMutArr :: HasCallStack => Int -> a -> MutArr# a
+newMutArr (I# size) x =
+  case newArray of
+    (# _, array #) -> array
+  where
+    newArray = runRW# $ \stateRW -> newArray# size x stateRW
+
+-- | Write to a given mutable array arr; given an
+-- index in [0, size(arr)-1], and a value.
+writeMutArr :: HasCallStack => MutArr# a -> Int -> a -> ()
+writeMutArr mutArr (I# ix) val =
+  case doWrite of _ -> ()
+  where
+    doWrite = runRW# $ \stateRW -> writeArray# mutArr ix val stateRW
+
+-- | Read from a given mutable array arr, given an index
+-- in [0, size(arr)-1]
+--
+-- This returns an unboxed tuple to give the callee the
+-- ability to evaluate the function call without evaluating
+-- the final result.
+readMutArr :: HasCallStack => MutArr# a -> Int -> (# a #)
+readMutArr mutArr (I# ix) =
+  case doRead of (# _, a #) -> (# a #)
+  where
+    doRead = runRW# $ \stateRW -> readArray# mutArr ix stateRW
+
+-- | Resize a mutable array. That is given an array, a size, and it returns
+-- a new array of the given size using the seed value to fill in the new
+-- cells when necessary and copying over all the unchanged cells.
+--
+-- The size should be non-negative.
+--
+-- @
+-- let b = resize a x n,
+--   then length b = n,
+--   and b[i] = a[i] for i < length a,
+--   and b[i] = x for length a <= i < n.
+-- @
+resizeMutArr :: HasCallStack => MutArr# a -> a -> Int -> MutArr# a
+resizeMutArr mutArr x newSize = case newMutArr newSize x of
+  newArr -> case copyIntoMutArr 0 maxBound mutArr newArr of
+    () -> newArr
+
+-- | Copy the first mutable array starting from 'from' to the second
+-- mutable array, copying at most 'len' elements or until the end
+-- of the either array.
+copyIntoMutArr :: Int -> Int -> MutArr# a -> MutArr# a -> ()
+copyIntoMutArr from len src dest = case doCopy of _ -> ()
+  where
+    doCopy = runRW# $ \stateRW ->
+      copyMutableArray# src from# dest 0# actual_len# stateRW
+    I# from# = from
+    I# actual_len# =
+      min
+        len
+        (min
+          (I# (sizeofMutableArray# src) - from)
+          (I# (sizeofMutableArray# dest)))
+


### PR DESCRIPTION
Depends on #180,  As part of #165.

Previously, vectors could only grow. This PR adds functions around resizing and slicing vectors and arrays.

* Adds a `pop` function, and renames `snoc` to `push`, just because it sounds more natural to me than `unsnoc`. Happy to revert this change if you prefer the former.
* Adds `slice` functions to arrays and vectors that can return a sub-range of elements.
* Adds a `shrinkToFit` function to vectors to reduce the capacity of a vector.

Alongside with tests for each, of course.