### PR TITLE
Export optics

### DIFF
--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -19,7 +19,12 @@ library
     Control.Monad.IO.Class.Linear
     Control.Monad.Linear
     Control.Monad.Linear.Internal
+    Control.Optics.Linear
     Control.Optics.Linear.Internal
+    Control.Optics.Linear.Iso
+    Control.Optics.Linear.Lens
+    Control.Optics.Linear.Prism
+    Control.Optics.Linear.Traversal
     Data.Array.Destination
     Data.Array.Mutable.Linear
     Data.Array.Mutable.Unlifted.Linear

--- a/src/Control/Optics/Linear.hs
+++ b/src/Control/Optics/Linear.hs
@@ -1,0 +1,15 @@
+module Control.Optics.Linear
+  ( Optic_(..)
+  , Optic
+  , module Control.Optics.Linear.Iso
+  , module Control.Optics.Linear.Lens
+  , module Control.Optics.Linear.Prism
+  , module Control.Optics.Linear.Traversal
+  )
+where
+
+import Control.Optics.Linear.Internal (Optic_(..), Optic)
+import Control.Optics.Linear.Iso
+import Control.Optics.Linear.Lens
+import Control.Optics.Linear.Prism
+import Control.Optics.Linear.Traversal

--- a/src/Control/Optics/Linear/Iso.hs
+++ b/src/Control/Optics/Linear/Iso.hs
@@ -1,0 +1,15 @@
+module Control.Optics.Linear.Iso
+  ( -- * Types
+    Iso, Iso'
+    -- * Composing optics
+  , (.>)
+    -- * Common optics
+  , swap, assoc
+    -- * Using optics
+  , withIso
+    -- * Constructing optics
+  , iso
+  )
+  where
+
+import Control.Optics.Linear.Internal

--- a/src/Control/Optics/Linear/Lens.hs
+++ b/src/Control/Optics/Linear/Lens.hs
@@ -1,0 +1,17 @@
+module Control.Optics.Linear.Lens
+  ( -- * Types
+    Lens, Lens'
+    -- * Composing lens
+  , (.>)
+    -- * Common optics
+  , _1, _2
+    -- * Using optics
+  , get, set, gets, setSwap
+  , over, over'
+  , withLens
+    -- * Constructing optics
+  , lens
+  )
+where
+
+import Control.Optics.Linear.Internal

--- a/src/Control/Optics/Linear/Prism.hs
+++ b/src/Control/Optics/Linear/Prism.hs
@@ -1,0 +1,17 @@
+module Control.Optics.Linear.Prism
+  ( -- * Types
+    Prism, Prism'
+    -- * Composing optics
+  , (.>)
+    -- * Common optics
+  , _Left, _Right
+  , _Just, _Nothing
+    -- * Using optics
+  , match, build
+  , withPrism
+    -- * Constructing optics
+  , prism
+  )
+  where
+
+import Control.Optics.Linear.Internal

--- a/src/Control/Optics/Linear/Traversal.hs
+++ b/src/Control/Optics/Linear/Traversal.hs
@@ -1,0 +1,15 @@
+module Control.Optics.Linear.Traversal
+  ( -- * Types
+    Traversal, Traversal'
+    -- * Composing optics
+  , (.>)
+    -- * Common optics
+  , traversed
+    -- * Using optics
+  , over, over'
+  , traverseOf, traverseOf'
+    -- * Constructing optics
+  )
+  where
+
+import Control.Optics.Linear.Internal


### PR DESCRIPTION
I followed the structure of the lens library: functions are
re-exported in modules which focus on one particular optics. So one
can see what the most relevant operations are for specific
optics. Everything is then re-exported in one big
Control.Optics.Linear module.

Closes #137 .