### PR TITLE
Implement Dupable instances for mutable collections

### DIFF
--- a/src/Data/Array/Mutable/Linear.hs
+++ b/src/Data/Array/Mutable/Linear.hs
@@ -222,6 +222,13 @@ instance Consumable (Array a) where
   consume :: Array a #-> ()
   consume (Array arr) = arr `Unlifted.lseq` ()
 
+instance Dupable (Array a) where
+  dup2 :: Array a #-> (Array a, Array a)
+  dup2 (Array arr) = wrap (Unlifted.dup2 arr)
+   where
+     wrap :: (# Array# a, Array# a #) #-> (Array a, Array a)
+     wrap (# a1, a2 #) = (Array a1, Array a2)
+
 instance Data.Functor Array where
   fmap f (Array arr) = Array (Unlifted.map f arr)
 

--- a/src/Data/Array/Mutable/Unlifted/Linear.hs
+++ b/src/Data/Array/Mutable/Unlifted/Linear.hs
@@ -29,9 +29,10 @@ module Data.Array.Mutable.Unlifted.Linear
   , copyInto
   , map
   , toList
+  , dup2
   ) where
 
-import Data.Unrestricted.Linear hiding (lseq)
+import Data.Unrestricted.Linear hiding (lseq, dup2)
 import Prelude (Int)
 import qualified Prelude as Prelude
 import qualified Unsafe.Linear as Unsafe
@@ -157,6 +158,17 @@ toList = unArray# Prelude.$ \arr ->
     | GHC.I# i# <- i =
         case GHC.runRW# (GHC.readArray# arr i#) of
           (# _, ret #) -> ret : go (i Prelude.+ 1) len arr
+
+-- | Clone an array.
+dup2 :: Array# a #-> (# Array# a, Array# a #)
+dup2 = Unsafe.toLinear go
+ where
+  go :: Array# a -> (# Array# a, Array# a #)
+  go (Array# arr) =
+    case GHC.runRW#
+           (GHC.cloneMutableArray# arr 0# (GHC.sizeofMutableArray# arr)) of
+      (# _, new #) -> (# Array# arr, Array# new #)
+{-# NOINLINE dup2 #-}
 
 -- * Internal library
 

--- a/src/Data/HashMap/Linear.hs
+++ b/src/Data/HashMap/Linear.hs
@@ -280,6 +280,10 @@ instance Consumable (HashMap k v) where
   consume :: HashMap k v #-> ()
   consume (HashMap _ arr) = consume arr
 
+instance Dupable (HashMap k v) where
+  dup2 (HashMap i arr) = dup2 arr & \(a1, a2) ->
+    (HashMap i a1, HashMap i a2)
+
 _debugShow :: (Show k, Show v) => HashMap k v #-> String
 _debugShow (HashMap _ robinArr) =
   Array.toList robinArr & \(Ur xs) -> show xs

--- a/src/Data/Set/Mutable/Linear.hs
+++ b/src/Data/Set/Mutable/Linear.hs
@@ -76,3 +76,6 @@ member (Set hm) a =
 instance Consumable (Set a) where
   consume (Set hmap) = consume hmap
 
+instance Dupable (Set a) where
+  dup2 (Set hm) = dup2 hm Linear.& \(hm1, hm2) ->
+    (Set hm1, Set hm2)

--- a/src/Data/Vector/Mutable/Linear.hs
+++ b/src/Data/Vector/Mutable/Linear.hs
@@ -280,6 +280,10 @@ slice from newSize (Vec oldSize arr) =
 instance Consumable (Vector a) where
   consume (Vec _ arr) = consume arr
 
+instance Dupable (Vector a) where
+  dup2 (Vec i arr) = dup2 arr & \(a1, a2) ->
+    (Vec i a1, Vec i a2)
+
 -- There is no way to get an unrestricted vector. So the below instance
 -- is just to satisfy the linear Semigroup's constraint.
 instance Prelude.Semigroup (Vector a) where

--- a/src/Prelude/Linear.hs
+++ b/src/Prelude/Linear.hs
@@ -49,7 +49,6 @@ module Prelude.Linear
   , void
   , lseq
   , dup
-  , dup2
   , dup3
   , module Data.Num.Linear
   , module Data.Either.Linear

--- a/test/Test/Data/Mutable/Array.hs
+++ b/test/Test/Data/Mutable/Array.hs
@@ -70,6 +70,7 @@ group =
   , testProperty "∀ s,n. slice s n = take s . drop n" sliceRef
   , testProperty "f <$> fromList xs == fromList (f <$> xs)" refFmap
   , testProperty "toList . fromList = id" refToListFromList
+  , testProperty "dup2 produces identical arrays" refDupable
   -- Regression tests
   , testProperty "do not reorder reads and writes" readAndWriteTest
   , testProperty "do not evaluate values unnecesesarily" strictnessTest
@@ -264,6 +265,18 @@ refFmap = property $ do
         Array.fromList xs Linear.$ \arr ->
           Array.toList (f Data.<$> arr)
   expected === actual
+
+refDupable :: Property
+refDupable = property $ do
+  xs <- forAll list
+  let Ur (r1, r2) =
+        Array.fromList xs Linear.$ \arr ->
+          dup2 arr Linear.& \(arr1, arr2) ->
+            Array.toList arr1 Linear.& \(Ur l1) ->
+              Array.toList arr2 Linear.& \(Ur l2) ->
+                Ur (l1, l2)
+  xs === r1
+  xs === r2
 
 -- https://github.com/tweag/linear-base/pull/135
 readAndWriteTest :: Property


### PR DESCRIPTION
Depends on #203, closes #165.

This PR implements `Dupable` instances for mutable arrays, vectors, hashmaps and sets.

It also adds a `dup2` function to unlifted mutable arrays, since we can not implement `Dupable` for unlifted types.

All the work is done by `GHC.Exts.cloneMutableArray#` through our unlifted arrays, and pretty much all other instances are implemented trivially by using `Dupable` instances of their contents.