### PR TITLE
Profunctor.Monoidal Either Void instances

### DIFF
--- a/src/Data/Profunctor/Kleisli/Linear.hs
+++ b/src/Data/Profunctor/Kleisli/Linear.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE LinearTypes #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
@@ -43,9 +45,15 @@ instance Control.Applicative f => Strong Either Void (Kleisli f) where
   first  (Kleisli f) = Kleisli (either (Data.fmap Left . f) (Control.pure . Right))
   second (Kleisli g) = Kleisli (either (Control.pure . Left) (Data.fmap Right . g))
 
-instance Control.Applicative f => Monoidal (,) () (Kleisli f) where
-  Kleisli f *** Kleisli g = Kleisli $ \(x,y) -> (,) Control.<$> f x Control.<*> g y
-  unit = Kleisli Control.pure
+instance Data.Applicative f => Monoidal (,) () (Kleisli f) where
+  Kleisli f *** Kleisli g = Kleisli $ \(x,y) -> (,) Data.<$> f x Data.<*> g y
+  unit = Kleisli $ \() -> Data.pure ()
+
+instance Data.Functor f => Monoidal Either Void (Kleisli f) where
+  Kleisli f *** Kleisli g = Kleisli $ \case
+    Left a -> Left Data.<$> f a
+    Right b -> Right Data.<$> g b
+  unit = Kleisli $ \case {}
 
 instance Control.Applicative f => Wandering (Kleisli f) where
   wander (Kleisli f) = Kleisli (Data.traverse f)


### PR DESCRIPTION
Mostly because we can.

I'm not sure if any of these are useful. Or the `Monoidal (,) ()` instance for that matter. Both are increasingly looking like they are an artifact of the past.

Though if we want a linear equivalent to arrows, we may need at least the `Monoidal (,) ()`.

So, anyway, it's exploratory, but can't hurt.