### PR TITLE
Fix type errors on inline examples

### DIFF
--- a/src/Data/Array/Mutable/Linear.hs
+++ b/src/Data/Array/Mutable/Linear.hs
@@ -19,9 +19,9 @@
 -- == A Tiny Example
 --
 -- > {-# LANGUAGE LinearTypes #-}
+-- > {-# LANGUAGE NoImplicitPrelude #-}
+-- >
 -- > import Prelude.Linear
--- > import Data.Unrestricted.Linear
--- > import qualified Unsafe.Linear as Unsafe
 -- > import qualified Data.Array.Mutable.Linear as Array
 -- >
 -- > isTrue :: Bool
@@ -31,13 +31,9 @@
 -- > isFalse = unur $ Array.fromList [1,2,3] isFirstZero
 -- >
 -- > isFirstZero :: Array.Array Int #-> Ur Bool
--- > isFirstZero arr = withReadingFirst (Array.read arr 0)
--- >   where
--- >     withReadingFirst :: (Array.Array Int, Int) #-> Ur Bool
--- >     withReadingFirst (arr, i) = lseq arr $ move (i === 0)
--- >
--- > (===) :: (Num a, Eq a) => a #-> a #-> Bool
--- > (===) = Unsafe.toLinear2 (==)
+-- > isFirstZero arr =
+-- >   Array.read arr 0
+-- >     & \(arr', Ur val) -> arr' `lseq` Ur (val == 0)
 module Data.Array.Mutable.Linear
   ( -- * Mutable Linear Arrays
     Array,

--- a/src/System/IO/Linear.hs
+++ b/src/System/IO/Linear.hs
@@ -21,7 +21,6 @@
 -- = Example
 -- @
 -- import qualified System.IO.Linear as Linear
--- import qualified Prelude.Linear as Linear
 --
 -- main :: IO ()
 -- main = Linear.withLinearIO $

--- a/src/System/IO/Resource.hs
+++ b/src/System/IO/Resource.hs
@@ -22,17 +22,16 @@
 -- = A simple example
 -- > {-# LANGUAGE LinearTypes #-}
 -- > {-# LANGUAGE QualifiedDo #-}
--- > {-# LANGUAGE RecordWildCards #-}
+-- > {-# LANGUAGE NoImplicitPrelude #-}
 -- >
 -- > import qualified System.IO.Resource as Linear
 -- > import qualified Control.Monad.Linear as Control
 -- > import qualified Data.Text as Text
--- > import Data.Unrestricted.Linear
--- > import System.IO
--- > import Prelude
+-- > import Prelude.Linear
+-- > import qualified Prelude
 -- >
 -- > linearWriteToFile :: IO ()
--- > linearWriteToFile = Linear.run $ Control.do
+-- > linearWriteToFile = Linear.run Prelude.$ Control.do
 -- >   handle1 <- Linear.openFile "/home/user/test.txt" WriteMode
 -- >   handle2 <- Linear.hPutStrLn handle1 (Text.pack "hello there")
 -- >   () <- Linear.hClose handle2
@@ -49,7 +48,8 @@ module System.IO.Resource
     -- $files
   , Handle
     -- ** File I/O
-  , openFile 
+  , openFile
+  , System.IOMode (..)
     -- ** Working with Handles
   , hClose
   , hIsEOF


### PR DESCRIPTION
I saw a few type errors on the inline examples, and fixed them; sometimes with slight stylistic modifications. We should use something like `doctest` to ensure that they do not get out-of-sync with the code. I'll create an issue.

This also adds a new export to `System.Resource.Linear` to ensure that the `openFile` method there can be used without importing `System.IO` too. This removes an import from an example.