### PR TITLE
Replace Stack with cabal-install on CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,6 +6,6 @@ steps:
     key: "install-linear-ghc"
   - label: "Run tests (cabal-install)"
     command: |
-      nix-shell --pure --run 'cabal test'
+      nix-shell --pure --run 'cabal update; cabal test'
     timeout: 30
     depends_on: "install-linear-ghc"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,8 +4,8 @@ steps:
       nix-shell --command ''
     timeout: 120
     key: "install-linear-ghc"
-  - label: "Run tests (Stack)"
+  - label: "Run tests (cabal-install)"
     command: |
-      nix-shell --pure --run 'stack --nix build --pedantic --test --bench --no-run-benchmarks'
+      nix-shell --pure --run 'cabal test'
     timeout: 30
     depends_on: "install-linear-ghc"

--- a/cabal.project
+++ b/cabal.project
@@ -2,10 +2,10 @@ packages: *.cabal
 
 allow-newer: all
 
--- If you update below, make sure to also update stack.yaml too
-
 package linear-base
   ghc-options: -Wall -Werror
+
+-- If you update below, make sure to also update stack.yaml too
 
 source-repository-package
   -- https://github.com/nick8325/quickcheck/pull/314

--- a/cabal.project
+++ b/cabal.project
@@ -4,6 +4,9 @@ allow-newer: all
 
 -- If you update below, make sure to also update stack.yaml too
 
+package linear-base
+  ghc-options: -Wall -Werror
+
 source-repository-package
   -- https://github.com/nick8325/quickcheck/pull/314
   type: git


### PR DESCRIPTION
Currently, our `stack` builds are failing, throwing errors like:

```
...
2020-09-22 15:05:03.459163: [debug] Failed to decode module interface:
/home/utdemir/workspace/github.com/tweag/linear-base6/.stack-work/dist/x86_64-linux-nix/Cabal-3.3.0.0/build/Data/Vector/Linear.hi
Decoding failure: not enough bytes
2020-09-22 15:05:03.459245: [debug] Failed to decode module interface:
/home/utdemir/workspace/github.com/tweag/linear-base6/.stack-work/dist/x86_64-linux-nix/Cabal-3.3.0.0/build/Data/Vector/Mutable/Linear.hi
Decoding failure: not enough bytes
2020-09-22 15:05:03.459334: [debug] Finished with exception in 18ms: getPackageFiles /home/utdemir/workspace/github.com/tweag/linear-base6/linear-base.cabal
Exception thrown: Prelude.chr: bad argument: 942814208
2020-09-22 15:05:03.459729: [error] Prelude.chr: bad argument: 942814208
```

More importantly, this affects CI (including `master`): https://buildkite.com/tweag-1/linear-base/builds/350#2971c76e-2967-45dc-9e8f-4c9f5434afd2

I couldn't pinpoint the exact reason since seemingly minor changes (eg. renaming a function parameter) can make the issue disappear. I suspect they are because an interface format change coming with new GHC. If this is the case, [this `stack` issue](https://github.com/commercialhaskell/stack/issues/5134) is likely relevant.

---

So, as a workaround, we can just replace `stack` with `cabal-install`. I tried modifying our CI configuration in this PR and it seems to be happy. 

We lose some determinisim there since now a Hackage update can break our build. But maybe that's good since then we can make sure that we keep up with the ecosystem (or add an upper bound).

The alternatives are:

* Figure out why Stack doesn't work. This can take an indeterminate amount of time. But if anyone has an idea, I'm happy to try.
* Move the CI to Nix including the Hackage dependencies. I choose not to do this since I didn't want to add yet another place to override our dependencies (besides `cabal.project` and `stack.yaml`).
* Add a `cabal.project.freeze` file to freeze the dependencies.
