### PR TITLE
Expand linear mutable HashMap interface

### DIFF
--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -86,6 +86,7 @@ test-suite test
   build-depends:
     base,
     linear-base,
+    containers,
     hedgehog,
     tasty,
     tasty-hedgehog,

--- a/src/Data/Array/Mutable/Linear.hs
+++ b/src/Data/Array/Mutable/Linear.hs
@@ -49,6 +49,7 @@ module Data.Array.Mutable.Linear
     write,
     unsafeWrite,
     resize,
+    map,
     -- * Accessors
     read,
     unsafeRead,
@@ -66,10 +67,10 @@ import qualified Data.Array.Mutable.Unlifted.Linear as Unlifted
 import qualified Data.Functor.Linear as Data
 import qualified Data.Vector as Vector
 import qualified Data.Vector.Mutable as MVector
-import Prelude.Linear ((&))
+import Prelude.Linear ((&), forget)
 import qualified Data.Primitive.Array as Prim
 import System.IO.Unsafe (unsafeDupablePerformIO)
-import Prelude hiding (read)
+import Prelude hiding (read, map)
 
 -- # Data types
 -------------------------------------------------------------------------------
@@ -234,6 +235,9 @@ freeze (Array arr) =
    -- Once it is exposed, we should be able to replace it with something
    -- safer like: `go arr = Vector 0 (sizeof arr) arr`
 
+map :: (a -> b) -> Array a #-> Array b
+map f (Array arr) = Array (Unlifted.map f arr)
+
 -- # Instances
 -------------------------------------------------------------------------------
 
@@ -249,7 +253,7 @@ instance Dupable (Array a) where
      wrap (# a1, a2 #) = (Array a1, Array a2)
 
 instance Data.Functor Array where
-  fmap f (Array arr) = Array (Unlifted.map f arr)
+  fmap f arr = map (forget f) arr
 
 -- # Internal library
 -------------------------------------------------------------------------------

--- a/src/Data/Array/Mutable/Unlifted/Linear.hs
+++ b/src/Data/Array/Mutable/Unlifted/Linear.hs
@@ -128,8 +128,8 @@ copyInto start@(GHC.I# start#) = Unsafe.toLinear2 go
             _ -> (# Array# src, Array# dst #)
 {-# NOINLINE copyInto #-}  -- prevents the runRW# effect from being reordered
 
-map :: (a #-> b) -> Array# a #-> Array# b
-map (f :: a #-> b) arr =
+map :: (a -> b) -> Array# a #-> Array# b
+map (f :: a -> b) arr =
   size arr
     `chain2` \(# arr', Ur s #) -> go 0 s arr'
  where

--- a/src/Data/HashMap/Linear.hs
+++ b/src/Data/HashMap/Linear.hs
@@ -16,36 +16,48 @@
 -- |
 -- This module provides mutable hashmaps with a linear interface.
 --
--- To use mutable hashmaps, create a linear computation of type
--- @HashMap k v #-> Ur b@ and feed it to 'empty'.
---
--- This hashmap is implemented with robin hood hashing which has good average
--- case performance.
+-- It is implemented with Robin Hood hashing which has amortized
+-- constant time lookups and updates.
 module Data.HashMap.Linear
   ( -- * A mutable hashmap
     HashMap,
     Keyed,
-    -- * Run a computation using a 'HashMap'
+    -- * Constructors
     empty,
-    -- * Modifiers and Constructors
+    fromList,
+    -- * Modifiers
     insert,
-    delete,
     insertAll,
+    delete,
+    filter,
+    filterWithKey,
+    mapMaybe,
+    mapMaybeWithKey,
+    shrinkToFit,
     -- * Accessors
     size,
+    capacity,
     lookup,
-    member
+    member,
+    toList,
+    -- * Combining maps
+    union,
+    unionWith,
+    intersectionWith
   )
 where
 
 import Data.Array.Mutable.Linear (Array)
+import qualified Data.Functor.Linear as Data
 import qualified Data.Array.Mutable.Linear as Array
 import Data.Hashable
 import Data.Unrestricted.Linear
-import Prelude.Linear hiding ((+), lookup, read)
+import Prelude.Linear hiding ((+), lookup, read, filter, mapMaybe)
 import Prelude ((+))
+import qualified Data.Maybe as NonLinear
+import qualified Data.Function as NonLinear
 import qualified Prelude
-import GHC.Stack
+import qualified Unsafe.Linear as Unsafe
 
 -- # Implementation Notes
 -- This is a simple implementatation of robin hood hashing.
@@ -57,25 +69,42 @@ import GHC.Stack
 -- * https://cs.uwaterloo.ca/research/tr/1986/CS-86-14.pdf
 --
 
+-- * Constants
+
+-- | When to trigger a resize.
+--
+-- A high load factor usually is not desirable because it makes operations
+-- do more probes. A very low one is also not desirable since there're some
+-- operations which take time relative to the 'capacity'.
+--
+-- This should be between (0, 1)
+--
+-- The value 0.75 is what Java uses:
+-- https://docs.oracle.com/javase/10/docs/api/java/util/HashMap.html
+constMaxLoadFactor :: Float
+constMaxLoadFactor = 0.75
+
+-- | When resizing, the capacity will be multiplied by this amount.
+--
+-- This should be greater than one.
+constGrowthFactor :: Int
+constGrowthFactor = 2
+
 -- # Core Data Types
 --------------------------------------------------
 
--- | A mutable hashmap with a linear API
+-- | A mutable hashmap with a linear interface.
 data HashMap k v where
   -- |
-  -- The count is the number of stored mappings.
-  -- Our sparseness invariant: count*3 <= size arr.
-  HashMap :: Count -> RobinArr k v #-> HashMap k v
-
--- INVARIANTS:
---   * Cells are empty iff the PSL is -1.
---   * Each (RobinVal k v) has the correct PSL
---   * We NEVER evaluate the key-val pair for PSL -1
---     since it might be (error "some message")
-
--- | The number of pairs stored in the hashmap
-newtype Count = Count Int
-  deriving (Prelude.Num)
+  -- @loadFactor m = size m / cap m@
+  --
+  -- Invariants:
+  -- - array is non-empty
+  -- - (count / capacity) <= constMaxLoadFactor.
+  HashMap
+    :: Int -- ^ The number of stored (key, value) pairs.
+    -> RobinArr k v -- ^ Underlying array.
+    #-> HashMap k v
 
 -- | An array of Robin values
 --
@@ -120,103 +149,344 @@ data ProbeResult k v where
 -- # Construction and Modification
 --------------------------------------------------
 
--- | Run a computation given an empty hashmap
+-- | Run a computation with an empty 'HashMap' with given capacity.
 empty :: forall k v b.
   Keyed k => Int -> (HashMap k v #-> Ur b) #-> Ur b
 empty size scope =
   Array.alloc
-    size
+    (max 1 size)
     Nothing
-    (\arr -> scope (HashMap (Count 0) arr))
+    (\arr -> scope (HashMap 0 arr))
 
--- | If the key is present, this update the value.
--- If not, if there's enough space, insert a new pair.
--- If there isn't enough space, resize and insert
-insert :: (Keyed k, HasCallStack) => HashMap k v #-> k -> v -> HashMap k v
-insert hm k v =
-  capacity hm & \(hm', Ur cap) ->
-    size hm' & \(hm'', Ur size) ->
-      case size < cap of
-        False -> resizeMap hm'' & \hm''' ->
-          insert hm''' k v
-        True ->
-          idealIndexForKey k hm'' & \(hm''', Ur idx) ->
-            tryInsertAtIndex hm''' idx (RobinVal (PSL 0) k v)
+-- | Run a computation with an 'HashMap' containing given key-value pairs.
+fromList :: forall k v b.
+  Keyed k => [(k, v)] -> (HashMap k v #-> Ur b) #-> Ur b
+fromList xs scope =
+  Array.alloc
+    (max
+      1
+      (ceiling @Float @Int (fromIntegral (length xs) / constMaxLoadFactor)))
+    Nothing
+    (\arr -> scope (insertAll xs (HashMap 0 arr)))
 
--- | Try to insert at a given index with a given PSL. So the
--- probing starts from the given index (with the given PSL).
-tryInsertAtIndex :: Keyed k =>
-  HashMap k v #-> Int -> RobinVal k v -> HashMap k v
-tryInsertAtIndex hmap ix (RobinVal psl key val) =
-  probeFrom (key, psl) ix hmap & \case
-    (HashMap ct arr, IndexToUpdate _ psl' ix') ->
-      HashMap ct (Array.write arr ix' (Just $ RobinVal psl' key val))
-    (HashMap (Count c) arr, IndexToInsert psl' ix') ->
-      HashMap (Count (c + 1)) (Array.write arr ix' (Just $ RobinVal psl' key val))
-    (hm, IndexToSwap oldVal psl' ix') ->
-      capacity hm  & \(HashMap ct arr, Ur cap) ->
-        tryInsertAtIndex
-          (HashMap ct (Array.write arr ix' (Just $ RobinVal psl' key val)))
-          ((ix' + 1) `mod` cap)
-          (incRobinValPSL oldVal)
+-- | The most general modification function; which can insert, update or delete
+-- a value of the key.
+alter :: Keyed k => HashMap k v #-> k -> (Maybe v -> Maybe v) -> HashMap k v
+alter hm key f =
+  idealIndexForKey key hm & \(hm', Ur idx) ->
+    probeFrom (key, 0) idx hm' & \case
+      -- The key does not exist, and there is an empty cell to insert.
+      (HashMap count arr, IndexToInsert psl ix) ->
+        Ur (f Nothing) & \case
+          -- We don't need to insert anything.
+          Ur Nothing -> HashMap count arr
+          -- We need to insert a new key.
+          Ur (Just v)->
+            HashMap
+             (count+1)
+             (Array.write arr ix (Just (RobinVal psl key v)))
+             & growMapIfNecessary
+      -- The key exists.
+      (hm'', IndexToUpdate v psl ix) ->
+        capacity hm'' & \(HashMap count arr, Ur cap) ->
+          Ur (f (Just v)) & \case
+            -- We need to delete it.
+            Ur Nothing ->
+              Array.write arr ix Nothing & \arr' ->
+                shiftSegmentBackward cap arr' ((ix + 1) `mod` cap) & \arr'' ->
+                  HashMap
+                    (count - 1)
+                    arr''
+            -- We need to update it.
+            Ur (Just new)->
+              HashMap
+                count
+                (Array.write arr ix (Just (RobinVal psl key new)))
+      -- The key does not exist, but there is a key to evict.
+      (hm, IndexToSwap evicted psl ix) ->
+        Ur (f Nothing) & \case
+          -- We don't need to insert anything.
+          Ur Nothing -> hm
+          -- We need to insert a new key.
+          Ur (Just v)->
+            capacity hm & \(HashMap count arr, Ur cap) ->
+              tryInsertAtIndex
+                (HashMap
+                  count
+                  (Array.write arr ix (Just (RobinVal psl key v))))
+                ((ix + 1) `mod` cap)
+                (incRobinValPSL evicted)
+              & growMapIfNecessary
 
--- | Resizes the hashmap to be about 2.5 times the previous size
-resizeMap :: Keyed k => HashMap k v #-> HashMap k v
-resizeMap hm =
-  capacity hm & \(HashMap _ arr, Ur cap) ->
-    extractPairs cap arr & \(arr', Ur kvs) ->
-      let newCap = (cap * 2) + (cap `div` 2)
-      in Array.allocBeside newCap Nothing arr' & \(oldArr, newArr) ->
-           oldArr `lseq`
-             insertAll kvs (HashMap (Count 0) newArr)
-  where
-    extractPairs :: Keyed k =>
-      Int -> RobinArr k v #-> (RobinArr k v, Ur [(k,v)])
-    extractPairs size arr = walk arr (size - 1) []
+-- | Insert a key value pair to a 'HashMap'. It overwrites the previous
+-- value if it exists.
+insert :: Keyed k => HashMap k v #-> k -> v -> HashMap k v
+insert hm k v = alter hm k (\_ -> Just v)
 
-    walk :: Keyed k =>
-      RobinArr k v #-> Int -> [(k,v)] -> (RobinArr k v, Ur [(k,v)])
-    walk arr ix kvs
-      | ix < 0 = (arr, Ur kvs)
-      | otherwise = Array.read arr ix & \case
-        (arr', Ur Nothing) ->
-          walk arr' (ix-1) kvs
-        (arr', Ur (Just (RobinVal _ k v))) ->
-          walk arr' (ix-1) ((k,v):kvs)
-
--- | 'delete h k' deletes key k and its value if it is present.
--- If it's not present, this does nothing.
+-- | Delete a key from a 'HashMap'. Does nothing if the key does not
+-- exist.
 delete :: Keyed k => HashMap k v #-> k -> HashMap k v
-delete hm k =
-  capacity hm & \(HashMap ct@(Count c) arr, Ur cap) ->
-    probeFrom (k,0) ((hash k) `mod` cap) (HashMap ct arr) & \case
-      (h, IndexToInsert _ _) -> h
-      (h, IndexToSwap _ _ _) -> h
-      (HashMap _ arr', IndexToUpdate _ _ ix) ->
-        Array.write arr' ix Nothing & \arr'' ->
-          shiftSegmentBackward cap arr'' ((ix + 1) `mod` cap) & \arr''' ->
-            HashMap (Count (c - 1)) arr'''
+delete hm k = alter hm k (\_ -> Nothing)
 
--- | Shift all cells with PSLs > 0 in a continuous segment
--- following the deleted cell, backwards by one and decrement
--- their PSLs.
-shiftSegmentBackward :: Keyed k =>
-  Int -> RobinArr k v #-> Int -> RobinArr k v
-shiftSegmentBackward s arr ix = Array.read arr ix & \case
-  (arr', Ur Nothing) -> arr'
-  (arr', Ur (Just (RobinVal 0 _ _))) -> arr'
-  (arr', Ur (Just val)) ->
-    Array.write arr' ix Nothing & \arr'' ->
-      shiftSegmentBackward
-        s
-        (Array.write arr'' ((ix-1) `mod` s) (Just $ decRobinValPSL val))
-        ((ix+1) `mod` s)
-
--- | 'insert' (in the provided order) a list of key-value pairs
--- to a given hashmap.
+-- | 'insert' (in the provided order) the given key-value pairs to
+-- the hashmap.
 insertAll :: Keyed k => [(k, v)] -> HashMap k v #-> HashMap k v
 insertAll [] hmap = hmap
 insertAll ((k, v) : xs) hmap = insertAll xs (insert hmap k v)
+-- TODO: Do a resize first on the length of the input.
+
+-- | A version of 'fmap' which can throw out the elements.
+--
+-- Complexity: O(capacity hm)
+mapMaybe :: Keyed k => (v -> Maybe v') -> HashMap k v #-> HashMap k v'
+mapMaybe f = mapMaybeWithKey (\_k v -> f v)
+
+-- | Same as 'mapMaybe', but also has access to the keys.
+mapMaybeWithKey :: Keyed k => (k -> v -> Maybe v') -> HashMap k v #-> HashMap k v'
+mapMaybeWithKey (f :: k -> v -> Maybe v') (HashMap _ arr') =
+  Array.size arr' & \case
+    (arr'', Ur 0) ->
+      recurOrReturn True 0 0 0 0 arr'' & \(arr''', Ur _) ->
+        HashMap 0 arr'''
+    (arr'', Ur sz) ->
+      numSpillovers arr'' & \(arr''', Ur spillovers) ->
+        go
+          spillovers
+          ((sz - 1 + spillovers) `mod` sz)
+          sz
+          0
+          arr'''
+          & \(arr'''', Ur b) -> HashMap b arr''''
+ where
+  go :: Int -- ^ Current index
+     -> Int -- ^ Last index to check
+     -> Int -- ^ Size of the array
+     -> Int -- ^ Number of resulting elements
+     -> RobinArr k v
+     #-> (RobinArr k v', Ur Int)
+  go curr end sz ret arr =
+    Array.read arr curr & \case
+      (arr', Ur Nothing) ->
+        recurOrReturn True curr end sz ret arr'
+      (arr', Ur (Just (RobinVal psl k v))) ->
+        case f k v of
+          Just v' ->
+           Array.write arr' curr
+             (Just (RobinVal psl k (Unsafe.coerce @v' @v v')))
+             & recurOrReturn True curr end sz (ret + 1)
+          Nothing ->
+            Array.write arr' curr Nothing
+              & \arr'' -> shiftSegmentBackward sz arr'' ((curr + 1) `mod` sz)
+              & recurOrReturn False curr end sz ret
+
+  -- Takes the same parameter as 'go', used to control when to end
+  -- the recursion.
+  recurOrReturn :: Bool -- ^ Whether the curr should be increased
+                -> Int -> Int -> Int -> Int
+                -> RobinArr k v #-> (RobinArr k v', Ur Int)
+  recurOrReturn incr curr end sz ret arr
+    | curr == end =
+      ( Unsafe.coerce @(RobinArr k v) @(RobinArr k v') arr
+      , Ur ret
+      )
+    | otherwise =
+      go
+        (if incr then (curr + 1) `mod` sz else curr)
+        end sz ret arr
+
+-- | Complexity: O(capacity hm)
+filterWithKey :: Keyed k => (k -> v -> Bool) -> HashMap k v #-> HashMap k v
+filterWithKey f =
+  mapMaybeWithKey
+    (\k v -> if f k v then Just v else Nothing)
+
+-- | Complexity: O(capacity hm)
+filter :: Keyed k => (v -> Bool) -> HashMap k v #-> HashMap k v
+filter f = filterWithKey (\_k v -> f v)
+
+-- | Union of two maps using the provided function on conflicts.
+--
+-- Complexity: O(min(capacity hm1, capacity hm2)
+unionWith
+  :: Keyed k => (v -> v -> v)
+  -> HashMap k v #-> HashMap k v #-> HashMap k v
+unionWith onConflict (hm1 :: HashMap k v) hm2 =
+  -- To insert the elements in smaller map to the larger map, we
+  -- compare their capacities, and flip the arguments if necessary.
+  capacity hm1 & \(hm1', Ur cap1) ->
+    capacity hm2 & \(hm2', Ur cap2) ->
+      if cap1 > cap2
+      then go onConflict hm1' (toList hm2')
+      else go (\v2 v1 -> onConflict v1 v2) hm2' (toList hm1')
+  where
+    go :: (v -> v -> v)
+       -> HashMap k v -- ^ larger map
+       #-> Ur [(k, v)] -- ^ contents of the smaller map
+       #-> HashMap k v
+    go _ hm (Ur []) = hm
+    go f hm (Ur ((k, vr):xs)) =
+      alter hm k (\case
+        Nothing -> Just vr
+        Just vl -> Just (f vl vr))
+        & \hm -> go f hm (Ur xs)
+
+-- | A right-biased union.
+--
+-- Complexity: O(min(capacity hm1, capacity hm2)
+union :: Keyed k => HashMap k v #-> HashMap k v #-> HashMap k v
+union hm1 hm2 = unionWith (\_v1 v2 -> v2) hm1 hm2
+
+-- | Intersection of two maps with the provided combine function.
+--
+-- Complexity: O(min(capacity hm1, capacity hm2)
+intersectionWith
+  :: Keyed k
+  => (a -> b -> c)
+  -> HashMap k a #-> HashMap k b #-> HashMap k c
+intersectionWith combine (hm1 :: HashMap k a') hm2 =
+  capacity hm1 & \(hm1', Ur cap1) ->
+    capacity hm2 & \(hm2', Ur cap2) ->
+      if cap1 > cap2
+      then go combine hm1' hm2'
+      else go (\v2 v1 -> combine v1 v2) hm2' hm1'
+ where
+   go :: (a -> b -> c) -> HashMap k a #-> HashMap k b #-> HashMap k c
+   go f hm1 hm2 = Unsafe.toLinear (go' f) hm1 hm2
+
+   -- This function is using 'hm1' unsafely, because 'mapMaybeWithKey'
+   -- does not allow passing state between elements. It relies on 'lookup'
+   -- not modifying the HashMap. It is possible to implement it safely
+   -- by inlining parts of 'mapMaybeWithKey', but this one is simpler.
+   go' :: (a -> b -> c) -> HashMap k a -> HashMap k b #-> HashMap k c
+   go' f hm1 hm2 =
+     hm2
+       & mapMaybeWithKey (\k b ->
+         lookup hm1 k & \case
+           (hm', Ur Nothing) -> Unsafe.toLinear (const Nothing) hm'
+           (hm', Ur (Just a)) -> Unsafe.toLinear (const (Just (f a b))) hm'
+         )
+
+-- |
+-- Reduce the 'HashMap' 'capacity' to decrease wasted memory. Returns
+-- a semantically identical 'HashMap'.
+--
+-- This is only useful after a lot of deletes.
+--
+-- Complexity: O(capacity hm)
+shrinkToFit :: Keyed k => HashMap k a #-> HashMap k a
+shrinkToFit hm =
+  size hm & \(hm', Ur size) ->
+    let targetSize = ceiling
+          (max 1 (fromIntegral size / constMaxLoadFactor))
+    in  resize targetSize hm'
+
+-- # Querying
+--------------------------------------------------
+
+-- | Number of key-value pairs inside the 'HashMap'
+size :: HashMap k v #-> (HashMap k v, Ur Int)
+size (HashMap ct arr) = (HashMap ct arr, Ur ct)
+
+-- | Maximum number of elements the HashMap can store without
+-- resizing. However, for performance reasons, the 'HashMap' might be
+-- before full.
+--
+-- Use 'shrinkToFit' to reduce the wasted space.
+capacity :: HashMap k v #-> (HashMap k v, Ur Int)
+capacity (HashMap ct arr) =
+  Array.size arr & \(arr', len) ->
+    (HashMap ct arr', len)
+
+-- | Look up a value from a 'HashMap'.
+lookup :: Keyed k => HashMap k v #-> k -> (HashMap k v, Ur (Maybe v))
+lookup hm k =
+  idealIndexForKey k hm & \(hm', Ur idx) ->
+    probeFrom (k,0) idx hm' & \case
+      (h, IndexToUpdate v _ _) ->
+        (h, Ur (Just v))
+      (h, IndexToInsert _ _) ->
+        (h, Ur Nothing)
+      (h, IndexToSwap _ _ _) ->
+        (h, Ur Nothing)
+
+-- | Check if the given key exists.
+member :: Keyed k => HashMap k v #-> k -> (HashMap k v, Ur Bool)
+member hm k =
+  lookup hm k & \case
+    (hm, Ur Nothing) -> (hm, Ur False)
+    (hm, Ur (Just _)) -> (hm, Ur True)
+
+-- | Converts a HashMap to a lazy list.
+toList :: HashMap k v #-> Ur [(k, v)]
+toList (HashMap _ arr) =
+  Array.toList arr & \(Ur elems) ->
+    elems
+      NonLinear.& NonLinear.catMaybes
+      NonLinear.& Prelude.map (\(RobinVal _ k v) -> (k, v))
+      NonLinear.& Ur
+
+-- # Instances
+--------------------------------------------------
+
+instance Consumable (HashMap k v) where
+  consume :: HashMap k v #-> ()
+  consume (HashMap _ arr) = consume arr
+
+instance Dupable (HashMap k v) where
+  dup2 (HashMap i arr) = dup2 arr & \(a1, a2) ->
+    (HashMap i a1, HashMap i a2)
+
+instance Data.Functor (HashMap k) where
+  fmap f (HashMap c arr) =
+    HashMap c $
+      Data.fmap
+        (\case
+          Nothing -> Nothing
+          Just (RobinVal p k v) -> Just (RobinVal p k (f v))
+        )
+        arr
+
+instance Prelude.Semigroup (HashMap k v) where
+  (<>) = error "Prelude.<>: invariant violation, unrestricted HashMap"
+
+instance Keyed k => Semigroup (HashMap k v) where
+  (<>) = union
+
+-- # Internal library
+--------------------------------------------------
+
+_debugShow :: (Show k, Show v) => HashMap k v #-> String
+_debugShow (HashMap _ robinArr) =
+  Array.toList robinArr & \(Ur xs) -> show xs
+
+-- | When using Robin-Hood hashing, the beginning of the array
+-- can contain elements "spilled over" from the end of the array.
+--
+-- This function finds the number of spillovers. The spillovers can
+-- be determined by the length of the prefix of the array where
+-- PSL > index.
+numSpillovers :: RobinArr k v #-> (RobinArr k v, Ur Int)
+numSpillovers arr =
+  Array.size arr & \(arr', Ur sz) ->
+    go 0 sz arr'
+ where
+  go :: Int -> Int -> RobinArr k v #-> (RobinArr k v, Ur Int)
+  go curr sz arr
+    | curr == sz = (arr, Ur 0) -- This should only happen when the
+                               -- Array is empty.
+    | otherwise =
+      Array.read arr curr & \case
+        (arr', Ur Nothing) -> (arr', Ur curr)
+        (arr', Ur (Just (RobinVal (PSL psl) _ _)))
+          | psl <= curr -> (arr', Ur curr)
+          | otherwise -> go (curr+1) sz arr'
+
+idealIndexForKey
+  :: Keyed k
+  => k -> HashMap k v #-> (HashMap k v, Ur Int)
+idealIndexForKey k hm =
+  capacity hm & \(hm', Ur cap) ->
+    (hm', Ur (mod (hash k) cap))
 
 -- | Given a key, psl of the probe so far, current unread index, and
 -- a full hashmap, return a probe result: the place the key already
@@ -236,54 +506,66 @@ probeFrom (k, p) ix (HashMap ct arr) = Array.read arr ix & \case
           capacity (HashMap ct arr') & \(HashMap ct' arr'', Ur cap) ->
             probeFrom (k, p+1) ((ix+1)`mod` cap) (HashMap ct' arr'')
 
--- # Querying
---------------------------------------------------
+-- | Try to insert at a given index with a given PSL. So the
+-- probing starts from the given index (with the given PSL).
+tryInsertAtIndex :: Keyed k =>
+  HashMap k v #-> Int -> RobinVal k v -> HashMap k v
+tryInsertAtIndex hmap ix (RobinVal psl key val) =
+  probeFrom (key, psl) ix hmap & \case
+    (HashMap ct arr, IndexToUpdate _ psl' ix') ->
+      HashMap ct (Array.write arr ix' (Just $ RobinVal psl' key val))
+    (HashMap c arr, IndexToInsert psl' ix') ->
+      HashMap (c + 1) (Array.write arr ix' (Just $ RobinVal psl' key val))
+    (hm, IndexToSwap oldVal psl' ix') ->
+      capacity hm  & \(HashMap ct arr, Ur cap) ->
+        tryInsertAtIndex
+          (HashMap ct (Array.write arr ix' (Just $ RobinVal psl' key val)))
+          ((ix' + 1) `mod` cap)
+          (incRobinValPSL oldVal)
 
-size :: HashMap k v #-> (HashMap k v, Ur Int)
-size (HashMap ct@(Count c) arr) = (HashMap ct arr, Ur c)
+-- | Shift all cells with PSLs > 0 in a continuous segment
+-- following the deleted cell, backwards by one and decrement
+-- their PSLs.
+shiftSegmentBackward :: Keyed k =>
+  Int -> RobinArr k v #-> Int -> RobinArr k v
+shiftSegmentBackward s arr ix = Array.read arr ix & \case
+  (arr', Ur Nothing) -> arr'
+  (arr', Ur (Just (RobinVal 0 _ _))) -> arr'
+  (arr', Ur (Just val)) ->
+    Array.write arr' ix Nothing & \arr'' ->
+      shiftSegmentBackward
+        s
+        (Array.write arr'' ((ix-1) `mod` s) (Just $ decRobinValPSL val))
+        ((ix+1) `mod` s)
+-- TODO: This does twice as much writes than necessary, it first empties
+-- the cell, just to update it again at the next call. We can save some
+-- writes by only emptying the last cell.
 
-capacity :: HashMap k v #-> (HashMap k v, Ur Int)
-capacity (HashMap ct arr) =
-  Array.size arr & \(arr', len) ->
-    (HashMap ct arr', len)
-
-member :: Keyed k => HashMap k v #-> k -> (HashMap k v, Ur Bool)
-member hm k =
-  idealIndexForKey k hm & \(hm', Ur idx) ->
-    probeFrom (k, 0) idx hm' & \case
-      (h, IndexToUpdate _ _ _) -> (h, Ur True)
-      (h, IndexToInsert _ _) -> (h, Ur False)
-      (h, IndexToSwap _ _ _) -> (h, Ur False)
-
-lookup :: Keyed k => HashMap k v #-> k -> (HashMap k v, Ur (Maybe v))
-lookup hm k =
-  idealIndexForKey k hm & \(hm', Ur idx) ->
-    probeFrom (k,0) idx hm' & \case
-      (h, IndexToUpdate v _ _) ->
-        (h, Ur (Just v))
-      (h, IndexToInsert _ _) ->
-        (h, Ur Nothing)
-      (h, IndexToSwap _ _ _) ->
-        (h, Ur Nothing)
-
-idealIndexForKey
-  :: Keyed k
-  => k -> HashMap k v #-> (HashMap k v, Ur Int)
-idealIndexForKey k hm =
+-- | Makes sure that the map is not exceeding its utilization threshold
+-- (constMaxUtilization), resizes (constGrowthFactor) if necessary.
+growMapIfNecessary :: Keyed k => HashMap k v #-> HashMap k v
+growMapIfNecessary hm =
   capacity hm & \(hm', Ur cap) ->
-    (hm', Ur (mod (hash k) cap))
+   size hm' & \(hm'', Ur sz) ->
+    let load = fromIntegral sz / fromIntegral cap
+    in if load < constMaxLoadFactor
+       then hm''
+       else
+         let newCap = max 1 (cap * constGrowthFactor)
+         in  resize newCap hm''
 
--- # Instances
---------------------------------------------------
-
-instance Consumable (HashMap k v) where
-  consume :: HashMap k v #-> ()
-  consume (HashMap _ arr) = consume arr
-
-instance Dupable (HashMap k v) where
-  dup2 (HashMap i arr) = dup2 arr & \(a1, a2) ->
-    (HashMap i a1, HashMap i a2)
-
-_debugShow :: (Show k, Show v) => HashMap k v #-> String
-_debugShow (HashMap _ robinArr) =
-  Array.toList robinArr & \(Ur xs) -> show xs
+-- | Resizes the HashMap to given capacity.
+--
+-- Invariant: Given capacity should be greater than the size, this is not
+-- checked.
+resize :: Keyed k => Int -> HashMap k v #-> HashMap k v
+resize targetSize (HashMap _ arr) =
+  Array.allocBeside targetSize Nothing arr & \(oldArr, newArr) ->
+    Array.toList oldArr & \(Ur elems) ->
+      let xs =
+            elems
+              NonLinear.& NonLinear.catMaybes
+              NonLinear.& Prelude.map (\(RobinVal _ k v) -> (k, v))
+       in  insertAll xs (HashMap 0 newArr)
+-- TODO: 'insertAll' keeps checking capacity on each insert. We should
+-- replace it with a faster unsafe variant.

--- a/src/Data/HashMap/Linear.hs
+++ b/src/Data/HashMap/Linear.hs
@@ -69,7 +69,8 @@ import qualified Unsafe.Linear as Unsafe
 -- * https://cs.uwaterloo.ca/research/tr/1986/CS-86-14.pdf
 --
 
--- * Constants
+-- # Constants
+--------------------------------------------------
 
 -- | When to trigger a resize.
 --
@@ -261,7 +262,7 @@ mapMaybeWithKey (f :: k -> v -> Maybe v') (HashMap _ arr') =
   go :: Int -- ^ Current index
      -> Int -- ^ Last index to check
      -> Int -- ^ Size of the array
-     -> Int -- ^ Number of resulting elements
+     -> Int -- ^ Accumulated count of pairs that are present after the map.
      -> RobinArr k v
      #-> (RobinArr k v', Ur Int)
   go curr end sz ret arr =
@@ -464,7 +465,7 @@ _debugShow (HashMap _ robinArr) =
 --
 -- This function finds the number of spillovers. The spillovers can
 -- be determined by the length of the prefix of the array where
--- PSL > index.
+-- PSL > index. This works since they form a contiguous segment.
 numSpillovers :: RobinArr k v #-> (RobinArr k v, Ur Int)
 numSpillovers arr =
   Array.size arr & \(arr', Ur sz) ->

--- a/test/Test/Data/Mutable/HashMap.hs
+++ b/test/Test/Data/Mutable/HashMap.hs
@@ -15,10 +15,13 @@ where
 import qualified Data.Functor.Linear as Linear
 import qualified Data.HashMap.Linear as HashMap
 import Data.Unrestricted.Linear
+import Data.Function ((&))
 import Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 import qualified Prelude.Linear as Linear
+import qualified Data.Map.Lazy as Map
+import Data.List (sort)
 import Test.Tasty
 import Test.Tasty.Hedgehog (testProperty)
 
@@ -41,7 +44,12 @@ group =
     testProperty "∀ k,v,m. member k (insert m k v) = True" memberInsert,
     testProperty "∀ k,m. member k (delete m k) = False" memberDelete,
     testProperty "∀ k,v,m. size (insert (m-k) k v) = 1+ size (m-k)" sizeInsert,
-    testProperty "∀ k,m with k. size (delete m k) + 1 = size m" deleteSize
+    testProperty "∀ k,m with k. size (delete m k) + 1 = size m" deleteSize,
+    testProperty "toList . fromList = id" refToListFromList,
+    testProperty "filter f (fromList xs) = fromList (filter f xs)" refFilter,
+    testProperty "fromList xs <> fromList ys = fromList (xs <> ys)" refMappend,
+    testProperty "unionWith reference" refUnionWith,
+    testProperty "intersectionWith reference" refIntersectionWith
   ]
 
 -- # Internal Library
@@ -60,15 +68,16 @@ type HMTest = HMap #-> Ur Bool
 maxSize :: Int
 maxSize = 800
 
+-- HashMap's have lots of corner cases, so we try harder to find them.
+defProperty :: PropertyT IO () -> Property
+defProperty = withTests 1000 . property
+
 -- | Run a test on a random HashMap
 testOnAnyHM :: PropertyT IO HMTest -> Property
-testOnAnyHM propHmtest = property $ do
+testOnAnyHM propHmtest = defProperty $ do
   kvs <- forAll keyVals
-  let randHM = makeHM kvs
   hmtest <- propHmtest
-  let test = hmtest Linear.. randHM
-  let initSize = maxSize `div` 50
-  assert $ unur Linear.$ HashMap.empty initSize test
+  assert $ unur Linear.$ HashMap.fromList kvs hmtest
 
 testKVPairExists :: (Int, String) -> HMTest
 testKVPairExists (k, v) hmap =
@@ -132,16 +141,11 @@ val = do
 -- | Random pairs
 keyVals :: Gen [(Int, String)]
 keyVals = do
-  size <- Gen.int $ Range.linearFrom 0 maxSize maxSize
+  size <- Gen.int $ Range.linear 0 maxSize
   let sizeGen = Range.singleton size
   keys <- Gen.list sizeGen key
   vals <- Gen.list sizeGen val
   return $ zip keys vals
-
--- | Insert all given pairs in order
-makeHM :: [(Int, String)] -> HMap #-> HMap
-makeHM [] hmap = hmap
-makeHM ((k, v) : xs) hmap = makeHM xs (HashMap.insert hmap k v)
 
 -- # Tests
 --------------------------------------------------------------------------------
@@ -235,3 +239,83 @@ checkSizeAfterDelete key hmap = fromSize (HashMap.size hmap)
     compSizes :: Ur Int #-> Ur Int #-> Ur Bool
     compSizes (Ur orgSize) (Ur newSize) =
       Ur ((newSize + 1) == orgSize)
+
+refToListFromList :: Property
+refToListFromList = defProperty $ do
+  xs <- forAll keyVals
+
+  let expected = Map.fromList xs
+                   & Map.toList
+
+      Ur actual = HashMap.fromList xs HashMap.toList
+
+  sort expected === sort actual
+
+refFilter :: Property
+refFilter = defProperty $ do
+  xs <- forAll keyVals
+
+  let predicate "" = False
+      predicate (i:_) = i < 'h'
+
+      expected = Map.fromList xs
+                   & Map.filter predicate
+                   & Map.toList
+
+      Ur actual = HashMap.fromList xs Linear.$
+        HashMap.toList Linear.. HashMap.filter predicate
+
+  sort expected === sort actual
+
+refMappend :: Property
+refMappend = defProperty $ do
+  xs <- forAll keyVals
+  ys <- forAll keyVals
+
+  let Ur expected =
+        HashMap.fromList (xs <> ys) Linear.$ HashMap.toList
+
+      Ur actual =
+        HashMap.fromList xs Linear.$ \hx ->
+          HashMap.fromList ys Linear.$ \hy ->
+            HashMap.toList (hx Linear.<> hy)
+
+  expected === actual
+
+refUnionWith :: Property
+refUnionWith = defProperty $ do
+  xs <- forAll keyVals
+  ys <- forAll keyVals
+
+  let combine a b = a ++ "," ++ b
+
+      expected = Map.unionWith combine
+                  (Map.fromList xs)
+                  (Map.fromList ys)
+                  & Map.toList
+
+      Ur actual =
+        HashMap.fromList xs Linear.$ \hx ->
+          HashMap.fromList ys Linear.$ \hy ->
+            HashMap.unionWith combine hx hy
+              Linear.& HashMap.toList
+
+  sort expected === sort actual
+
+refIntersectionWith :: Property
+refIntersectionWith = defProperty $ do
+  xs <- forAll keyVals
+  ys <- forAll keyVals
+
+  let expected = Map.intersectionWith (,)
+                  (Map.fromList xs)
+                  (Map.fromList ys)
+                  & Map.toList
+
+      Ur actual =
+        HashMap.fromList xs Linear.$ \hx ->
+          HashMap.fromList ys Linear.$ \hy ->
+            HashMap.intersectionWith (,) hx hy
+              Linear.& HashMap.toList
+
+  sort expected === sort actual

--- a/test/Test/Data/Mutable/HashMap.hs
+++ b/test/Test/Data/Mutable/HashMap.hs
@@ -280,7 +280,7 @@ refMappend = defProperty $ do
           HashMap.fromList ys Linear.$ \hy ->
             HashMap.toList (hx Linear.<> hy)
 
-  expected === actual
+  sort expected === sort actual
 
 refUnionWith :: Property
 refUnionWith = defProperty $ do


### PR DESCRIPTION
Closes #164 .

This PR expands HashMap interface with following main functionalities:

* An `alter` function which can be used to delete, insert or update keys.
* A `mapMaybe` function which can transform the HashMap optionally throwing out the elements.

Most of the rest of the changes are implemented in terms of the above functions.

* `mapMaybe` provides the `Functor` instance and `filter`-like functions
* `alter` provides `union` and `intersection` functions, which in turn becomes the `Semigroup` instance.

While implementing above changes, I had to add a `map` function to `Array`'s; because the `Functor` instance was overly restrictive:

```haskell
fmap :: (a #-> b) -> Array a #-> Array b
map  :: (a  -> b) -> Array a #-> Array b
```

Since the `Array` does not store linear values, the new `map` function allows using `a` unrestrictedly. `fmap` can then be derived from `map` by `forget`-ing the linear arrow.