### PR TITLE
Add 'dup2' to 'Dupable' class

### DIFF
--- a/src/Prelude/Linear.hs
+++ b/src/Prelude/Linear.hs
@@ -49,7 +49,6 @@ module Prelude.Linear
   , void
   , lseq
   , dup
-  , dup2
   , dup3
   , module Data.Num.Linear
   , module Data.Either.Linear


### PR DESCRIPTION
Closes #151 .

Even though `dupV` should be a better choice in the long term (after we address https://github.com/tweag/linear-base/issues/151#issuecomment-690130887), since our lenght-indexed vector interface is not easy-to-use this PR adds `dup2` to `Dupable` typeclass; with a `{-# MINIMAL dupV | dup2 #-}` pragma.

In order to do that it adds a bounded `iterate` function to length-indexed vectors, and exposes the `caseNat` utility.

In the `iterate` function, there is an `unsafeCoerce` to simplify a small equation. It should be possible to prove that equation from smaller axioms, but I did not see much advantage for this function.