### PR TITLE
withLens & reifyLens

### DIFF
--- a/src/Control/Optics/Linear/Lens.hs
+++ b/src/Control/Optics/Linear/Lens.hs
@@ -8,7 +8,7 @@ module Control.Optics.Linear.Lens
     -- * Using optics
   , get, set, gets, setSwap
   , over, over'
-  , withLens
+  , reifyLens, withLens
     -- * Constructing optics
   , lens
   )


### PR DESCRIPTION
The `withX` family of function is continuation-passing style. Probably
to avoid some allocations. The withLens function was not of this
shape, so I think it deserves another name. I like `reifyLens` for it,
so I used it.

I also added a quick implementation of a `withLens` function in terms
of `reifyLens`. Most certainly we can do a more direct implementation,
but I didn't take the time to think about it.

The getter/setter split of lenses doesn't really make sense for linear
lens. However, there is a presentation using an existential type which
does have such a shape. I decided to use it for `withLens`, by
symmetry with `withIso` and `withPrism`.

Depends on #219 #221 .