### PR TITLE
Rename Data.Vector.Linear to Data.V.Linear

### DIFF
--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -45,7 +45,7 @@ library
     Data.Set.Mutable.Linear
     Data.Tuple.Linear
     Data.Unrestricted.Linear
-    Data.Vector.Linear
+    Data.V.Linear
     Data.Vector.Mutable.Linear
     Debug.Trace.Linear
     Foreign.Marshal.Pure

--- a/src/Data/Unrestricted/Linear.hs
+++ b/src/Data/Unrestricted/Linear.hs
@@ -86,9 +86,9 @@ module Data.Unrestricted.Linear
   ) where
 
 import qualified Data.Functor.Linear.Internal as Data
-import Data.Vector.Linear (V)
 import Data.Type.Equality
-import qualified Data.Vector.Linear as V
+import Data.V.Linear (V)
+import qualified Data.V.Linear as V
 import GHC.TypeLits
 import GHC.Types hiding (Any)
 import Data.Monoid.Linear

--- a/src/Data/V/Linear.hs
+++ b/src/Data/V/Linear.hs
@@ -29,14 +29,14 @@
 -- > {-# LANGUAGE TypeFamilies #-}
 -- >
 -- > import Prelude.Linear
--- > import qualified Data.Vector.Linear as Vector
+-- > import qualified Data.V.Linear as V
 -- >
 -- > isTrue :: Bool
--- > isTrue = Vector.elim (listMaker 4 9) doSomething
+-- > isTrue = V.elim (listMaker 4 9) doSomething
 -- >   where
 -- >     -- GHC can't figure out this type equality, so this is needed.
--- >     listMaker :: Int #-> Int #-> Vector.V 2 Int
--- >     listMaker = Vector.make @2 @Int
+-- >     listMaker :: Int #-> Int #-> V.V 2 Int
+-- >     listMaker = V.make @2 @Int
 -- >
 -- > doSomething :: Int #-> Int #-> Bool
 -- > doSomething x y = lseq x (lseq y True)
@@ -48,7 +48,7 @@
 -- sense of [linear algebra](https://en.wikipedia.org/wiki/Linear_algebra),
 -- rather than linear types).
 
-module Data.Vector.Linear
+module Data.V.Linear
   ( V
   , FunN
   , elim


### PR DESCRIPTION
Closes #207.

As discussed in #207, this patch changes our vector-of-known-length module name from `Data.Vector.Linear` to `Data.V.Linear`.