### PR TITLE
Consistent ordering of linear return values

### DIFF
--- a/examples/Simple/TopSort.hs
+++ b/examples/Simple/TopSort.hs
@@ -67,16 +67,16 @@ postOrderHM nodes dag = findSources nodes (computeInDeg nodes dag) & \case
   -- Increment in-degree of all neighbors
   incChildren :: InDegGraph #-> Ur Node #-> InDegGraph
   incChildren dag (Ur node) = HMap.lookup dag node & \case
-     (dag, Ur Nothing) -> dag
-     (dag, Ur (Just (xs,i))) -> incNodes (move xs) dag
+     (Ur Nothing, dag) -> dag
+     (Ur (Just (xs,i)), dag) -> incNodes (move xs) dag
     where
       incNodes :: Ur [Node] #-> InDegGraph #-> InDegGraph
       incNodes (Ur ns) dag = Linear.foldl incNode dag (map Ur ns)
 
       incNode :: InDegGraph #-> Ur Node #-> InDegGraph
       incNode dag (Ur node) = HMap.lookup dag node & \case
-        (dag', Ur Nothing) -> dag'
-        (dag', Ur (Just (n,d))) ->
+        (Ur Nothing, dag') -> dag'
+        (Ur (Just (n,d)), dag') ->
           HMap.insert dag' node (n,d+1)
         --HMap.alter dag (\(Just (n,d)) -> Just (n,d+1)) node
 
@@ -84,8 +84,8 @@ postOrderHM nodes dag = findSources nodes (computeInDeg nodes dag) & \case
 pluckSources :: [Node] -> [Node] -> InDegGraph #-> Ur [Node]
 pluckSources [] postOrd dag = lseq dag (move postOrd)
 pluckSources (s:ss) postOrd dag = HMap.lookup dag s & \case
-  (dag, Ur Nothing) -> pluckSources ss (s:postOrd) dag
-  (dag, Ur (Just (xs,i))) -> walk xs dag & \case
+  (Ur Nothing, dag) -> pluckSources ss (s:postOrd) dag
+  (Ur (Just (xs,i)), dag) -> walk xs dag & \case
       (dag', Ur newSrcs) ->
         pluckSources (newSrcs ++ ss) (s:postOrd) dag'
   where
@@ -97,8 +97,8 @@ pluckSources (s:ss) postOrd dag = HMap.lookup dag s & \case
     -- Decrement the degree of a node, save it if it is now a source
     decDegree :: Node -> InDegGraph #-> (InDegGraph, Ur (Maybe Node))
     decDegree node dag = HMap.lookup dag node & \case
-        (dag', Ur Nothing) -> (dag', Ur Nothing)
-        (dag', Ur (Just (n,d))) ->
+        (Ur Nothing, dag') -> (dag', Ur Nothing)
+        (Ur (Just (n,d)), dag') ->
           checkSource node (HMap.insert dag' node (n,d-1))
 
 
@@ -111,9 +111,9 @@ findSources nodes dag =
 -- | Check if a node is a source, and if so return it
 checkSource :: Node -> InDegGraph #-> (InDegGraph, Ur (Maybe Node))
 checkSource node dag = HMap.lookup dag node & \case
-  (dag, Ur Nothing) -> (dag, Ur Nothing)
-  (dag, Ur (Just (xs,0))) ->  (dag, Ur (Just node))
-  (dag, Ur (Just (xs,n))) -> (dag, Ur Nothing)
+  (Ur Nothing, dag) -> (dag, Ur Nothing)
+  (Ur (Just (xs,0)), dag) ->  (dag, Ur (Just node))
+  (Ur (Just (xs,n)), dag) -> (dag, Ur Nothing)
 
 
 mapAccum ::

--- a/src/Data/Array/Mutable/Linear.hs
+++ b/src/Data/Array/Mutable/Linear.hs
@@ -92,7 +92,7 @@ alloc s x f
 
 -- | Allocate a constant array given a size and an initial value,
 -- using another array as a uniqueness proof.
-allocBeside :: Int -> a -> Array b #-> (Array b, Array a)
+allocBeside :: Int -> a -> Array b #-> (Array a, Array b)
 allocBeside s x (Array orig)
   | s < 0 =
      Unlifted.lseq
@@ -101,7 +101,7 @@ allocBeside s x (Array orig)
   | otherwise =
       wrap (Unlifted.allocBeside s x orig)
      where
-      wrap :: (# Array# b, Array# a #) #-> (Array b, Array a)
+      wrap :: (# Array# a, Array# b #) #-> (Array a, Array b)
       wrap (# orig, new #) = (Array orig, Array new)
 
 -- | Allocate an array from a list
@@ -123,11 +123,11 @@ fromList list (f :: Array a #-> Ur b) =
 -- # Mutations and Reads
 -------------------------------------------------------------------------------
 
-size :: Array a #-> (Array a, Ur Int)
+size :: Array a #-> (Ur Int, Array a)
 size (Array arr) = f (Unlifted.size arr)
  where
-  f :: (# Array# a, Ur Int #) #-> (Array a, Ur Int)
-  f (# arr, s #) = (Array arr, s)
+  f :: (# Ur Int, Array# a #) #-> (Ur Int, Array a)
+  f (# s, arr #) = (s, Array arr)
 
 -- | Writes a value to an index of an Array. The index should be less than the
 -- arrays size, otherwise this errors.
@@ -142,16 +142,16 @@ unsafeWrite (Array arr) ix val =
 
 -- | Read an index from an Array. The index should be less than the arrays size,
 -- otherwise this errors.
-read :: HasCallStack => Array a #-> Int -> (Array a, Ur a)
+read :: HasCallStack => Array a #-> Int -> (Ur a, Array a)
 read arr i = unsafeRead (assertIndexInRange i arr) i
 
 -- | Same as read, but does not do bounds-checking. The behaviour is undefined
 -- if an out-of-bounds index is provided.
-unsafeRead :: Array a #-> Int -> (Array a, Ur a)
+unsafeRead :: Array a #-> Int -> (Ur a, Array a)
 unsafeRead (Array arr) ix = wrap (Unlifted.read ix arr)
  where
-  wrap :: (# Array# a, Ur a #) #-> (Array a, Ur a)
-  wrap (# arr, ret #) = (Array arr, ret)
+  wrap :: (# Ur a, Array# a #) #-> (Ur a, Array a)
+  wrap (# ret, arr #) = (ret, Array arr)
 
 -- | Resize an array. That is, given an array, a target size, and a seed
 -- value; resize the array to the given size using the seed value to fill
@@ -175,10 +175,10 @@ resize newSize seed (Array arr :: Array a)
       doCopy (Unlifted.allocBeside newSize seed arr)
      where
       doCopy :: (# Array# a, Array# a #) #-> Array a
-      doCopy (# src, dest #) = wrap (Unlifted.copyInto 0 src dest)
+      doCopy (# new, old #) = wrap (Unlifted.copyInto 0 old new)
 
       wrap :: (# Array# a, Array# a #) #-> Array a
-      wrap (# old, new #) = old `Unlifted.lseq` Array new
+      wrap (# src, dst #) = src `Unlifted.lseq` Array dst
 
 
 -- | Return the array elements as a lazy list.
@@ -203,7 +203,7 @@ slice
   -> Array a #-> (Array a, Array a)
 slice from targetSize arr =
   size arr & \case
-    (Array old, Ur s)
+    (Ur s, Array old)
       | s < from + targetSize ->
           Unlifted.lseq
             old
@@ -216,7 +216,7 @@ slice from targetSize arr =
                old)
   where
     doCopy :: (# Array# a, Array# a #) #-> (Array a, Array a)
-    doCopy (# old, new #) = wrap (Unlifted.copyInto from old new)
+    doCopy (# new, old #) = wrap (Unlifted.copyInto from old new)
 
     wrap :: (# Array# a, Array# a  #) #-> (Array a, Array a)
     wrap (# old, new #) = (Array old, Array new)
@@ -261,7 +261,7 @@ instance Data.Functor Array where
 -- | Check if given index is within the Array, otherwise panic.
 assertIndexInRange :: HasCallStack => Int -> Array a #-> Array a
 assertIndexInRange i arr =
-  size arr & \(arr', Ur s) ->
+  size arr & \(Ur s, arr') ->
     if 0 <= i && i < s
     then arr'
     else arr' `lseq` error "Array: index out of bounds"

--- a/src/Data/HashMap/Linear.hs
+++ b/src/Data/HashMap/Linear.hs
@@ -160,10 +160,10 @@ empty size scope =
     (\arr -> scope (HashMap 0 arr))
 
 -- | Create an empty HashMap, using another as a uniqueness proof.
-allocBeside :: Keyed k => Int -> HashMap k' v' #-> (HashMap k' v', HashMap k v)
+allocBeside :: Keyed k => Int -> HashMap k' v' #-> (HashMap k v, HashMap k' v')
 allocBeside size (HashMap s' arr) =
   Array.allocBeside (max 1 size) Nothing arr & \(arr', arr'') ->
-    (HashMap s' arr', HashMap size arr'')
+    (HashMap size arr', HashMap s' arr'')
 
 -- | Run a computation with an 'HashMap' containing given key-value pairs.
 fromList :: forall k v b.
@@ -180,7 +180,7 @@ fromList xs scope =
 -- a value of the key.
 alter :: Keyed k => HashMap k v #-> k -> (Maybe v -> Maybe v) -> HashMap k v
 alter hm key f =
-  idealIndexForKey key hm & \(hm', Ur idx) ->
+  idealIndexForKey key hm & \(Ur idx, hm') ->
     probeFrom (key, 0) idx hm' & \case
       -- The key does not exist, and there is an empty cell to insert.
       (HashMap count arr, IndexToInsert psl ix) ->
@@ -195,7 +195,7 @@ alter hm key f =
              & growMapIfNecessary
       -- The key exists.
       (hm'', IndexToUpdate v psl ix) ->
-        capacity hm'' & \(HashMap count arr, Ur cap) ->
+        capacity hm'' & \(Ur cap, HashMap count arr) ->
           Ur (f (Just v)) & \case
             -- We need to delete it.
             Ur Nothing ->
@@ -216,7 +216,7 @@ alter hm key f =
           Ur Nothing -> hm
           -- We need to insert a new key.
           Ur (Just v)->
-            capacity hm & \(HashMap count arr, Ur cap) ->
+            capacity hm & \(Ur cap, HashMap count arr) ->
               tryInsertAtIndex
                 (HashMap
                   count
@@ -252,11 +252,11 @@ mapMaybe f = mapMaybeWithKey (\_k v -> f v)
 mapMaybeWithKey :: Keyed k => (k -> v -> Maybe v') -> HashMap k v #-> HashMap k v'
 mapMaybeWithKey (f :: k -> v -> Maybe v') (HashMap _ arr') =
   Array.size arr' & \case
-    (arr'', Ur 0) ->
+    (Ur 0, arr'') ->
       recurOrReturn True 0 0 0 0 arr'' & \(arr''', Ur _) ->
         HashMap 0 arr'''
-    (arr'', Ur sz) ->
-      numSpillovers arr'' & \(arr''', Ur spillovers) ->
+    (Ur sz, arr'') ->
+      numSpillovers arr'' & \(Ur spillovers, arr''') ->
         go
           spillovers
           ((sz - 1 + spillovers) `mod` sz)
@@ -273,9 +273,9 @@ mapMaybeWithKey (f :: k -> v -> Maybe v') (HashMap _ arr') =
      #-> (RobinArr k v', Ur Int)
   go curr end sz ret arr =
     Array.read arr curr & \case
-      (arr', Ur Nothing) ->
+      (Ur Nothing, arr') ->
         recurOrReturn True curr end sz ret arr'
-      (arr', Ur (Just (RobinVal psl k v))) ->
+      (Ur (Just (RobinVal psl k v)), arr') ->
         case f k v of
           Just v' ->
            Array.write arr' curr
@@ -320,8 +320,8 @@ unionWith
 unionWith onConflict (hm1 :: HashMap k v) hm2 =
   -- To insert the elements in smaller map to the larger map, we
   -- compare their capacities, and flip the arguments if necessary.
-  capacity hm1 & \(hm1', Ur cap1) ->
-    capacity hm2 & \(hm2', Ur cap2) ->
+  capacity hm1 & \(Ur cap1, hm1') ->
+    capacity hm2 & \(Ur cap2, hm2') ->
       if cap1 > cap2
       then go onConflict hm1' (toList hm2')
       else go (\v2 v1 -> onConflict v1 v2) hm2' (toList hm1')
@@ -351,9 +351,9 @@ intersectionWith
   => (a -> b -> c)
   -> HashMap k a #-> HashMap k b #-> HashMap k c
 intersectionWith combine (hm1 :: HashMap k a') hm2 =
-  allocBeside 0 hm1 & \(hm1', hmNew) ->
-    capacity hm1' & \(hm1'', Ur cap1) ->
-      capacity hm2 & \(hm2', Ur cap2) ->
+  allocBeside 0 hm1 & \(hmNew, hm1') ->
+    capacity hm1' & \(Ur cap1, hm1'') ->
+      capacity hm2 & \(Ur cap2, hm2') ->
         if cap1 > cap2
         then go combine hm1'' (toList hm2') hmNew
         else go (\v2 v1 -> combine v1 v2) hm2' (toList hm1'') hmNew
@@ -366,8 +366,8 @@ intersectionWith combine (hm1 :: HashMap k a') hm2 =
    go _ hm (Ur []) acc = hm `lseq` acc
    go f hm (Ur ((k, b):xs)) acc =
      lookup hm k & \case
-       (hm', Ur Nothing) -> go f hm' (Ur xs) acc
-       (hm', Ur (Just a)) -> go f hm' (Ur xs) (insert acc k (f a b))
+       (Ur Nothing, hm') -> go f hm' (Ur xs) acc
+       (Ur (Just a), hm') -> go f hm' (Ur xs) (insert acc k (f a b))
 
 -- |
 -- Reduce the 'HashMap' 'capacity' to decrease wasted memory. Returns
@@ -378,7 +378,7 @@ intersectionWith combine (hm1 :: HashMap k a') hm2 =
 -- Complexity: O(capacity hm)
 shrinkToFit :: Keyed k => HashMap k a #-> HashMap k a
 shrinkToFit hm =
-  size hm & \(hm', Ur size) ->
+  size hm & \(Ur size, hm') ->
     let targetSize = ceiling
           (max 1 (fromIntegral size / constMaxLoadFactor))
     in  resize targetSize hm'
@@ -387,37 +387,37 @@ shrinkToFit hm =
 --------------------------------------------------
 
 -- | Number of key-value pairs inside the 'HashMap'
-size :: HashMap k v #-> (HashMap k v, Ur Int)
-size (HashMap ct arr) = (HashMap ct arr, Ur ct)
+size :: HashMap k v #-> (Ur Int, HashMap k v)
+size (HashMap ct arr) = (Ur ct, HashMap ct arr)
 
 -- | Maximum number of elements the HashMap can store without
 -- resizing. However, for performance reasons, the 'HashMap' might be
 -- before full.
 --
 -- Use 'shrinkToFit' to reduce the wasted space.
-capacity :: HashMap k v #-> (HashMap k v, Ur Int)
+capacity :: HashMap k v #-> (Ur Int, HashMap k v)
 capacity (HashMap ct arr) =
-  Array.size arr & \(arr', len) ->
-    (HashMap ct arr', len)
+  Array.size arr & \(len, arr') ->
+    (len, HashMap ct arr')
 
 -- | Look up a value from a 'HashMap'.
-lookup :: Keyed k => HashMap k v #-> k -> (HashMap k v, Ur (Maybe v))
+lookup :: Keyed k => HashMap k v #-> k -> (Ur (Maybe v), HashMap k v)
 lookup hm k =
-  idealIndexForKey k hm & \(hm', Ur idx) ->
+  idealIndexForKey k hm & \(Ur idx, hm') ->
     probeFrom (k,0) idx hm' & \case
       (h, IndexToUpdate v _ _) ->
-        (h, Ur (Just v))
+        (Ur (Just v), h)
       (h, IndexToInsert _ _) ->
-        (h, Ur Nothing)
+        (Ur Nothing, h)
       (h, IndexToSwap _ _ _) ->
-        (h, Ur Nothing)
+        (Ur Nothing, h)
 
 -- | Check if the given key exists.
-member :: Keyed k => HashMap k v #-> k -> (HashMap k v, Ur Bool)
+member :: Keyed k => HashMap k v #-> k -> (Ur Bool, HashMap k v)
 member hm k =
   lookup hm k & \case
-    (hm, Ur Nothing) -> (hm, Ur False)
-    (hm, Ur (Just _)) -> (hm, Ur True)
+    (Ur Nothing, hm') -> (Ur False, hm')
+    (Ur (Just _), hm') -> (Ur True, hm')
 
 -- | Converts a HashMap to a lazy list.
 toList :: HashMap k v #-> Ur [(k, v)]
@@ -468,28 +468,28 @@ _debugShow (HashMap _ robinArr) =
 -- This function finds the number of spillovers. The spillovers can
 -- be determined by the length of the prefix of the array where
 -- PSL > index. This works since they form a contiguous segment.
-numSpillovers :: RobinArr k v #-> (RobinArr k v, Ur Int)
+numSpillovers :: RobinArr k v #-> (Ur Int, RobinArr k v)
 numSpillovers arr =
-  Array.size arr & \(arr', Ur sz) ->
+  Array.size arr & \(Ur sz, arr') ->
     go 0 sz arr'
  where
-  go :: Int -> Int -> RobinArr k v #-> (RobinArr k v, Ur Int)
+  go :: Int -> Int -> RobinArr k v #-> (Ur Int, RobinArr k v)
   go curr sz arr
-    | curr == sz = (arr, Ur 0) -- This should only happen when the
+    | curr == sz = (Ur 0, arr) -- This should only happen when the
                                -- Array is empty.
     | otherwise =
       Array.read arr curr & \case
-        (arr', Ur Nothing) -> (arr', Ur curr)
-        (arr', Ur (Just (RobinVal (PSL psl) _ _)))
-          | psl <= curr -> (arr', Ur curr)
+        (Ur Nothing, arr') -> (Ur curr, arr')
+        (Ur (Just (RobinVal (PSL psl) _ _)), arr')
+          | psl <= curr -> (Ur curr, arr')
           | otherwise -> go (curr+1) sz arr'
 
 idealIndexForKey
   :: Keyed k
-  => k -> HashMap k v #-> (HashMap k v, Ur Int)
+  => k -> HashMap k v #-> (Ur Int, HashMap k v)
 idealIndexForKey k hm =
-  capacity hm & \(hm', Ur cap) ->
-    (hm', Ur (mod (hash k) cap))
+  capacity hm & \(Ur cap, hm') ->
+    (Ur (mod (hash k) cap), hm')
 
 -- | Given a key, psl of the probe so far, current unread index, and
 -- a full hashmap, return a probe result: the place the key already
@@ -497,16 +497,16 @@ idealIndexForKey k hm =
 probeFrom :: Keyed k =>
   (k, PSL) -> Int -> HashMap k v #-> (HashMap k v, ProbeResult k v)
 probeFrom (k, p) ix (HashMap ct arr) = Array.read arr ix & \case
-  (arr', Ur Nothing) ->
+  (Ur Nothing, arr') ->
     (HashMap ct arr', IndexToInsert p ix)
-  (arr', Ur (Just robinVal'@(RobinVal psl k' v'))) ->
+  (Ur (Just robinVal'@(RobinVal psl k' v')), arr') ->
     case k == k' of
       -- Note: in the True case, we must have p == psl
       True -> (HashMap ct arr', IndexToUpdate v' psl ix)
       False -> case psl < p of
         True -> (HashMap ct arr', IndexToSwap robinVal' p ix)
         False ->
-          capacity (HashMap ct arr') & \(HashMap ct' arr'', Ur cap) ->
+          capacity (HashMap ct arr') & \(Ur cap, HashMap ct' arr'') ->
             probeFrom (k, p+1) ((ix+1)`mod` cap) (HashMap ct' arr'')
 
 -- | Try to insert at a given index with a given PSL. So the
@@ -520,7 +520,7 @@ tryInsertAtIndex hmap ix (RobinVal psl key val) =
     (HashMap c arr, IndexToInsert psl' ix') ->
       HashMap (c + 1) (Array.write arr ix' (Just $ RobinVal psl' key val))
     (hm, IndexToSwap oldVal psl' ix') ->
-      capacity hm  & \(HashMap ct arr, Ur cap) ->
+      capacity hm  & \(Ur cap, HashMap ct arr) ->
         tryInsertAtIndex
           (HashMap ct (Array.write arr ix' (Just $ RobinVal psl' key val)))
           ((ix' + 1) `mod` cap)
@@ -532,9 +532,9 @@ tryInsertAtIndex hmap ix (RobinVal psl key val) =
 shiftSegmentBackward :: Keyed k =>
   Int -> RobinArr k v #-> Int -> RobinArr k v
 shiftSegmentBackward s arr ix = Array.read arr ix & \case
-  (arr', Ur Nothing) -> arr'
-  (arr', Ur (Just (RobinVal 0 _ _))) -> arr'
-  (arr', Ur (Just val)) ->
+  (Ur Nothing, arr') -> arr'
+  (Ur (Just (RobinVal 0 _ _)), arr') -> arr'
+  (Ur (Just val), arr') ->
     Array.write arr' ix Nothing & \arr'' ->
       shiftSegmentBackward
         s
@@ -548,8 +548,8 @@ shiftSegmentBackward s arr ix = Array.read arr ix & \case
 -- (constMaxUtilization), resizes (constGrowthFactor) if necessary.
 growMapIfNecessary :: Keyed k => HashMap k v #-> HashMap k v
 growMapIfNecessary hm =
-  capacity hm & \(hm', Ur cap) ->
-   size hm' & \(hm'', Ur sz) ->
+  capacity hm & \(Ur cap, hm') ->
+   size hm' & \(Ur sz, hm'') ->
     let load = fromIntegral sz / fromIntegral cap
     in if load < constMaxLoadFactor
        then hm''
@@ -563,7 +563,7 @@ growMapIfNecessary hm =
 -- checked.
 resize :: Keyed k => Int -> HashMap k v #-> HashMap k v
 resize targetSize (HashMap _ arr) =
-  Array.allocBeside targetSize Nothing arr & \(oldArr, newArr) ->
+  Array.allocBeside targetSize Nothing arr & \(newArr, oldArr) ->
     Array.toList oldArr & \(Ur elems) ->
       let xs =
             elems

--- a/src/Data/List/Linear.hs
+++ b/src/Data/List/Linear.hs
@@ -116,9 +116,9 @@ reverse :: [a] #-> [a]
 reverse = Unsafe.toLinear NonLinear.reverse
 
 -- | Return the length of the given list alongside with the list itself.
-length :: [a] #-> ([a], Ur Int)
+length :: [a] #-> (Ur Int, [a])
 length = Unsafe.toLinear $ \xs ->
-  (xs, Ur (NonLinear.length xs))
+  (Ur (NonLinear.length xs), xs)
 -- We can only do this because of the fact that 'NonLinear.length'
 -- does not inspect the elements.
 

--- a/src/Data/Set/Mutable/Linear.hs
+++ b/src/Data/Set/Mutable/Linear.hs
@@ -77,13 +77,13 @@ intersection (Set hm1) (Set hm2) =
 -- # Accessors
 -------------------------------------------------------------------------------
 
-size :: Keyed a => Set a #-> (Set a, Ur Int)
+size :: Keyed a => Set a #-> (Ur Int, Set a)
 size (Set hm) =
-  Linear.size hm Linear.& \(hm', s) -> (Set hm', s)
+  Linear.size hm Linear.& \(s, hm') -> (s, Set hm')
 
-member :: Keyed a => Set a #-> a -> (Set a, Ur Bool)
+member :: Keyed a => Set a #-> a -> (Ur Bool, Set a)
 member (Set hm) a =
-  Linear.member hm a Linear.& \(hm', b) -> (Set hm', b)
+  Linear.member hm a Linear.& \(b, hm') -> (b, Set hm')
 
 fromList :: Keyed a => [a] -> (Set a #-> Ur b) #-> Ur b
 fromList xs f =

--- a/test/Test/Data/Mutable/Set.hs
+++ b/test/Test/Data/Mutable/Set.hs
@@ -63,8 +63,8 @@ testEqual :: (Show a, Eq a) =>
 testEqual (Ur x) (Ur y) = Ur (x === y)
 
 -- XXX: This is a terrible name
-getSnd :: Consumable a => (a, b) #-> b
-getSnd (a, b) = lseq a b
+getFst :: Consumable b => (a, b) #-> a
+getFst (a, b) = lseq b a
 
 -- # Tests
 --------------------------------------------------------------------------------
@@ -80,7 +80,7 @@ memberInsert1Test :: Int -> SetTester
 memberInsert1Test val set =
   testEqual
     (Ur True)
-    (getSnd (Set.member (Set.insert set val) val))
+    (getFst (Set.member (Set.insert set val) val))
 
 memberInsert2 :: Property
 memberInsert2 = property $ do
@@ -93,11 +93,11 @@ memberInsert2 = property $ do
 memberInsert2Test :: Int -> Int -> SetTester
 memberInsert2Test val1 val2 set = fromRead (Set.member set val2)
   where
-    fromRead :: (Set.Set Int, Ur Bool) #-> Ur (TestT IO ())
-    fromRead (set, memberVal2) =
+    fromRead :: (Ur Bool, Set.Set Int) #-> Ur (TestT IO ())
+    fromRead (memberVal2, set) =
       testEqual
         memberVal2
-        (getSnd (Set.member (Set.insert set val1) val2))
+        (getFst (Set.member (Set.insert set val1) val2))
 
 memberDelete1 :: Property
 memberDelete1 = property $ do
@@ -110,7 +110,7 @@ memberDelete1Test :: Int -> SetTester
 memberDelete1Test val set =
   testEqual
     (Ur False)
-    (getSnd (Set.member (Set.delete set val) val))
+    (getFst (Set.member (Set.delete set val) val))
 
 memberDelete2 :: Property
 memberDelete2 = property $ do
@@ -123,11 +123,11 @@ memberDelete2 = property $ do
 memberDelete2Test :: Int -> Int -> SetTester
 memberDelete2Test val1 val2 set = fromRead (Set.member set val2)
   where
-    fromRead :: (Set.Set Int, Ur Bool) #-> Ur (TestT IO ())
-    fromRead (set, memberVal2) =
+    fromRead :: (Ur Bool, Set.Set Int) #-> Ur (TestT IO ())
+    fromRead (memberVal2, set) =
       testEqual
         memberVal2
-        (getSnd Linear.$ Set.member (Set.delete set val1) val2)
+        (getFst Linear.$ Set.member (Set.delete set val1) val2)
 
 sizeInsert1 :: Property
 sizeInsert1 = property $ do
@@ -139,11 +139,11 @@ sizeInsert1 = property $ do
 sizeInsert1Test :: Int -> SetTester
 sizeInsert1Test val set = fromRead (Set.size set)
   where
-    fromRead :: (Set.Set Int, Ur Int) #-> Ur (TestT IO ())
-    fromRead (set, sizeOriginal) =
+    fromRead :: (Ur Int, Set.Set Int) #-> Ur (TestT IO ())
+    fromRead (sizeOriginal, set) =
       testEqual
         sizeOriginal
-        (getSnd Linear.$ (Set.size (Set.insert set val)))
+        (getFst Linear.$ (Set.size (Set.insert set val)))
 
 sizeInsert2 :: Property
 sizeInsert2 = property $ do
@@ -155,11 +155,11 @@ sizeInsert2 = property $ do
 sizeInsert2Test :: Int -> SetTester
 sizeInsert2Test val set = fromRead (Set.size set)
   where
-    fromRead :: (Set.Set Int, Ur Int) #-> Ur (TestT IO ())
-    fromRead (set, sizeOriginal) =
+    fromRead :: (Ur Int, Set.Set Int) #-> Ur (TestT IO ())
+    fromRead (sizeOriginal, set) =
       testEqual
         ((Linear.+ 1) Data.<$> sizeOriginal)
-        (getSnd Linear.$ (Set.size (Set.insert set val)))
+        (getFst Linear.$ (Set.size (Set.insert set val)))
 
 sizeDelete1 :: Property
 sizeDelete1 = property $ do
@@ -171,11 +171,11 @@ sizeDelete1 = property $ do
 sizeDelete1Test :: Int -> SetTester
 sizeDelete1Test val set = fromRead (Set.size set)
   where
-    fromRead :: (Set.Set Int, Ur Int) #-> Ur (TestT IO ())
-    fromRead (set, sizeOriginal) =
+    fromRead :: (Ur Int, Set.Set Int) #-> Ur (TestT IO ())
+    fromRead (sizeOriginal, set) =
       testEqual
         ((Linear.- 1) Data.<$> sizeOriginal)
-        (getSnd Linear.$ (Set.size (Set.delete set val)))
+        (getFst Linear.$ (Set.size (Set.delete set val)))
 
 sizeDelete2 :: Property
 sizeDelete2 = property $ do
@@ -187,8 +187,8 @@ sizeDelete2 = property $ do
 sizeDelete2Test :: Int -> SetTester
 sizeDelete2Test val set = fromRead (Set.size set)
   where
-    fromRead :: (Set.Set Int, Ur Int) #-> Ur (TestT IO ())
-    fromRead (set, sizeOriginal) =
+    fromRead :: (Ur Int, Set.Set Int) #-> Ur (TestT IO ())
+    fromRead (sizeOriginal, set) =
       testEqual
         sizeOriginal
-        (getSnd Linear.$ (Set.size (Set.delete set val)))
+        (getFst Linear.$ (Set.size (Set.delete set val)))


### PR DESCRIPTION
Closes #191 .

This PR flips the returned tuples at linear mutable collections, so the "actual" return value is at the `fst`, and the collection to thread linearly is at `snd`.

No other changes. If there are any (not type-checked) documentation referring to the type signatures, they need to be fixed too.

See the discussion at #191 for more details.