### PR TITLE
Add a constant time 'freeze' function to mutable arrays and vectors

### DIFF
--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -69,7 +69,8 @@ library
     storable-tuple,
     text,
     transformers,
-    vector
+    vector,
+    primitive
   default-language: Haskell2010
 
 test-suite test
@@ -87,7 +88,8 @@ test-suite test
     hedgehog,
     tasty,
     tasty-hedgehog,
-    mmorph
+    mmorph,
+    vector
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   default-language: Haskell2010
 

--- a/src/Data/Array/Mutable/Linear.hs
+++ b/src/Data/Array/Mutable/Linear.hs
@@ -55,6 +55,7 @@ module Data.Array.Mutable.Linear
     size,
     slice,
     toList,
+    freeze,
   )
 where
 
@@ -63,6 +64,7 @@ import GHC.Stack
 import Data.Array.Mutable.Unlifted.Linear (Array#)
 import qualified Data.Array.Mutable.Unlifted.Linear as Unlifted
 import qualified Data.Functor.Linear as Data
+import Data.Vector (Vector)
 import Prelude.Linear ((&))
 import Prelude hiding (read)
 
@@ -214,6 +216,10 @@ slice from targetSize arr =
 
     wrap :: (# Array# a, Array# a  #) #-> (Array a, Array a)
     wrap (# old, new #) = (Array old, Array new)
+
+-- | /O(1)/ Convert an 'Array' to an immutable 'Vector' (from 'vector' package).
+freeze :: Array a #-> Ur (Vector a)
+freeze (Array arr) = Unlifted.freeze arr
 
 -- # Instances
 -------------------------------------------------------------------------------

--- a/src/Data/Array/Mutable/Linear.hs
+++ b/src/Data/Array/Mutable/Linear.hs
@@ -64,8 +64,11 @@ import GHC.Stack
 import Data.Array.Mutable.Unlifted.Linear (Array#)
 import qualified Data.Array.Mutable.Unlifted.Linear as Unlifted
 import qualified Data.Functor.Linear as Data
-import Data.Vector (Vector)
+import qualified Data.Vector as Vector
+import qualified Data.Vector.Mutable as MVector
 import Prelude.Linear ((&))
+import qualified Data.Primitive.Array as Prim
+import System.IO.Unsafe (unsafeDupablePerformIO)
 import Prelude hiding (read)
 
 -- # Data types
@@ -217,9 +220,19 @@ slice from targetSize arr =
     wrap :: (# Array# a, Array# a  #) #-> (Array a, Array a)
     wrap (# old, new #) = (Array old, Array new)
 
--- | /O(1)/ Convert an 'Array' to an immutable 'Vector' (from 'vector' package).
-freeze :: Array a #-> Ur (Vector a)
-freeze (Array arr) = Unlifted.freeze arr
+-- | /O(1)/ Convert an 'Array' to an immutable 'Vector.Vector' (from
+-- 'vector' package).
+freeze :: Array a #-> Ur (Vector.Vector a)
+freeze (Array arr) =
+  Unlifted.freeze go arr
+ where
+   go arr = unsafeDupablePerformIO $ do
+     mut <- Prim.unsafeThawArray (Prim.Array arr)
+     let mv = MVector.MVector 0 (Prim.sizeofMutableArray mut) mut
+     Vector.unsafeFreeze mv
+   -- We only need to do above because 'Vector' constructor is hidden.
+   -- Once it is exposed, we should be able to replace it with something
+   -- safer like: `go arr = Vector 0 (sizeof arr) arr`
 
 -- # Instances
 -------------------------------------------------------------------------------

--- a/src/Data/Vector/Mutable/Linear.hs
+++ b/src/Data/Vector/Mutable/Linear.hs
@@ -66,6 +66,7 @@ module Data.Vector.Mutable.Linear
     size,
     capacity,
     toList,
+    freeze,
   )
 where
 
@@ -77,6 +78,7 @@ import Data.Monoid.Linear
 import qualified Data.Array.Mutable.Linear as Array
 import qualified Data.Functor.Linear as Data
 import qualified Unsafe.Linear as Unsafe
+import qualified Data.Vector as Vector
 
 -- # Constants
 -------------------------------------------------------------------------------
@@ -273,6 +275,12 @@ slice from newSize (Vec oldSize arr) =
        then Vec newSize arr
        else Array.slice from newSize arr & \(oldArr, newArr) ->
               oldArr `lseq` fromArray newArr
+
+-- | /O(1)/ Convert a 'Vector' to an immutable 'Vector' (from 'vector' package).
+freeze :: Vector a #-> Ur (Vector.Vector a)
+freeze (Vec sz arr) =
+  Array.freeze arr
+    & \(Ur vec) -> Ur (Vector.take sz vec)
 
 -- # Instances
 -------------------------------------------------------------------------------

--- a/src/Data/Vector/Mutable/Linear.hs
+++ b/src/Data/Vector/Mutable/Linear.hs
@@ -276,7 +276,8 @@ slice from newSize (Vec oldSize arr) =
        else Array.slice from newSize arr & \(oldArr, newArr) ->
               oldArr `lseq` fromArray newArr
 
--- | /O(1)/ Convert a 'Vector' to an immutable 'Vector' (from 'vector' package).
+-- | /O(1)/ Convert a 'Vector' to an immutable 'Vector.Vector' (from
+-- 'vector' package).
 freeze :: Vector a #-> Ur (Vector.Vector a)
 freeze (Vec sz arr) =
   Array.freeze arr

--- a/test/Test/Data/Mutable/Array.hs
+++ b/test/Test/Data/Mutable/Array.hs
@@ -44,6 +44,7 @@ import Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 import qualified Prelude.Linear as Linear hiding ((>))
+import qualified Data.Vector as Vector
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testProperty)
 
@@ -70,6 +71,7 @@ group =
   , testProperty "∀ s,n. slice s n = take s . drop n" sliceRef
   , testProperty "f <$> fromList xs == fromList (f <$> xs)" refFmap
   , testProperty "toList . fromList = id" refToListFromList
+  , testProperty "toList . freeze . fromList = id" refFreeze
   , testProperty "dup2 produces identical arrays" refDupable
   -- Regression tests
   , testProperty "do not reorder reads and writes" readAndWriteTest
@@ -265,6 +267,12 @@ refFmap = property $ do
         Array.fromList xs Linear.$ \arr ->
           Array.toList (f Data.<$> arr)
   expected === actual
+
+refFreeze :: Property
+refFreeze = property $ do
+  xs <- forAll list
+  let Ur vec = Array.fromList xs Array.freeze
+  xs === Vector.toList vec
 
 refDupable :: Property
 refDupable = property $ do


### PR DESCRIPTION
As suggested in https://github.com/tweag/linear-base/pull/180#issuecomment-694047048, this PR adds a constant time `freeze` method to unlifted and lifted mutable arrays and mutable vectors.

As usual, it is implemented with unsafe primitives in unlifted arrays, and the rest of the collections make use of that implementation. I hope I got the `MVector`'s parameters right, as far as I could understand its first parameter is the starting index and the second index is the length. Because of that starting index, we can not have a constant time `thaw` operation (which would be unsafe anyway).

I am not entirely sure about the name `freeze`. I was also thinking of names like `toVector` or `toImmutableVector`, but they are likelier to be confused with either of our `Vector`'s. Let me know if you prefer something else.

Some simple tests pass, and I hope I'm not violating any invariant of the `vector` package.

Relevant: https://github.com/tweag/linear-base/issues/185