### PR TITLE
Implement Data.List.Linear

### DIFF
--- a/examples/Simple/TopSort.hs
+++ b/examples/Simple/TopSort.hs
@@ -62,24 +62,23 @@ postOrderHM nodes dag = findSources nodes (computeInDeg nodes dag) & \case
  where
    -- O(V + N)
   computeInDeg :: [Node] -> InDegGraph #-> InDegGraph
-  computeInDeg nodes dag = Linear.foldl incChildren dag nodes
+  computeInDeg nodes dag = Linear.foldl incChildren dag (map Ur nodes)
 
   -- Increment in-degree of all neighbors
-  incChildren :: InDegGraph #-> Node -> InDegGraph
-  incChildren dag node = HMap.lookup dag node & \case
+  incChildren :: InDegGraph #-> Ur Node #-> InDegGraph
+  incChildren dag (Ur node) = HMap.lookup dag node & \case
      (dag, Ur Nothing) -> dag
      (dag, Ur (Just (xs,i))) -> incNodes (move xs) dag
     where
       incNodes :: Ur [Node] #-> InDegGraph #-> InDegGraph
-      incNodes (Ur ns) dag = Linear.foldl incNode dag ns
+      incNodes (Ur ns) dag = Linear.foldl incNode dag (map Ur ns)
 
-      incNode :: InDegGraph #-> Node -> InDegGraph
-      incNode dag node = HMap.lookup dag node & \case
+      incNode :: InDegGraph #-> Ur Node #-> InDegGraph
+      incNode dag (Ur node) = HMap.lookup dag node & \case
         (dag', Ur Nothing) -> dag'
         (dag', Ur (Just (n,d))) ->
           HMap.insert dag' node (n,d+1)
         --HMap.alter dag (\(Just (n,d)) -> Just (n,d+1)) node
-
 
 -- pluckSources sources postOrdSoFar dag
 pluckSources :: [Node] -> [Node] -> InDegGraph #-> Ur [Node]

--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -29,6 +29,7 @@ library
     Data.Eq.Linear
     Data.Functor.Linear
     Data.HashMap.Linear
+    Data.List.Linear
     Data.Maybe.Linear
     Data.Monoid.Linear
     Data.Num.Linear

--- a/src/Control/Monad/Linear/Internal.hs
+++ b/src/Control/Monad/Linear/Internal.hs
@@ -112,10 +112,8 @@ ap f x = f >>= (\f' -> fmap f' x)
 -- | Fold from left to right with a linear monad.
 -- This is a linear version of 'NonLinear.foldM'.
 foldM :: forall m a b. Monad m => (b #-> a #-> m b) -> b #-> [a] #-> m b
-foldM f z0 xs = foldr f' return xs z0
-  where
-    f' :: a #-> (b #-> m b) #-> b #-> m b
-    f' x k z = f z x >>= k
+foldM _ i [] = return i
+foldM f i (x:xs) = f i x >>= \i' -> foldM f i' xs
 
 -----------------------------------------------
 -- Deriving Data.XXX in terms of Control.XXX --

--- a/src/Data/List/Linear.hs
+++ b/src/Data/List/Linear.hs
@@ -1,0 +1,219 @@
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+
+{-|
+Linear versions of 'Data.List' functions.
+
+This module only contains minimal amount of documentation; consult the
+original "Data.List" module for more detailed information.
+-}
+module Data.List.Linear
+  ( -- * Basic functions
+    map
+  , filter
+  , uncons
+  , reverse
+  , length
+  , splitAt
+  , span
+  , intersperse
+  , intercalate
+  , transpose
+  -- * Folds
+  , foldr
+  , foldl
+  , foldl'
+  , foldMap
+  , foldMap'
+  -- * Special folds
+  , concat
+  , concatMap
+  , and
+  , or
+  , any
+  , all
+  -- * Building lists
+  , scanl
+  , replicate
+  , unfoldr
+  -- * Zipping lists
+  , zip
+  , zip'
+  , zip3
+  , zipWith
+  , zipWith'
+  , zipWith3
+  ) where
+
+import qualified Unsafe.Linear as Unsafe
+import qualified Prelude as Prelude
+import Prelude (Maybe(..), Either(..), Int, otherwise)
+import Data.Num.Linear
+import Prelude.Linear.Internal
+import Data.Bool.Linear
+import Data.Unrestricted.Linear
+import Data.Functor.Linear
+import Data.Monoid.Linear
+import Data.List.NonEmpty (NonEmpty ((:|)))
+import qualified Data.List as NonLinear
+
+-- # Basic functions
+--------------------------------------------------
+
+map :: (a #-> b) -> [a] #-> [b]
+map = fmap
+
+-- | @filter p xs@ returns a list with elements satisfying the predicate.
+--
+-- See 'Data.Maybe.Linear.mapMaybe' if you do not want the 'Dupable' constraint.
+filter :: Dupable a => (a #-> Bool) -> [a] #-> [a]
+filter _ [] = []
+filter p (x:xs) =
+  dup x & \case
+    (x', x'') ->
+      if p x'
+      then x'' : filter p xs
+      else x'' `lseq` filter p xs
+
+uncons :: [a] #-> Maybe (a, [a])
+uncons [] = Nothing
+uncons (x:xs) = Just (x, xs)
+
+reverse :: [a] #-> [a]
+reverse = Unsafe.toLinear NonLinear.reverse
+
+-- | Return the length of the given list alongside with the list itself.
+length :: [a] #-> ([a], Ur Int)
+length = Unsafe.toLinear $ \xs ->
+  (xs, Ur (NonLinear.length xs))
+-- We can only do this because of the fact that 'NonLinear.length'
+-- does not inspect the elements.
+
+--  'splitAt' @n xs@ returns a tuple where first element is @xs@ prefix of
+-- length @n@ and second element is the remainder of the list.
+splitAt :: Int -> [a] #-> ([a], [a])
+splitAt i = Unsafe.toLinear (Prelude.splitAt i)
+
+-- | 'span', applied to a predicate @p@ and a list @xs@, returns a tuple where
+-- first element is longest prefix (possibly empty) of @xs@ of elements that
+-- satisfy @p@ and second element is the remainder of the list.
+span :: Dupable a => (a #-> Bool) -> [a] #-> ([a], [a])
+span _ [] = ([], [])
+span f (x:xs) = dup x & \case
+  (x', x'') ->
+    if f x'
+    then span f xs & \case (ts, fs) -> (x'':ts, fs)
+    else ([x''], xs)
+
+-- | The intersperse function takes an element and a list and
+-- `intersperses' that element between the elements of the list.
+intersperse :: a -> [a] #-> [a]
+intersperse sep = Unsafe.toLinear (NonLinear.intersperse sep)
+
+-- | @intercalate xs xss@ is equivalent to @(concat (intersperse xs
+-- xss))@. It inserts the list xs in between the lists in xss and
+-- concatenates the result.
+intercalate :: [a] -> [[a]] #-> [a]
+intercalate sep = Unsafe.toLinear (NonLinear.intercalate sep)
+
+-- | The transpose function transposes the rows and columns of its argument.
+transpose :: [[a]] #-> [[a]]
+transpose = Unsafe.toLinear NonLinear.transpose
+
+-- # Folds
+--------------------------------------------------
+
+foldr :: (a #-> b #-> b) -> b #-> [a] #-> b
+foldr f = Unsafe.toLinear2 (NonLinear.foldr (\a b -> f a b))
+
+foldl :: (b #-> a #-> b) -> b #-> [a] #-> b
+foldl f = Unsafe.toLinear2 (NonLinear.foldl (\b a -> f b a))
+
+foldl' :: (b #-> a #-> b) -> b #-> [a] #-> b
+foldl' f = Unsafe.toLinear2 (NonLinear.foldl' (\b a -> f b a))
+
+-- | Map each element of the structure to a monoid,
+-- and combine the results.
+foldMap :: Monoid m => (a #-> m) -> [a] #-> m
+foldMap f = foldr ((<>) . f) mempty
+
+-- | A variant of 'foldMap' that is strict in the accumulator.
+foldMap' :: Monoid m => (a #-> m) ->  [a] #-> m
+foldMap' f = foldl' (\acc a -> acc <> f a) mempty
+
+concat :: [[a]] #-> [a]
+concat = Unsafe.toLinear NonLinear.concat
+
+concatMap :: (a #-> [b]) -> [a] #-> [b]
+concatMap f = Unsafe.toLinear (NonLinear.concatMap (forget f))
+
+-- | __NOTE:__ This does not short-circuit, and always consumes the
+-- entire container.
+any :: (a #-> Bool) -> [a] #-> Bool
+any p = foldl' (\b a -> b || p a) False
+
+-- | __NOTE:__ This does not short-circuit, and always consumes the
+-- entire container.
+all :: (a #-> Bool) -> [a] #-> Bool
+all p = foldl' (\b a -> b && p a) True
+
+-- | __NOTE:__ This does not short-circuit, and always consumes the
+-- entire container.
+and :: [Bool] #-> Bool
+and = foldl' (&&) True
+
+-- | __NOTE:__ This does not short-circuit, and always consumes the
+-- entire container.
+or :: [Bool] #-> Bool
+or = foldl' (||) False
+
+-- # Building Lists
+--------------------------------------------------
+
+scanl :: Dupable b => (b #-> a #-> b) -> b #-> [a] #-> [b]
+scanl _ b [] = [b]
+scanl f b (x:xs) = dup2 b & \(b', b'') -> b' : scanl f (f b'' x) xs
+
+replicate :: Dupable a => Int -> a #-> [a]
+replicate i a
+  | i Prelude.< 1 = a `lseq` []
+  | i Prelude.== 1 = [a]
+  | otherwise  = dup2 a & \(a', a'') -> a' : replicate (i-1) a''
+
+unfoldr :: (b #-> Maybe (a, b)) -> b #-> [a]
+unfoldr f = Unsafe.toLinear (NonLinear.unfoldr (forget f))
+
+-- # Zipping Lists
+--------------------------------------------------
+
+zip :: (Consumable a, Consumable b) => [a] #-> [b] #-> [(a, b)]
+zip = zipWith (,)
+
+-- | Same as 'zip', but returns the leftovers instead of consuming them.
+zip' :: [a] #-> [b] #-> ([(a, b)], Maybe (Either (NonEmpty a) (NonEmpty b)))
+zip' = zipWith' (,)
+
+zip3 :: (Consumable a, Consumable b, Consumable c) => [a] #-> [b] #-> [c] #-> [(a, b, c)]
+zip3 = zipWith3 (,,)
+
+zipWith :: (Consumable a, Consumable b) => (a#->b#->c) -> [a] #-> [b] #-> [c]
+zipWith f xs ys =
+  zipWith' f xs ys & \(ret, leftovers) ->
+    leftovers `lseq` ret
+
+-- | Same as 'zipWith', but returns the leftovers instead of consuming them.
+zipWith' :: (a#->b#->c) -> [a] #-> [b] #-> ([c], Maybe (Either (NonEmpty a) (NonEmpty b)))
+zipWith' _ [] [] = ([], Nothing)
+zipWith' _ (a:as) [] = ([], Just (Left (a :| as)))
+zipWith' _ [] (b:bs) = ([], Just (Right (b :| bs)))
+zipWith' f (a:as) (b:bs) = zipWith' f as bs & \case
+  (cs, rest) -> (f a b : cs, rest)
+
+zipWith3 :: forall a b c d. (Consumable a, Consumable b, Consumable c) => (a#->b#->c#->d) -> [a] #-> [b] #-> [c] #-> [d]
+zipWith3 _ [] ys zs = (ys, zs) `lseq` []
+zipWith3 _ xs [] zs = (xs, zs) `lseq` []
+zipWith3 _ xs ys [] = (xs, ys) `lseq` []
+zipWith3 f (x:xs) (y:ys) (z:zs) = f x y z : zipWith3 f xs ys zs

--- a/src/Data/List/Linear.hs
+++ b/src/Data/List/Linear.hs
@@ -15,19 +15,20 @@ module Data.List.Linear
     (++)
   , map
   , filter
-  , head
+  , NonLinear.head
   , uncons
-  , tail
-  , last
-  , init
+  , NonLinear.tail
+  , NonLinear.last
+  , NonLinear.init
   , reverse
   , length
+  , NonLinear.null
   , splitAt
   , span
   , partition
   , takeWhile
   , dropWhile
-  , find
+  , NonLinear.find
   , intersperse
   , intercalate
   , transpose
@@ -102,29 +103,9 @@ filter p (x:xs) =
       then x'' : filter p xs
       else x'' `lseq` filter p xs
 
--- | __NOTE__: This does not short-circuit and always traverses the
--- entire array to consume the rest of the elements.
-head :: (HasCallStack, Consumable a) => [a] #-> a
-head [] = Prelude.error "head: empty list"
-head (x:xs) = xs `lseq` x
-
 uncons :: [a] #-> Maybe (a, [a])
 uncons [] = Nothing
 uncons (x:xs) = Just (x, xs)
-
-tail :: (HasCallStack, Consumable a) => [a] #-> [a]
-tail [] = Prelude.error "tail: empty list"
-tail (x:xs) = x `lseq` xs
-
-last :: (HasCallStack, Consumable a) => [a] #-> a
-last [] = Prelude.error "last: empty list"
-last [x] = x
-last (x:xs) = x `lseq` last xs
-
-init :: (HasCallStack, Consumable a) => [a] #-> [a]
-init [] = Prelude.error "init: empty list"
-init [x] = x `lseq` []
-init (x:xs) = x : init xs
 
 reverse :: [a] #-> [a]
 reverse = Unsafe.toLinear NonLinear.reverse
@@ -135,16 +116,6 @@ length = Unsafe.toLinear $ \xs ->
   (xs, Ur (NonLinear.length xs))
 -- We can only do this because of the fact that 'NonLinear.length'
 -- does not inspect the elements.
-
--- | __NOTE__: This does not short-circuit and always traverses the
--- entire array to consume the rest of the elements.
-find :: Dupable a => (a #-> Bool) -> [a] #-> Maybe a
-find _ [] = Nothing
-find p (x:xs) =
-  dup x & \(x', x'') ->
-    if p x'
-    then xs `lseq` Just x''
-    else x'' `lseq` find p xs
 
 --  'splitAt' @n xs@ returns a tuple where first element is @xs@ prefix of
 -- length @n@ and second element is the remainder of the list.

--- a/src/Data/Unrestricted/Linear.hs
+++ b/src/Data/Unrestricted/Linear.hs
@@ -91,6 +91,7 @@ import qualified Data.Vector.Linear as V
 import GHC.TypeLits
 import GHC.Types hiding (Any)
 import Data.Monoid.Linear
+import Data.List.NonEmpty
 import qualified Prelude
 import qualified Unsafe.Linear as Unsafe
 
@@ -273,6 +274,18 @@ instance Movable a => Movable (Prelude.Maybe a) where
   move (Prelude.Nothing) = Ur Prelude.Nothing
   move (Prelude.Just x) = Data.fmap Prelude.Just (move x)
 
+instance (Consumable a, Consumable b) => Consumable (Prelude.Either a b) where
+  consume (Prelude.Left a) = consume a
+  consume (Prelude.Right b) = consume b
+
+instance (Dupable a, Dupable b) => Dupable (Prelude.Either a b) where
+  dupV (Prelude.Left a) = Data.fmap Prelude.Left (dupV a)
+  dupV (Prelude.Right b) = Data.fmap Prelude.Right (dupV b)
+
+instance (Movable a, Movable b) => Movable (Prelude.Either a b) where
+  move (Prelude.Left a) = Data.fmap Prelude.Left (move a)
+  move (Prelude.Right b) = Data.fmap Prelude.Right (move b)
+
 instance Consumable a => Consumable [a] where
   consume [] = ()
   consume (a:l) = consume a `lseq` consume l
@@ -284,6 +297,15 @@ instance Dupable a => Dupable [a] where
 instance Movable a => Movable [a] where
   move [] = Ur []
   move (a:l) = (:) Data.<$> move a Data.<*> move l
+
+instance Consumable a => Consumable (NonEmpty a) where
+  consume (x :| xs) = consume x `lseq` consume xs
+
+instance Dupable a => Dupable (NonEmpty a) where
+  dupV (x :| xs) = (:|) Data.<$> dupV x Data.<*> dupV xs
+
+instance Movable a => Movable (NonEmpty a) where
+  move (x :| xs) = (:|) Data.<$> move x Data.<*> move xs
 
 instance Consumable (Ur a) where
   consume (Ur _) = ()

--- a/src/Prelude/Linear.hs
+++ b/src/Prelude/Linear.hs
@@ -66,6 +66,7 @@ import Data.Num.Linear
 import Data.Bool.Linear
 import Data.Either.Linear
 import Data.Maybe.Linear
+import Data.List.Linear
 import Prelude hiding
   ( ($)
   , id
@@ -92,14 +93,6 @@ import Prelude hiding
   )
 import GHC.Exts (FUN)
 import Prelude.Linear.Internal
-
--- XXX: temporary: with multiplicity polymorphism functions expecting a
--- non-linear arrow would allow a linear arrow passed, so this would be
--- redundant
--- | Convenience operator when a higher-order function expects a non-linear
--- arrow but we have a linear arrow.
-forget :: (a #-> b) #-> a -> b
-forget f x = f x
 
 -- | Replacement for the flip function with generalized multiplicities.
 flip :: FUN r (FUN p a (FUN q b c)) (FUN q b (FUN p a c))

--- a/src/Prelude/Linear/Internal.hs
+++ b/src/Prelude/Linear/Internal.hs
@@ -59,4 +59,4 @@ f . g = \x -> f (g x)
 -- | Convenience operator when a higher-order function expects a non-linear
 -- arrow but we have a linear arrow.
 forget :: (a #-> b) #-> a -> b
-forget f x = f x
+forget f a = f a

--- a/src/Prelude/Linear/Internal.hs
+++ b/src/Prelude/Linear/Internal.hs
@@ -53,13 +53,10 @@ uncurry f (x,y) = f x y
 (.) :: (b #-> c) #-> (a #-> b) #-> a #-> c
 f . g = \x -> f (g x)
 
--- | Linearly typed replacement for the standard 'Prelude.foldr' function,
--- to allow linear consumption of a list.
-foldr :: (a #-> b #-> b) -> b #-> [a] #-> b
-foldr f z = \case
-  [] -> z
-  x:xs -> f x (foldr f z xs)
-
-foldl :: (b #-> a -> b) -> b #-> [a] -> b
-foldl _ b [] = b
-foldl f b (x:xs) = foldl f (f b x) xs
+-- XXX: temporary: with multiplicity polymorphism functions expecting a
+-- non-linear arrow would allow a linear arrow passed, so this would be
+-- redundant
+-- | Convenience operator when a higher-order function expects a non-linear
+-- arrow but we have a linear arrow.
+forget :: (a #-> b) #-> a -> b
+forget f x = f x


### PR DESCRIPTION
Closes #170, discussion at #126 .

This PR adds linear versions of the majority of Data.List and Data.Foldable functions, specializing them to work on lists. Most of them are implemented by unsafe coerces, and the ones requiring `Consumable` or `Dupable` typeclasses reimplemented. I hope I got the casts right (meaning, they aren't omitting or duplicating any elements without using the required typeclasses).

I also omitted a few methods from `Data.List`, if they

* work on infinite lists, eg: `iterate`, `repeat`.
* discard most of the elements, eg: `head`, `find`, `null` (or they require significant changes on the type signatures)
* are partial, eg: `scan1`, `foldl1`

The latter two points are arbitrary decisions on my part, so let me know if you disagree and I can add them back. In my opinion, for those cases the user might find manually implementing them tailored to they needs easier. And we can always add them in future if someone requests them, or when we decide to.

It introduces a minor interface change:

```haskell
-- before
foldl :: (b #-> a -> b) -> b #-> [a] -> b
-- after
foldl :: (b #-> a #-> b) -> b #-> [a] #-> b
```

Which, I think is not a major issue since the former can be derived from latter by wrapping list elements with `Ur`. I had to do this for one of our examples.

Similar to #174, it only copies over minimal amount of documentation from `Data.List`, to reduce the amount of duplication. Let me know if you prefer otherwise. 

It also:

* Moves `forget` to `Prelude.Linear.Internal` to break an import cycle.
* It also adds `Consumable` instances for `NonEmpty` and `Either`, since they were necessary to reduce some duplication on zipping functions.
* Rewrite `Control.Monad.Linear.foldM` with explicit recursion instead of `foldr` to break an import cycle (because now `foldr` is imported from `Data.List.Linear` instead of `Prelude.Linear.Internal`).
