### PR TITLE
Explicit Prelude.Linear re-exports

### DIFF
--- a/src/Control/Optics/Linear/Internal.hs
+++ b/src/Control/Optics/Linear/Internal.hs
@@ -121,7 +121,7 @@ setSwap :: Optic_ (Linear.Kleisli (Compose (LinearArrow b) ((,) a))) a b s t -> 
 setSwap (Optical l) s = getLA (getCompose (Linear.runKleisli (l (Linear.Kleisli (\a -> Compose (LA (\b -> (a,b)))))) s))
 
 match :: Optic_ (Market a b) a b s t -> s #-> Either t a
-match (Optical l) = snd (runMarket (l (Market id Right)))
+match (Optical l) = P.snd (runMarket (l (Market id Right)))
 
 build :: Optic_ (Linear.CoKleisli (Const b)) a b s t -> b #-> t
 build (Optical l) x = Linear.runCoKleisli (l (Linear.CoKleisli getConst')) (Const x)

--- a/src/Data/Array/Destination.hs
+++ b/src/Data/Array/Destination.hs
@@ -63,7 +63,7 @@ fill = Unsafe.toLinear2 unsafeFill
     -- length function on destination.
   where
     unsafeFill a (DArray ds) =
-      if MVector.length ds Prelude./= 1 then
+      if MVector.length ds /= 1 then
         error "Destination.fill: requires a destination of size 1"
       else
         unsafeDupablePerformIO Prelude.$ MVector.write ds 0 a

--- a/src/Data/Array/Destination.hs
+++ b/src/Data/Array/Destination.hs
@@ -63,7 +63,7 @@ fill = Unsafe.toLinear2 unsafeFill
     -- length function on destination.
   where
     unsafeFill a (DArray ds) =
-      if MVector.length ds /= 1 then
+      if MVector.length ds Prelude./= 1 then
         error "Destination.fill: requires a destination of size 1"
       else
         unsafeDupablePerformIO Prelude.$ MVector.write ds 0 a

--- a/src/Data/Array/Polarized/Pull/Internal.hs
+++ b/src/Data/Array/Polarized/Pull/Internal.hs
@@ -44,13 +44,13 @@ singleton = Unsafe.toLinear (\x -> fromFunction (\_ -> x) 1)
 -- Zip both pull arrays together.
 zip :: Array a #-> Array b #-> Array (a,b)
 zip (Array g n) (Array h m)
-  | n Prelude./= m    = error "Polarized.zip: size mismatch"
+  | n /= m    = error "Polarized.zip: size mismatch"
   | otherwise = fromFunction (\k -> (g k, h k)) n
 
 -- | Concatenate two pull arrays.
 append :: Array a #-> Array a #-> Array a
 append (Array f m) (Array g n) = Array h (m + n)
-  where h k = if k Prelude.< m
+  where h k = if k < m
                  then f k
                  else g (k-m)
 
@@ -79,8 +79,8 @@ findLength (Array f n) = (n, Array f n)
 fromFunction :: (Int -> a) -> Int -> Array a
 fromFunction f n = Array f' n
   where f' k
-          | k Prelude.< 0 = error "Pull.Array: negative index"
-          | k Prelude.>= n = error "Pull.Array: index too large"
+          | k < 0 = error "Pull.Array: negative index"
+          | k >= n = error "Pull.Array: index too large"
           | otherwise = f k
 -- XXX: this is used internally to ensure out of bounds errors occur, but
 -- is unnecessary if the input function can be assumed to already have bounded

--- a/src/Data/Array/Polarized/Pull/Internal.hs
+++ b/src/Data/Array/Polarized/Pull/Internal.hs
@@ -13,7 +13,6 @@ import Prelude.Linear
 import qualified Prelude
 import Data.Vector (Vector)
 import qualified Data.Vector as Vector
-import Data.Monoid.Linear
 
 import qualified Unsafe.Linear as Unsafe
 
@@ -45,13 +44,13 @@ singleton = Unsafe.toLinear (\x -> fromFunction (\_ -> x) 1)
 -- Zip both pull arrays together.
 zip :: Array a #-> Array b #-> Array (a,b)
 zip (Array g n) (Array h m)
-  | n /= m    = error "Polarized.zip: size mismatch"
+  | n Prelude./= m    = error "Polarized.zip: size mismatch"
   | otherwise = fromFunction (\k -> (g k, h k)) n
 
 -- | Concatenate two pull arrays.
 append :: Array a #-> Array a #-> Array a
 append (Array f m) (Array g n) = Array h (m + n)
-  where h k = if k < m
+  where h k = if k Prelude.< m
                  then f k
                  else g (k-m)
 
@@ -80,8 +79,8 @@ findLength (Array f n) = (n, Array f n)
 fromFunction :: (Int -> a) -> Int -> Array a
 fromFunction f n = Array f' n
   where f' k
-          | k < 0 = error "Pull.Array: negative index"
-          | k >= n = error "Pull.Array: index too large"
+          | k Prelude.< 0 = error "Pull.Array: negative index"
+          | k Prelude.>= n = error "Pull.Array: index too large"
           | otherwise = f k
 -- XXX: this is used internally to ensure out of bounds errors occur, but
 -- is unnecessary if the input function can be assumed to already have bounded

--- a/src/Data/Array/Polarized/Push.hs
+++ b/src/Data/Array/Polarized/Push.hs
@@ -18,7 +18,6 @@ import qualified Data.Functor.Linear as Data
 import Data.Vector (Vector)
 import Prelude.Linear
 import qualified Prelude
-import Data.Monoid.Linear
 
 -- TODO: the below isn't really true yet since no friendly way of constructing
 -- a PushArray directly is given yet (see issue #62), but the spirit holds.

--- a/src/Data/Bool/Linear.hs
+++ b/src/Data/Bool/Linear.hs
@@ -9,10 +9,11 @@ module Data.Bool.Linear
   , (&&)
   , (||)
   , not
+  , otherwise
   )
   where
 
-import Prelude (Bool(..))
+import Prelude (Bool(..), otherwise)
 
 -- | @True@ iff both are @True@.
 -- __NOTE:__ this is strict and not lazy!

--- a/src/Data/Either/Linear.hs
+++ b/src/Data/Either/Linear.hs
@@ -4,7 +4,8 @@
 
 -- | This module contains useful functions for working with 'Either's.
 module Data.Either.Linear
-  ( either
+  ( Either (..)
+  , either
   , lefts
   , rights
   , fromLeft

--- a/src/Data/Eq/Linear.hs
+++ b/src/Data/Eq/Linear.hs
@@ -32,6 +32,7 @@ class Eq a where
   x == y = not (x /= y)
   (/=) :: a #-> a #-> Bool
   x /= y = not (x == y)
+  infix 4 ==, /=
 
 deriving via MovableEq () instance Eq ()
 deriving via MovableEq Prelude.Int instance Eq Prelude.Int

--- a/src/Data/HashMap/Linear.hs
+++ b/src/Data/HashMap/Linear.hs
@@ -172,7 +172,7 @@ fromList xs scope =
   Array.alloc
     (max
       1
-      (ceiling @Float @Int (fromIntegral (length xs) / constMaxLoadFactor)))
+      (ceiling @Float @Int (fromIntegral (Prelude.length xs) / constMaxLoadFactor)))
     Nothing
     (\arr -> scope (insertAll xs (HashMap 0 arr)))
 
@@ -380,7 +380,7 @@ shrinkToFit :: Keyed k => HashMap k a #-> HashMap k a
 shrinkToFit hm =
   size hm & \(hm', Ur size) ->
     let targetSize = ceiling
-          (max 1 (fromIntegral size / constMaxLoadFactor))
+          (Prelude.max 1 (fromIntegral size Prelude./ constMaxLoadFactor))
     in  resize targetSize hm'
 
 -- # Querying
@@ -503,7 +503,7 @@ probeFrom (k, p) ix (HashMap ct arr) = Array.read arr ix & \case
     case k == k' of
       -- Note: in the True case, we must have p == psl
       True -> (HashMap ct arr', IndexToUpdate v' psl ix)
-      False -> case psl < p of
+      False -> case psl Prelude.< p of
         True -> (HashMap ct arr', IndexToSwap robinVal' p ix)
         False ->
           capacity (HashMap ct arr') & \(HashMap ct' arr'', Ur cap) ->
@@ -551,7 +551,7 @@ growMapIfNecessary hm =
   capacity hm & \(hm', Ur cap) ->
    size hm' & \(hm'', Ur sz) ->
     let load = fromIntegral sz / fromIntegral cap
-    in if load < constMaxLoadFactor
+    in if load Prelude.< constMaxLoadFactor
        then hm''
        else
          let newCap = max 1 (cap * constGrowthFactor)

--- a/src/Data/List/Linear.hs
+++ b/src/Data/List/Linear.hs
@@ -21,6 +21,7 @@ module Data.List.Linear
   , NonLinear.last
   , NonLinear.init
   , reverse
+  , NonLinear.lookup
   , length
   , NonLinear.null
     -- * Extracting sublists
@@ -76,7 +77,7 @@ module Data.List.Linear
 
 import qualified Unsafe.Linear as Unsafe
 import qualified Prelude as Prelude
-import Prelude (Maybe(..), Either(..), Int, otherwise)
+import Prelude (Maybe(..), Either(..), Int)
 import Prelude.Linear.Internal
 import Data.Bool.Linear
 import Data.Unrestricted.Linear

--- a/src/Data/Maybe/Linear.hs
+++ b/src/Data/Maybe/Linear.hs
@@ -3,7 +3,8 @@
 
 -- | This module provides linear functions on the standard 'Maybe' type.
 module Data.Maybe.Linear
-  ( maybe
+  ( Maybe (..)
+  , maybe
   , fromMaybe
   , maybeToList
   , catMaybes

--- a/src/Data/Monoid/Linear.hs
+++ b/src/Data/Monoid/Linear.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 
@@ -14,6 +15,7 @@ module Data.Monoid.Linear
   ( -- * Monoids and related classes
     Semigroup(..)
   , Monoid(..)
+  , mconcat
   -- * Endo
   , Endo(..), appEndo
   , NonLinear(..)
@@ -39,6 +41,13 @@ class (Semigroup a, Prelude.Monoid a) => Monoid a where
   mempty :: a
   mempty = Prelude.mempty
   -- convenience redefine
+
+mconcat :: Monoid a => [a] #-> a
+mconcat (xs' :: [a]) = go mempty xs'
+  where
+    go :: a #-> [a] #-> a
+    go acc [] = acc
+    go acc (x:xs) = go (acc <> x) xs
 
 ---------------
 -- Instances --

--- a/src/Data/Ord/Linear.hs
+++ b/src/Data/Ord/Linear.hs
@@ -8,6 +8,7 @@
 
 module Data.Ord.Linear
   ( Ord(..)
+  , Ordering(..)
   , min
   , max
   , compare
@@ -73,6 +74,8 @@ class Eq a => Ord a where
 
   (>=) :: a #-> a #-> Bool
   x >= y = not (x < y)
+
+  infix 4 <=, <, >, >=
 
 -- NOTE: the unsafe linear coercing in the three functions below makes sense
 -- ONLY because any type satisfying these constraints has a linear ord

--- a/src/Data/Tuple/Linear.hs
+++ b/src/Data/Tuple/Linear.hs
@@ -8,9 +8,12 @@ module Data.Tuple.Linear
     fst
   , snd
   , swap
+  , curry
+  , uncurry
   )
   where
 
+import Prelude.Linear.Internal
 import Data.Unrestricted.Linear
 
 fst :: Consumable b => (a,b) #-> a

--- a/src/Data/Vector/Mutable/Linear.hs
+++ b/src/Data/Vector/Mutable/Linear.hs
@@ -122,7 +122,7 @@ empty f = Array.fromList [] (f . fromArray)
 constant :: HasCallStack =>
   Int -> a -> (Vector a #-> Ur b) #-> Ur b
 constant size' x f
-  | size' Prelude.< 0 =
+  | size' < 0 =
       (error ("Trying to construct a vector of size " ++ show size') :: x #-> x)
       (f undefined)
   | otherwise = Array.alloc size' x (f . fromArray)
@@ -237,7 +237,7 @@ mapMaybe vec (f :: a -> Maybe b) =
   go r w s vec'
     -- If we processed all elements, set the capacity after the last written
     -- index and coerce the result to the correct type.
-    | r Prelude.== s =
+    | r == s =
         vec' & \(Vec _ arr) ->
           Vec w (Unsafe.coerce arr)
     -- Otherwise, read an element, write if the predicate is true and advance
@@ -256,7 +256,7 @@ shrinkToFit :: Vector a #-> Vector a
 shrinkToFit vec =
   capacity vec & \(vec', Ur cap) ->
     size vec' & \(vec'', Ur s') ->
-      if cap Prelude.> s'
+      if cap > s'
       then unsafeResize s' vec''
       else vec''
 
@@ -324,7 +324,7 @@ growToFit :: HasCallStack => Int -> Vector a #-> Vector a
 growToFit n vec =
   capacity vec & \(vec', Ur cap) ->
     size vec' & \(vec'', Ur s') ->
-      if s' + n Prelude.<= cap
+      if s' + n <= cap
       then vec''
       else
         let -- Calculate the closest power of growth factor
@@ -357,6 +357,6 @@ unsafeResize newSize (Vec size' ma) =
 assertIndexInRange :: HasCallStack => Int -> Vector a #-> Vector a
 assertIndexInRange i vec =
   size vec & \(vec', Ur s) ->
-    if 0 Prelude.<= i Prelude.&& i Prelude.< s
+    if 0 <= i && i < s
     then vec'
     else vec' `lseq` error "Vector: index out of bounds"

--- a/src/Data/Vector/Mutable/Linear.hs
+++ b/src/Data/Vector/Mutable/Linear.hs
@@ -122,7 +122,7 @@ empty f = Array.fromList [] (f . fromArray)
 constant :: HasCallStack =>
   Int -> a -> (Vector a #-> Ur b) #-> Ur b
 constant size' x f
-  | size' < 0 =
+  | size' Prelude.< 0 =
       (error ("Trying to construct a vector of size " ++ show size') :: x #-> x)
       (f undefined)
   | otherwise = Array.alloc size' x (f . fromArray)
@@ -214,7 +214,7 @@ modify_ vec f ix =
 toList :: Vector a #-> Ur [a]
 toList (Vec s arr) =
   Array.toList arr & \(Ur xs) ->
-    Ur (take s xs)
+    Ur (Prelude.take s xs)
 
 -- | Filters the vector in-place. It does not deallocate unused capacity,
 -- use 'shrinkToFit' for that if necessary.
@@ -237,7 +237,7 @@ mapMaybe vec (f :: a -> Maybe b) =
   go r w s vec'
     -- If we processed all elements, set the capacity after the last written
     -- index and coerce the result to the correct type.
-    | r == s =
+    | r Prelude.== s =
         vec' & \(Vec _ arr) ->
           Vec w (Unsafe.coerce arr)
     -- Otherwise, read an element, write if the predicate is true and advance
@@ -256,7 +256,7 @@ shrinkToFit :: Vector a #-> Vector a
 shrinkToFit vec =
   capacity vec & \(vec', Ur cap) ->
     size vec' & \(vec'', Ur s') ->
-      if cap > s'
+      if cap Prelude.> s'
       then unsafeResize s' vec''
       else vec''
 
@@ -324,7 +324,7 @@ growToFit :: HasCallStack => Int -> Vector a #-> Vector a
 growToFit n vec =
   capacity vec & \(vec', Ur cap) ->
     size vec' & \(vec'', Ur s') ->
-      if s' + n <= cap
+      if s' + n Prelude.<= cap
       then vec''
       else
         let -- Calculate the closest power of growth factor
@@ -357,6 +357,6 @@ unsafeResize newSize (Vec size' ma) =
 assertIndexInRange :: HasCallStack => Int -> Vector a #-> Vector a
 assertIndexInRange i vec =
   size vec & \(vec', Ur s) ->
-    if 0 <= i && i < s
+    if 0 Prelude.<= i Prelude.&& i Prelude.< s
     then vec'
     else vec' `lseq` error "Vector: index out of bounds"

--- a/src/Foreign/Marshal/Pure.hs
+++ b/src/Foreign/Marshal/Pure.hs
@@ -87,8 +87,8 @@ import Foreign.Marshal.Utils
 import Foreign.Ptr
 import Foreign.Storable
 import Foreign.Storable.Tuple ()
-import Prelude (($), return, (<*>))
-import Prelude.Linear hiding (($))
+import Prelude (($), return, (<*>), Eq(..), (<$>), (=<<))
+import Prelude.Linear hiding (($), Eq(..))
 import System.IO.Unsafe
 import qualified Unsafe.Linear as Unsafe
 

--- a/src/Prelude/Linear.hs
+++ b/src/Prelude/Linear.hs
@@ -23,20 +23,98 @@
 
 module Prelude.Linear
   ( -- * Standard Types, Classes and Related Functions
-    ($)
-  , (&)
-  , (<*)
-  , foldl
-  , foldr
-  , const
-  , id
-  , seq
+    -- ** Basic data types
+    module Data.Bool.Linear
+  , Prelude.Char
+  , module Data.Maybe.Linear
+  , module Data.Either.Linear
+    -- * Tuples
+  , Prelude.fst
+  , Prelude.snd
   , curry
   , uncurry
+    -- ** Basic type classes
+  , module Data.Eq.Linear
+  , module Data.Ord.Linear
+  , Prelude.Enum (..)
+  , Prelude.Bounded (..)
+    -- ** Numbers
+  , Prelude.Int
+  , Prelude.Integer
+  , Prelude.Float
+  , Prelude.Double
+  , Prelude.Rational
+  , Prelude.Word
+  , module Data.Num.Linear
+  , Prelude.Real (..)
+  , Prelude.Integral (..)
+  , Prelude.Floating (..)
+  , Prelude.Fractional (..)
+  , Prelude.RealFrac (..)
+  , Prelude.RealFloat (..)
+    -- *** Numeric functions
+  , Prelude.subtract
+  , Prelude.even
+  , Prelude.odd
+  , Prelude.gcd
+  , Prelude.lcm
+  , (Prelude.^)
+  , (Prelude.^^)
+  , Prelude.fromIntegral
+  , Prelude.realToFrac
+    -- ** Monads and functors
+  , (<*)
+    -- ** Semigroups and monoids
+  , module Data.Monoid.Linear
+    -- ** Miscellaneous functions
+  , id
+  , const
   , (.)
-  , forget
-  , Semigroup(..)
-  , Monoid(..)
+  , flip
+  , ($)
+  , (&)
+  , Prelude.until
+  , asTypeOf
+  , Prelude.error
+  , Prelude.errorWithoutStackTrace
+  , Prelude.undefined
+  , seq
+  , ($!)
+    -- * List operations
+  , module Data.List.Linear
+    -- * Functions on strings
+    -- TODO: Implement a linear counterpart of this
+  , module Data.String
+    -- * Converting to and from String
+  , Prelude.ShowS
+  , Prelude.Show (..)
+  , Prelude.shows
+  , Prelude.showChar
+  , Prelude.showString
+  , Prelude.showParen
+  , Prelude.ReadS
+  , Prelude.Read (..)
+  , Prelude.reads
+  , Prelude.readParen
+  , Prelude.read
+  , Prelude.lex
+    -- * Basic input and output
+  , Prelude.IO
+  , Prelude.putChar
+  , Prelude.putStr
+  , Prelude.putStrLn
+  , Prelude.print
+  , Prelude.getChar
+  , Prelude.getLine
+  , Prelude.getContents
+  , Prelude.interact
+    -- ** Files
+  , Prelude.FilePath
+  , Prelude.readFile
+  , Prelude.writeFile
+  , Prelude.appendFile
+  , Prelude.readIO
+  , Prelude.readLn
     -- * Using 'Ur' values in linear code
     -- $ unrestricted
   , Ur(..)
@@ -50,12 +128,7 @@ module Prelude.Linear
   , lseq
   , dup
   , dup3
-  , module Data.Num.Linear
-  , module Data.Either.Linear
-  , module Data.Bool.Linear
-  , module Data.Maybe.Linear
-    -- * Re-exports from the standard 'Prelude' for convenience
-  , module Prelude
+  , forget
   ) where
 
 import qualified Data.Functor.Linear as Data
@@ -65,33 +138,14 @@ import Data.Num.Linear
 import Data.Bool.Linear
 import Data.Either.Linear
 import Data.Maybe.Linear
+import Data.Ord.Linear
+import Data.Tuple.Linear
 import Data.List.Linear
-import Prelude hiding
-  ( ($)
-  , id
-  , const
-  , seq
-  , curry
-  , uncurry
-  , flip
-  , foldl
-  , foldr
-  , (.)
-  , maybe
-  , either
-  , (||)
-  , (&&)
-  , not
-  , Functor(..)
-  , Applicative(..)
-  , Monad(..)
-  , Traversable(..)
-  , Semigroup(..)
-  , Monoid(..)
-  , Num(..)
-  )
+import qualified Prelude
 import GHC.Exts (FUN)
 import Prelude.Linear.Internal
+import Data.Eq.Linear
+import Data.String
 
 -- | Replacement for the flip function with generalized multiplicities.
 flip :: FUN r (FUN p a (FUN q b c)) (FUN q b (FUN p a c))

--- a/src/Prelude/Linear/Internal.hs
+++ b/src/Prelude/Linear/Internal.hs
@@ -3,6 +3,7 @@
 
 {-# OPTIONS_HADDOCK hide #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE LinearTypes #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
@@ -33,11 +34,17 @@ id x = x
 const :: a #-> b -> a
 const x _ = x
 
+asTypeOf :: a #-> a -> a
+asTypeOf = const
+
 -- | @seq x y@ only forces @x@ to head normal form, therefore is not guaranteed
 -- to consume @x@ when the resulting computation is consumed. Therefore, @seq@
 -- cannot be linear in it's first argument.
 seq :: a -> b #-> b
 seq x = Unsafe.toLinear (Prelude.seq x)
+
+($!) :: (a #-> b) #-> a #-> b
+($!) f !a = f a
 
 -- | Beware, 'curry' is not compatible with the standard one because it is
 -- higher-order and we don't have multiplicity polymorphism yet.

--- a/src/System/IO/Linear.hs
+++ b/src/System/IO/Linear.hs
@@ -62,6 +62,7 @@ import qualified Data.Functor.Linear as Data
 import GHC.Exts (State#, RealWorld)
 import Prelude.Linear hiding (IO)
 import qualified Unsafe.Linear as Unsafe
+import qualified Prelude
 import qualified System.IO as System
 
 
@@ -104,7 +105,7 @@ fromSystemIO = Unsafe.coerce
 -- 'Ur'.
 fromSystemIOU :: System.IO a -> IO (Ur a)
 fromSystemIOU action =
-  fromSystemIO (Ur <$> action)
+  fromSystemIO (Ur Prelude.<$> action)
 
 -- | Convert a linear IO action to a "System.IO" action.
 toSystemIO :: IO a #-> System.IO a
@@ -118,7 +119,7 @@ toSystemIO = Unsafe.coerce -- basically just subtyping
 -- main = Linear.withLinearIO $ do ...
 -- @
 withLinearIO :: IO (Ur a) -> System.IO a
-withLinearIO action = (\x -> unur x) <$> (toSystemIO action)
+withLinearIO action = (\x -> unur x) Prelude.<$> (toSystemIO action)
 
 -- * Monadic interface
 

--- a/src/System/IO/Resource.hs
+++ b/src/System/IO/Resource.hs
@@ -106,7 +106,7 @@ run (RIO action) = do
         (restore (Linear.withLinearIO (action rrm)))
         (do -- release stray resources
            ReleaseMap releaseMap <- System.readIORef rrm
-           safeRelease P.$ Ur.fmap snd P.$ IntMap.toList releaseMap))
+           safeRelease P.$ Ur.fmap P.snd P.$ IntMap.toList releaseMap))
       -- Remarks: resources are guaranteed to be released on non-exceptional
       -- return. So, contrary to a standard bracket/ResourceT implementation, we
       -- only release exceptions in the release map upon exception.


### PR DESCRIPTION
Closes #172, relevant discussion: https://github.com/tweag/linear-base/pull/133#issuecomment-679234955

This PR modifies `Prelude.Linear` to not export `module Prelude`, but replaces it with explicit re-exports.

I tried to keep the interface the same; but I found some linear implementations we could export instead of the unrestricted counterparts:

* We now export `Data.Eq.Linear` and `Data.Ord.Linear`, instead of exporting unrestricted equality and comparision functions.
* We now export linear versions of `fst` and `snd` instead of unrestricted ones from the `base`.

Also:

* We don't export any `Functor`s, because it isn't clear whether data or control `Functor`'s should be exported. However, we do export unrestricted `IO` instead of linear `IO`.
* I added `Maybe`, `Either` and `Ordering` types and constructors to their relevant linear modules, so they don't need to be exported separately.

While implementing this issue, I also implementing a few simple functions which were missing:

```haskell
mconcat :: Monoid a => [a] #-> a
asTypeOf :: a #-> a -> a

($!) :: (a #-> b) #-> a #-> b
($!) f a = Unsafe.toLinear2 (Prelude.$!) (forget f) a
```

I think the implementation `$!` is sound; even though it uses `a` twice, first to evaluate it and then to feed it to the function. Can you confirm this, @aspiwack ?

Let me know if you prefer anything different.