### PR TITLE
Implement Ord in terms of `compare`

### DIFF
--- a/src/Data/Eq/Linear.hs
+++ b/src/Data/Eq/Linear.hs
@@ -1,7 +1,5 @@
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LinearTypes #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE StandaloneDeriving #-}
 
@@ -34,9 +32,46 @@ class Eq a where
   x /= y = not (x == y)
   infix 4 ==, /=
 
+-- * Instances
+
+instance Prelude.Eq a => Eq (Ur a) where
+  Ur x == Ur y = x Prelude.== y
+  Ur x /= Ur y = x Prelude./= y
+
+instance (Consumable a, Eq a) => Eq [a] where
+  [] == [] = True
+  (x:xs) == (y:ys) = x == y && xs == ys
+  xs == ys = (xs, ys) `lseq` False
+
+instance (Consumable a, Eq a) => Eq (Prelude.Maybe a) where
+  Prelude.Nothing == Prelude.Nothing = True
+  Prelude.Just x == Prelude.Just y = x == y
+  x == y = (x, y) `lseq` False
+
+instance (Consumable a, Consumable b, Eq a, Eq b)
+  => Eq (Prelude.Either a b) where
+  Prelude.Left x == Prelude.Left y = x == y
+  Prelude.Right x == Prelude.Right y = x == y
+  x == y = (x, y) `lseq` False
+
+instance (Eq a, Eq b) => Eq (a, b) where
+  (a, b) == (a', b') =
+    a == a' && b == b'
+
+instance (Eq a, Eq b, Eq c) => Eq (a, b, c) where
+  (a, b, c) == (a', b', c') =
+    a == a' && b == b' && c == c'
+
+instance (Eq a, Eq b, Eq c, Eq d) => Eq (a, b, c, d) where
+  (a, b, c, d) == (a', b', c', d') =
+    a == a' && b == b' && c == c' && d == d'
+
 deriving via MovableEq () instance Eq ()
 deriving via MovableEq Prelude.Int instance Eq Prelude.Int
 deriving via MovableEq Prelude.Double instance Eq Prelude.Double
+deriving via MovableEq Prelude.Bool instance Eq Prelude.Bool
+deriving via MovableEq Prelude.Char instance Eq Prelude.Char
+deriving via MovableEq Prelude.Ordering instance Eq Prelude.Ordering
 
 newtype MovableEq a = MovableEq a
 

--- a/src/Data/Monoid/Linear.hs
+++ b/src/Data/Monoid/Linear.hs
@@ -102,3 +102,17 @@ newtype NonLinear a = NonLinear a
 
 instance Semigroup a => Prelude.Semigroup (NonLinear a) where
   NonLinear a <> NonLinear b = NonLinear (a <> b)
+
+instance Semigroup Ordering where
+    LT <> LT = LT
+    LT <> GT = LT
+    LT <> EQ = LT
+    EQ <> y = y
+    GT <> LT = GT
+    GT <> GT = GT
+    GT <> EQ = GT
+    -- We can not use `lseq` above because of an import loop.
+    -- So it's easier to just expand the cases here.
+
+instance Monoid Ordering where
+    mempty = EQ

--- a/src/Data/Ord/Linear.hs
+++ b/src/Data/Ord/Linear.hs
@@ -7,7 +7,6 @@
 module Data.Ord.Linear
   ( Ord(..)
   , Ordering(..)
-  , (<), (<=), (>), (>=)
   , min
   , max
   )
@@ -20,18 +19,6 @@ import Data.Ord (Ordering(..))
 import Data.Bool.Linear ( Bool (..), not )
 import Data.Unrestricted.Linear
 import Data.Monoid.Linear
-
-{-
-
-== Design notes on linear orderings.
-
-Unlike in the non-linear setting, a linear @compare@ doesn't follow from
-@<=@ since you need two calls: one to @<=@ and one to @==@.
-
-Since a linear `compare` can be used to implement other comparison
-operators (and the inverse is not true), we choose to only add `compare`
-to the typeclass, and implement other operators outside of it.
--}
 
 -- | Linear Orderings
 --
@@ -47,25 +34,31 @@ to the typeclass, and implement other operators outside of it.
 -- * @x <= y@ = @not (y > x)@
 -- * @x >= y@ = @not (y < x)@
 --
+-- Unlike in the non-linear setting, a linear @compare@ doesn't follow from
+-- @<=@ since it requires calls: one to @<=@ and one to @==@. However,
+-- from a linear @compare@ it is easy to implement the others. Hence, the
+-- minimal complete definition only contains @compare@.
 class Eq a => Ord a where
+  {-# MINIMAL compare #-}
+
   -- | @compare x y@ returns an @Ordering@ which is
   -- one of @GT@ (greater than), @EQ@ (equal), or @LT@ (less than)
   -- which should be understood as \"x is @(compare x y)@ y\".
   compare :: a #-> a #-> Ordering
 
-(<=) :: Ord a => a #-> a #-> Bool
-x <= y = not (x > y)
+  (<=) :: a #-> a #-> Bool
+  x <= y = not (x > y)
 
-(<) :: Ord a => a #-> a #-> Bool
-x < y = compare x y == LT
+  (<) :: a #-> a #-> Bool
+  x < y = compare x y == LT
 
-(>) :: Ord a => a #-> a #-> Bool
-x > y = compare x y == GT
+  (>) :: a #-> a #-> Bool
+  x > y = compare x y == GT
 
-(>=) :: Ord a => a #-> a #-> Bool
-x >= y = not (x < y)
+  (>=) :: a #-> a #-> Bool
+  x >= y = not (x < y)
 
-infix 4 <=, <, >, >=
+  infix 4 <=, <, >, >=
 
 
 -- | @max x y@ returns the larger input, or  'y'

--- a/src/Data/Ord/Linear.hs
+++ b/src/Data/Ord/Linear.hs
@@ -1,56 +1,42 @@
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LinearTypes #-}
-{-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE LambdaCase #-}
 
 module Data.Ord.Linear
   ( Ord(..)
   , Ordering(..)
+  , (<), (<=), (>), (>=)
   , min
   , max
-  , compare
   )
   where
 
 import Data.Eq.Linear
-import qualified Prelude as Ur
 import qualified Prelude
+import Prelude.Linear.Internal
 import Data.Ord (Ordering(..))
 import Data.Bool.Linear ( Bool (..), not )
 import Data.Unrestricted.Linear
-import qualified Unsafe.Linear as Unsafe
+import Data.Monoid.Linear
 
 {-
 
 == Design notes on linear orderings.
 
-@compare@ can't be a part of a linear ordering typeclass. Unlike in the
-non-linear setting, a linear @compare@ doesn't follow from @<=@ since you need
-two calls: one to @<=@ and one to @==@.
+Unlike in the non-linear setting, a linear @compare@ doesn't follow from
+@<=@ since you need two calls: one to @<=@ and one to @==@.
 
-So what should the typeclass have, @(<)@ or @(<=)@?
-
-Observe that by using @not@ these /linear/ functions are equivalent (i.e., you
-can use one to implement the other and satisfy all axioms, even with linear
-types for the conversions).
-
- * @(<)@  \( \iff \) @(>=)@
- * @(>)@  \( \iff \) @(<=)@
-
-Thus, you can't separate a class with @(<)@ from one with @<=@. Further, this
-equivalence shows that a minimal definition is one function from each bullet
-point. (And thus there are 4 minimal definitions.)
-
+Since a linear `compare` can be used to implement other comparison
+operators (and the inverse is not true), we choose to only add `compare`
+to the typeclass, and implement other operators outside of it.
 -}
 
 -- | Linear Orderings
 --
--- Linear orderings provide a strict order but they do not
--- implement @compare@ because that requires two uses of a linear
--- @(<=)@. The laws for @(<=)@ for all \(a,b,c\):
+-- Linear orderings provide a strict order. The laws for @(<=)@ for
+-- all \(a,b,c\):
 --
 -- * reflexivity: \(a \leq a \)
 -- * antisymmetry: \((a \leq b) \land (b \leq a) \rightarrow (a = b) \)
@@ -62,45 +48,92 @@ point. (And thus there are 4 minimal definitions.)
 -- * @x >= y@ = @not (y < x)@
 --
 class Eq a => Ord a where
-  {-# MINIMAL (<), (>) | (<=), (>=) | (<), (<=) | (>), (>=) #-}
-  (<=) :: a #-> a #-> Bool
-  x <= y = not (x > y)
+  -- | @compare x y@ returns an @Ordering@ which is
+  -- one of @GT@ (greater than), @EQ@ (equal), or @LT@ (less than)
+  -- which should be understood as \"x is @(compare x y)@ y\".
+  compare :: a #-> a #-> Ordering
 
-  (<) :: a #-> a #-> Bool
-  x < y = not (x >= y)
+(<=) :: Ord a => a #-> a #-> Bool
+x <= y = not (x > y)
 
-  (>) :: a #-> a #-> Bool
-  x > y = not (x <= y)
+(<) :: Ord a => a #-> a #-> Bool
+x < y = compare x y == LT
 
-  (>=) :: a #-> a #-> Bool
-  x >= y = not (x < y)
+(>) :: Ord a => a #-> a #-> Bool
+x > y = compare x y == GT
 
-  infix 4 <=, <, >, >=
+(>=) :: Ord a => a #-> a #-> Bool
+x >= y = not (x < y)
 
--- NOTE: the unsafe linear coercing in the three functions below makes sense
--- ONLY because any type satisfying these constraints has a linear ord
--- instance, (from the instance in this file).  Hence, with a linear @Ord@
--- instance and @Dupable@, there is a purely linear implementation of this
--- function (which is sometimes less efficient than the one in base, and
--- hence we unsafely coerce).
+infix 4 <=, <, >, >=
 
--- | @max x y@ returns the largest input
-max :: (Dupable a, Ur.Ord a) =>  a #-> a #-> a
-max = Unsafe.toLinear2 (Ur.max)
 
--- | @min x y@ returs the smallest input
-min :: (Dupable a, Ur.Ord a) => a #-> a #-> a
-min = Unsafe.toLinear2 (Ur.min)
+-- | @max x y@ returns the larger input, or  'y'
+-- in case of a tie.
+max :: (Dupable a, Ord a) =>  a #-> a #-> a
+max x y =
+  dup2 x & \(x', x'') ->
+    dup2 y & \(y', y'') ->
+      if x' <= y'
+      then x'' `lseq` y''
+      else y'' `lseq` x''
 
--- | @compare x y@ returns an @Ordering@ which is
--- one of @GT@ (greater than), @EQ@ (equal), or @LT@ (less than)
--- which should be understood as \"x is @(compare x y)@ y\".
-compare :: (Dupable a, Ur.Ord a) => a #-> a #-> Ordering
-compare = Unsafe.toLinear2 Ur.compare
+-- | @min x y@ returns the smaller input, or 'y'
+-- in case of a tie.
+min :: (Dupable a, Ord a) =>  a #-> a #-> a
+min x y =
+  dup2 x & \(x', x'') ->
+    dup2 y & \(y', y'') ->
+      if x' <= y'
+      then y'' `lseq` x''
+      else x'' `lseq` y''
+
+-- * Instances
+
+instance Prelude.Ord a => Ord (Ur a) where
+  Ur x `compare` Ur y = x `Prelude.compare` y
+
+instance (Consumable a, Ord a) => Ord (Prelude.Maybe a) where
+  Prelude.Nothing `compare` Prelude.Nothing = EQ
+  Prelude.Nothing `compare` Prelude.Just y = y `lseq` LT
+  Prelude.Just x `compare` Prelude.Nothing = x `lseq` GT
+  Prelude.Just x `compare` Prelude.Just y = x `compare` y
+
+instance (Consumable a, Consumable b, Ord a, Ord b)
+  => Ord (Prelude.Either a b) where
+  Prelude.Left x `compare` Prelude.Right y = (x, y) `lseq` LT
+  Prelude.Right x `compare` Prelude.Left y = (x, y) `lseq` GT
+  Prelude.Left x `compare` Prelude.Left y = x `compare` y
+  Prelude.Right x `compare` Prelude.Right y = x `compare` y
+
+instance (Consumable a, Ord a) => Ord [a] where
+  {-# SPECIALISE instance Ord [Prelude.Char] #-}
+  compare [] [] = EQ
+  compare xs [] = xs `lseq` GT
+  compare [] ys = ys `lseq` LT
+  compare (x:xs) (y:ys) =
+    compare x y & \case
+      EQ -> compare xs ys
+      res -> (xs, ys) `lseq` res
+
+instance (Ord a, Ord b) => Ord (a, b) where
+  (a, b) `compare` (a', b') =
+    compare a a' <> compare b b'
+
+instance (Ord a, Ord b, Ord c) => Ord (a, b, c) where
+  (a, b, c) `compare` (a', b', c') =
+    compare a a' <> compare b b' <> compare c c'
+
+instance (Ord a, Ord b, Ord c, Ord d) => Ord (a, b, c, d) where
+  (a, b, c, d) `compare` (a', b', c', d') =
+    compare a a' <> compare b b' <> compare c c' <> compare d d'
 
 deriving via MovableOrd () instance Ord ()
 deriving via MovableOrd Prelude.Int instance Ord Prelude.Int
 deriving via MovableOrd Prelude.Double instance Ord Prelude.Double
+deriving via MovableOrd Prelude.Bool instance Ord Prelude.Bool
+deriving via MovableOrd Prelude.Char instance Ord Prelude.Char
+deriving via MovableOrd Prelude.Ordering instance Ord Prelude.Ordering
 
 newtype MovableOrd a = MovableOrd a
 
@@ -114,18 +147,6 @@ instance (Prelude.Eq a, Movable a) => Eq (MovableOrd a) where
     = a Prelude./= b
 
 instance (Prelude.Ord a, Movable a) => Ord (MovableOrd a) where
-  MovableOrd ar <= MovableOrd br
+  MovableOrd ar `compare` MovableOrd br
     | Ur a <- move ar , Ur b <- move br
-    = a Prelude.<= b
-
-  MovableOrd ar < MovableOrd br
-    | Ur a <- move ar , Ur b <- move br
-    = a Prelude.< b
-
-  MovableOrd ar > MovableOrd br
-    | Ur a <- move ar , Ur b <- move br
-    = a Prelude.> b
-
-  MovableOrd ar >= MovableOrd br
-    | Ur a <- move ar , Ur b <- move br
-    = a Prelude.>= b
+    = a `Prelude.compare` b

--- a/src/Data/Unrestricted/Linear.hs
+++ b/src/Data/Unrestricted/Linear.hs
@@ -251,6 +251,21 @@ instance Dupable Char where
 instance Movable Char where
   move (C# c) = Unsafe.toLinear (\x -> Ur (C# x)) c
 
+instance Consumable Ordering where
+  consume LT = ()
+  consume GT = ()
+  consume EQ = ()
+
+instance Dupable Ordering where
+  dup2 LT = (LT, LT)
+  dup2 GT = (GT, GT)
+  dup2 EQ = (EQ, EQ)
+
+instance Movable Ordering where
+  move LT = Ur LT
+  move GT = Ur GT
+  move EQ = Ur EQ
+
 -- TODO: instances for longer primitive tuples
 -- TODO: default instances based on the Generic framework
 


### PR DESCRIPTION
Previously the `Ord` typeclass was implemented in terms of comparison operators (`<`, `>=` eg). And since a linear `compare` does not follow from them, it was implemented as:

```haskell
compare :: (Dupable a, Ur.Ord a) => a #-> a #-> Ordering
compare = Unsafe.toLinear2 Ur.compare
```

But, as established at #209, this approach is unsound. So that would force us to remove the `compare` function. However, that is unfortunate, because in the linear setting `compare` is strictly more powerful than the others. As another point, when implementing `Ord` instances for composite types, `compare` is a lot more useful since it saves us from implementing two separate, but very similar looking functions (`<` and `>`, for example).

So, the natural conclusion is to reverse the current state of affairs, with implementing `Ord` typeclass in terms of only `compare`, and implementing the comparison operators outside of the typeclass. This way:

* We can have both comparison operators and `compare` function.
* Implementing instances is easier with `compare`. This can be seen on the instances in this patch.

Another solution would be to add `compare` to the typeclass definition alongside with the others. But that will make the comparison functions redundant since `compare` would be in each minimal complete definition anyway.

This PR implements the above change, and it adds some `Ord` (and therefore `Eq`) instances necessary for commonly used data types.