### PR TITLE
Implement Functor and Semigroup instances for mutable vectors and arrays

### DIFF
--- a/src/Data/Array/Mutable/Linear.hs
+++ b/src/Data/Array/Mutable/Linear.hs
@@ -63,7 +63,6 @@ import GHC.Stack
 import Data.Array.Mutable.Unlifted.Linear (Array#)
 import qualified Data.Array.Mutable.Unlifted.Linear as Unlifted
 import qualified Data.Functor.Linear as Data
-import qualified Unsafe.Linear as Unsafe
 import Prelude.Linear ((&))
 import Prelude hiding (read)
 
@@ -224,21 +223,7 @@ instance Consumable (Array a) where
   consume (Array arr) = arr `Unlifted.lseq` ()
 
 instance Data.Functor Array where
-  fmap (f :: a #-> b) arr =
-    size arr & \(arr', Ur s) -> go 0 s arr'
-   where
-    -- When we're mapping  an array, we first insert `b`'s
-    -- inside an `Array b` by unsafeCoerce'ing, and then we
-    -- unsafeCoerce the result to an `Array b`.
-    go :: Int -> Int -> Array a #-> Array b
-    go i s arr
-      | i == s =
-          Unsafe.coerce arr
-      | otherwise =
-          unsafeRead arr i
-            & \(arr', Ur a) ->
-                unsafeWrite arr' i (Unsafe.coerce (f a))
-            & \arr'' -> go (i+1) s arr''
+  fmap f (Array arr) = Array (Unlifted.map f arr)
 
 -- # Internal library
 -------------------------------------------------------------------------------

--- a/src/Data/Array/Mutable/Linear.hs
+++ b/src/Data/Array/Mutable/Linear.hs
@@ -62,6 +62,8 @@ import Data.Unrestricted.Linear
 import GHC.Stack
 import Data.Array.Mutable.Unlifted.Linear (Array#)
 import qualified Data.Array.Mutable.Unlifted.Linear as Unlifted
+import qualified Data.Functor.Linear as Data
+import qualified Unsafe.Linear as Unsafe
 import Prelude.Linear ((&))
 import Prelude hiding (read)
 
@@ -220,6 +222,23 @@ slice from targetSize arr =
 instance Consumable (Array a) where
   consume :: Array a #-> ()
   consume (Array arr) = arr `Unlifted.lseq` ()
+
+instance Data.Functor Array where
+  fmap (f :: a #-> b) arr =
+    size arr & \(arr', Ur s) -> go 0 s arr'
+   where
+    -- When we're mapping  an array, we first insert `b`'s
+    -- inside an `Array b` by unsafeCoerce'ing, and then we
+    -- unsafeCoerce the result to an `Array b`.
+    go :: Int -> Int -> Array a #-> Array b
+    go i s arr
+      | i == s =
+          Unsafe.coerce arr
+      | otherwise =
+          unsafeRead arr i
+            & \(arr', Ur a) ->
+                unsafeWrite arr' i (Unsafe.coerce (f a))
+            & \arr'' -> go (i+1) s arr''
 
 -- # Internal library
 -------------------------------------------------------------------------------

--- a/src/Data/Vector/Mutable/Linear.hs
+++ b/src/Data/Vector/Mutable/Linear.hs
@@ -295,8 +295,8 @@ instance Semigroup (Vector a) where
    where
      go :: [a] -> Vector a #-> Vector a
      go [] vec = vec
-     go (x:xs) (Vec cap arr) =
-       unsafeWrite (Vec (cap+1) arr) cap x
+     go (x:xs) (Vec sz arr) =
+       unsafeWrite (Vec (sz+1) arr) sz x
          & go xs
 
 instance Data.Functor Vector where


### PR DESCRIPTION
Depends on #181, As part of #165.

This PR adds a (data) `Functor` instance for mutable arrays and vectors. The `fmap` implementation for both instances do in-place updates (yay linear types). Internal implementation does `unsafeCoerce`, but hopefully it is simple enough, and there's test coverage.

It also adds a `Semigroup` instance for `Vector`'s, where `mappend` tries not to allocate a new vector when there is enough space available.