### PR TITLE
Add doctest

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,2 +1,6 @@
-import Distribution.Simple
-main = defaultMain
+module Main where
+
+import Distribution.Extra.Doctest (defaultMainWithDoctests)
+
+main :: IO ()
+main = defaultMainWithDoctests "doctests"

--- a/cabal.project
+++ b/cabal.project
@@ -19,3 +19,15 @@ source-repository-package
   location: https://github.com/utdemir/haskell-hedgehog.git
   tag: c98aa9e33bf6871098d6f4ac94eeaac10383d696
   subdir: hedgehog
+
+source-repository-package
+  -- https://github.com/dreixel/syb/pull/25
+  type: git
+  location: https://github.com/utdemir/syb.git
+  tag: a072e20d7a5806779486646418fa20c5ffd99a4f
+
+source-repository-package
+  -- https://github.com/sol/doctest/pull/272
+  type: git
+  location: https://github.com/utdemir/doctest.git
+  tag: 090cccaf12c5643ca80f8c2afe693a488277d365

--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -8,10 +8,16 @@ author: Tweag
 maintainer: arnaud.spiwack@tweag.io
 copyright: (c) Tweag Holding and affiliates
 category: Prelude
-build-type: Simple
+build-type: Custom
 extra-source-files: README.md
 synopsis: Standard library for linear types.
 description: Please see README.md.
+
+custom-setup
+ setup-depends:
+   base >= 4 && <5,
+   Cabal,
+   cabal-doctest
 
 library
   hs-source-dirs: src
@@ -121,6 +127,16 @@ test-suite examples
     text
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   default-language: Haskell2010
+
+test-suite doctests
+  type:                 exitcode-stdio-1.0
+  hs-source-dirs:       test/
+  main-is:              Doctest.hs
+  build-depends:        base
+                      , doctest
+                      , linear-base
+  ghc-options:          -Wall -threaded
+  default-language:     Haskell2010
 
 source-repository head
   type: git

--- a/src/Data/Array/Mutable/Linear.hs
+++ b/src/Data/Array/Mutable/Linear.hs
@@ -18,22 +18,21 @@
 --
 -- == A Tiny Example
 --
--- > {-# LANGUAGE LinearTypes #-}
--- > {-# LANGUAGE NoImplicitPrelude #-}
--- >
--- > import Prelude.Linear
--- > import qualified Data.Array.Mutable.Linear as Array
--- >
--- > isTrue :: Bool
--- > isTrue = unur $ Array.fromList [0..10] isFirstZero
--- >
--- > isFalse :: Bool
--- > isFalse = unur $ Array.fromList [1,2,3] isFirstZero
--- >
--- > isFirstZero :: Array.Array Int #-> Ur Bool
--- > isFirstZero arr =
--- >   Array.read arr 0
--- >     & \(arr', Ur val) -> arr' `lseq` Ur (val == 0)
+-- >>> :set -XLinearTypes
+-- >>> :set -XNoImplicitPrelude
+-- >>> import Prelude.Linear
+-- >>> import qualified Data.Array.Mutable.Linear as Array
+-- >>> :{
+--  isFirstZero :: Array.Array Int #-> Ur Bool
+--  isFirstZero arr =
+--    Array.read arr 0
+--      & \(Ur val, arr') -> arr' `lseq` Ur (val == 0)
+-- :}
+--
+-- >>> unur $ Array.fromList [0..10] isFirstZero
+-- True
+-- >>> unur $ Array.fromList [1,2,3] isFirstZero
+-- False
 module Data.Array.Mutable.Linear
   ( -- * Mutable Linear Arrays
     Array,

--- a/src/Data/V/Linear.hs
+++ b/src/Data/V/Linear.hs
@@ -23,24 +23,25 @@
 -- Make these vectors by giving any finite number of arguments to 'make'
 -- and use them with 'elim':
 --
--- > {-# LANGUAGE LinearTypes #-}
--- > {-# LANGUAGE TypeApplications #-}
--- > {-# LANGUAGE TypeInType #-}
--- > {-# LANGUAGE TypeFamilies #-}
--- >
--- > import Prelude.Linear
--- > import qualified Data.V.Linear as V
--- >
--- > isTrue :: Bool
--- > isTrue = V.elim (listMaker 4 9) doSomething
--- >   where
--- >     -- GHC can't figure out this type equality, so this is needed.
--- >     listMaker :: Int #-> Int #-> V.V 2 Int
--- >     listMaker = V.make @2 @Int
--- >
--- > doSomething :: Int #-> Int #-> Bool
--- > doSomething x y = lseq x (lseq y True)
+-- >>> :set -XLinearTypes
+-- >>> :set -XTypeApplications
+-- >>> :set -XTypeInType
+-- >>> :set -XTypeFamilies
+-- >>> import Prelude.Linear
+-- >>> import qualified Data.V.Linear as V
+-- >>> :{
+--  doSomething :: Int #-> Int #-> Bool
+--  doSomething x y = x + y > 0
+-- :}
 --
+-- >>> :{
+--  isTrue :: Bool
+--  isTrue = V.elim (build 4 9) doSomething
+--    where
+--      -- GHC can't figure out this type equality, so this is needed.
+--      build :: Int #-> Int #-> V.V 2 Int
+--      build = V.make @2 @Int
+-- :}
 --
 -- A much more expensive library of vectors of known size (including matrices
 -- and tensors of all dimensions) is the [@linear@ library on

--- a/src/Data/Vector/Mutable/Linear.hs
+++ b/src/Data/Vector/Mutable/Linear.hs
@@ -20,28 +20,20 @@
 --
 -- == Example
 --
--- > {-# LANGUAGE LinearTypes #-}
--- > import Prelude.Linear
--- > import Data.Ur.Linear
--- > import qualified Unsafe.Linear as Unsafe
--- > import qualified Data.Vector.Mutable.Linear as Vector
--- >
--- > isTrue :: Bool
--- > isTrue = unur $ Vector.fromList [0..10] isFirstZero
--- >
--- > isFalse :: Bool
--- > isFalse = unur $ Vector.fromList [1,2,3] isFirstZero
--- >
--- > isFirstZero :: Vector.Vector Int #-> Ur Bool
--- > isFirstZero arr = withReadingFirst (Vector.read arr 0)
--- >   where
--- >     withReadingFirst :: (Vector.Vector Int, Int) #-> Ur Bool
--- >     withReadingFirst (arr, i) = lseq arr $ move (i === 0)
--- >
--- > (===) :: (Num a, Eq a) => a #-> a #-> Bool
--- > (===) = Unsafe.toLinear2 (==)
+-- >>> :set -XLinearTypes
+-- >>> import Prelude.Linear
+-- >>> import qualified Data.Vector.Mutable.Linear as Vector
+-- >>> :{
+--  isFirstZero :: Vector.Vector Int #-> Ur Bool
+--  isFirstZero vec =
+--    Vector.read vec 0
+--      & \(Ur ret, vec) -> vec `lseq` Ur (ret == 0)
+-- :}
 --
---
+-- >>> unur $ Vector.fromList [0..10] isFirstZero
+-- True
+-- >>> unur $ Vector.fromList [1,2,3] isFirstZero
+-- False
 module Data.Vector.Mutable.Linear
   ( -- * A mutable vector
     Vector,

--- a/src/Foreign/Marshal/Pure.hs
+++ b/src/Foreign/Marshal/Pure.hs
@@ -36,15 +36,17 @@
 --
 -- A toy example:
 --
--- > {-# LANGUAGE LinearTypes #-}
--- > import Data.Unrestricted.Linear
--- > import qualified Foreign.Marshal.Pure as Manual
--- >
--- > three :: Int
--- > three = unur (Manual.withPool nothingWith3)
--- >
--- > nothingWith3 :: Pool #-> Ur Int
--- > nothingWith3 pool = move (Manual.deconstruct (Manual.alloc 3 pool))
+-- >>> :set -XLinearTypes
+-- >>> import Data.Unrestricted.Linear
+-- >>> import qualified Foreign.Marshal.Pure as Manual
+-- >>> :{
+--   nothingWith3 :: Pool #-> Ur Int
+--   nothingWith3 pool = move (Manual.deconstruct (Manual.alloc 3 pool))
+-- :}
+--
+-- >>> unur (Manual.withPool nothingWith3)
+-- 3
+--
 --
 -- === What are 'Pool's?
 --

--- a/src/Prelude/Linear.hs
+++ b/src/Prelude/Linear.hs
@@ -7,16 +7,19 @@
 --
 -- A simple example:
 --
--- > {-# LANGUAGE LinearTypes #-}
--- > {-# LANGUAGE NoImplicitPrelude #-}
--- > import Prelude.Linear
--- >
--- > makeInt :: Either Int Bool #-> Int
--- > makeInt = either id boolToInt
--- >
--- > boolToInt :: Bool #-> Int
--- > boolToInt False = 0
--- > boolToInt True = 1
+-- >>> :set -XLinearTypes
+-- >>> :set -XNoImplicitPrelude
+-- >>> import Prelude.Linear
+-- >>> :{
+--   boolToInt :: Bool #-> Int
+--   boolToInt False = 0
+--   boolToInt True = 1
+-- :}
+--
+-- >>> :{
+--   makeInt :: Either Int Bool #-> Int
+--   makeInt = either id boolToInt
+-- :}
 --
 -- This module is designed to be imported unqualifed.
 

--- a/src/Streaming/Internal/Consume.hs
+++ b/src/Streaming/Internal/Consume.hs
@@ -83,7 +83,7 @@ import qualified Control.Monad.Linear as Control
 {-| Write 'String's to 'System.stdout' using 'Text.putStrLn'; terminates on a broken output pipe
     (The name and implementation are modelled on the @Pipes.Prelude@ @stdoutLn@).
 
->>> withLinearIO $ Control.fmap move $ S.stdoutLn $ S.each $ words "one two three"
+\>\>\> withLinearIO $ Control.fmap move $ S.stdoutLn $ S.each $ words "one two three"
 one
 two
 three
@@ -136,8 +136,8 @@ writeFile filepath stream = Control.do
 
 {- | Reduce a stream, performing its actions but ignoring its elements.
 
->>> rest <- S.effects $ S.splitAt 2 $ each' [1..5]
->>> S.print rest
+\>\>\> rest <- S.effects $ S.splitAt 2 $ each' [1..5]
+\>\>\> S.print rest
 3
 4
 5
@@ -178,10 +178,10 @@ erase stream = loop stream where
 
    Here, for example, we split a stream in two places and throw out the middle segment:
 
->>> rest <- S.print $ S.drained $ S.splitAt 2 $ S.splitAt 5 $ each' [1..7]
+\>\>\> rest <- S.print $ S.drained $ S.splitAt 2 $ S.splitAt 5 $ each' [1..7]
 1
 2
->>> S.print rest
+\>\>\> S.print rest
 6
 7
 
@@ -197,17 +197,17 @@ drained = Control.join . Control.fmap (Control.lift . effects)
 
 {-| Reduce a stream to its return value with a monadic action.
 
->>> S.mapM_ Prelude.print $ each' [1..3]
+\>\>\> S.mapM_ Prelude.print $ each' [1..3]
 1
 2
 3
 
 
->>> rest <- S.mapM_ Prelude.print $ S.splitAt 3 $ each' [1..10]
+\>\>\> rest <- S.mapM_ Prelude.print $ S.splitAt 3 $ each' [1..10]
 1
 2
 3
->>> S.sum rest
+\>\>\> S.sum rest
 49 :> ()
 
 -}
@@ -233,10 +233,10 @@ mapM_  f stream = loop stream where
    This does not short circuit and all effects are performed.
    The third parameter will often be 'id' where a fold is written by hand:
 
->>> S.fold (+) 0 id $ each' [1..10]
+\>\>\> S.fold (+) 0 id $ each' [1..10]
 55 :> ()
 
->>> S.fold (*) 1 id $ S.fold (+) 0 id $ S.copy $ each' [1..10]
+\>\>\> S.fold (*) 1 id $ S.fold (+) 0 id $ S.copy $ each' [1..10]
 3628800 :> (55 :> ())
 
     It can be used to replace a standard Haskell type with one more suited to
@@ -254,7 +254,7 @@ mapM_  f stream = loop stream where
     Here we use the Applicative instance for @Control.Foldl.Fold@ to
     stream three-item segments of a stream together with their sums and products.
 
->>> S.print $ mapped (L.purely S.fold (liftA3 (,,) L.list L.product L.sum)) $ chunksOf 3 $ each' [1..10]
+\>\>\> S.print $ mapped (L.purely S.fold (liftA3 (,,) L.list L.product L.sum)) $ chunksOf 3 $ each' [1..10]
 ([1,2,3],6,6)
 ([4,5,6],120,15)
 ([7,8,9],504,24)
@@ -276,7 +276,7 @@ fold f x g stream = loop stream where
     are performed. The third parameter will often be 'id' where a fold
     is written by hand:
 
->>> S.fold_ (+) 0 id $ each [1..10]
+\>\>\> S.fold_ (+) 0 id $ each [1..10]
 55
 
     It can be used to replace a standard Haskell type with one more suited to
@@ -308,7 +308,7 @@ fold_ f x g stream = loop stream where
    Thus to accumulate the elements of a stream as a vector, together with a random
    element we might write:
 
->>> L.impurely S.foldM (liftA2 (,) L.vectorM L.random) $ each' [1..10::Int] :: IO (Of (Vector Int, Maybe Int) ())
+\>\>\> L.impurely S.foldM (liftA2 (,) L.vectorM L.random) $ each' [1..10::Int] :: IO (Of (Vector Int, Maybe Int) ())
 ([1,2,3,4,5,6,7,8,9,10],Just 9) :> ()
 
 -}
@@ -361,16 +361,16 @@ any_ f stream = fold_ (||) False id (map f stream)
 >  mapped S.sum :: Stream (Stream (Of Int)) m r #-> Stream (Of Int) m r
 
 
->>> S.sum $ each' [1..10]
+\>\>\> S.sum $ each' [1..10]
 55 :> ()
 
->>> (n :> rest)  <- S.sum $ S.splitAt 3 $ each' [1..10]
->>> System.IO.print n
+\>\>\> (n :> rest)  <- S.sum $ S.splitAt 3 $ each' [1..10]
+\>\>\> System.IO.print n
 6
->>> (m :> rest') <- S.sum $ S.splitAt 3 rest
->>> System.IO.print m
+\>\>\> (m :> rest') <- S.sum $ S.splitAt 3 rest
+\>\>\> System.IO.print m
 15
->>> S.print rest'
+\>\>\> S.print rest'
 7
 8
 9
@@ -479,7 +479,7 @@ notElem_ a stream = Control.fmap Linear.not $ elem_ a stream
 
 {-| Run a stream, keeping its length and its return value.
 
->>> S.print $ mapped S.length $ chunksOf 3 $ S.each' [1..10]
+\>\>\> S.print $ mapped S.length $ chunksOf 3 $ S.each' [1..10]
 3
 3
 3
@@ -493,7 +493,7 @@ length = fold (\n _ -> n + 1) 0 id
 
 {-| Run a stream, remembering only its length:
 
->>> runIdentity $ S.length_ (S.each [1..10] :: Stream (Of Int) Identity ())
+\>\>\> runIdentity $ S.length_ (S.each [1..10] :: Stream (Of Int) Identity ())
 10
 
 -}
@@ -508,12 +508,12 @@ length_ = fold_ (\n _ -> n + 1) 0 id
     Like 'toList_', 'toList' breaks streaming; unlike 'toList_' it /preserves the return value/
     and thus is frequently useful with e.g. 'mapped'
 
->>> S.print $ mapped S.toList $ chunksOf 3 $ each' [1..9]
+\>\>\> S.print $ mapped S.toList $ chunksOf 3 $ each' [1..9]
 [1,2,3]
 [4,5,6]
 [7,8,9]
 
->>> S.print $ mapped S.toList $ chunksOf 2 $ S.replicateM 4 getLine
+\>\>\> S.print $ mapped S.toList $ chunksOf 2 $ S.replicateM 4 getLine
 s<Enter>
 t<Enter>
 ["s","t"]

--- a/src/Streaming/Internal/Many.hs
+++ b/src/Streaming/Internal/Many.hs
@@ -57,18 +57,18 @@ import qualified Control.Monad.Linear as Control
    This @unzip@ does
    stream, though of course you can spoil this by using e.g. 'toList':
 
->>> let xs = Prelude.map (\x -> (x, Prelude.show x)) [1..5 :: Int]
+\>\>\> let xs = Prelude.map (\x -> (x, Prelude.show x)) [1..5 :: Int]
 
->>> S.toList $ S.toList $ S.unzip (S.each' xs)
+\>\>\> S.toList $ S.toList $ S.unzip (S.each' xs)
 ["1","2","3","4","5"] :> ([1,2,3,4,5] :> ())
 
->>> Prelude.unzip xs
+\>\>\> Prelude.unzip xs
 ([1,2,3,4,5],["1","2","3","4","5"])
 
     Note the difference of order in the results. It may be of some use to think why.
     The first application of 'toList' was applied to a stream of integers:
 
->>> :t S.unzip $ S.each' xs
+\>\>\> :t S.unzip $ S.each' xs
 S.unzip $ S.each' xs :: Control.Monad m => Stream (Of Int) (Stream (Of String) m) ()
 
     Like any fold, 'toList' takes no notice of the monad of effects.
@@ -79,14 +79,14 @@ S.unzip $ S.each' xs :: Control.Monad m => Stream (Of Int) (Stream (Of String) m
     So when I apply 'toList', I exhaust that stream of integers, folding
     it into a list:
 
->>> :t S.toList $ S.unzip $ S.each' xs
+\>\>\> :t S.toList $ S.unzip $ S.each' xs
 S.toList $ S.unzip $ S.each' xs
   :: Control.Monad m => Stream (Of String) m (Of [Int] ())
 
     When I apply 'toList' to /this/, I reduce everything to an ordinary action in @IO@,
     and return a list of strings:
 
->>> S.toList $ S.toList $ S.unzip (S.each' xs)
+\>\>\> S.toList $ S.toList $ S.unzip (S.each' xs)
 ["1","2","3","4","5"] :> ([1,2,3,4,5] :> ())
 
 'unzip' can be considered a special case of either 'unzips' or 'expand':
@@ -304,7 +304,7 @@ extractResult (Right s) = effects s
 
    The return values of both streams are returned.
 
->>> S.print $ merge (each [1,3,5]) (each [2,4])
+\>\>\> S.print $ merge (each [1,3,5]) (each [2,4])
 1
 2
 3

--- a/src/Streaming/Internal/Many.hs
+++ b/src/Streaming/Internal/Many.hs
@@ -57,6 +57,7 @@ import qualified Control.Monad.Linear as Control
    This @unzip@ does
    stream, though of course you can spoil this by using e.g. 'toList':
 
+@
 \>\>\> let xs = Prelude.map (\x -> (x, Prelude.show x)) [1..5 :: Int]
 
 \>\>\> S.toList $ S.toList $ S.unzip (S.each' xs)
@@ -64,12 +65,15 @@ import qualified Control.Monad.Linear as Control
 
 \>\>\> Prelude.unzip xs
 ([1,2,3,4,5],["1","2","3","4","5"])
+@
 
     Note the difference of order in the results. It may be of some use to think why.
     The first application of 'toList' was applied to a stream of integers:
 
+@
 \>\>\> :t S.unzip $ S.each' xs
 S.unzip $ S.each' xs :: Control.Monad m => Stream (Of Int) (Stream (Of String) m) ()
+@
 
     Like any fold, 'toList' takes no notice of the monad of effects.
 
@@ -79,15 +83,19 @@ S.unzip $ S.each' xs :: Control.Monad m => Stream (Of Int) (Stream (Of String) m
     So when I apply 'toList', I exhaust that stream of integers, folding
     it into a list:
 
+@
 \>\>\> :t S.toList $ S.unzip $ S.each' xs
 S.toList $ S.unzip $ S.each' xs
   :: Control.Monad m => Stream (Of String) m (Of [Int] ())
+@
 
     When I apply 'toList' to /this/, I reduce everything to an ordinary action in @IO@,
     and return a list of strings:
 
+@
 \>\>\> S.toList $ S.toList $ S.unzip (S.each' xs)
 ["1","2","3","4","5"] :> ([1,2,3,4,5] :> ())
+@
 
 'unzip' can be considered a special case of either 'unzips' or 'expand':
 
@@ -304,6 +312,7 @@ extractResult (Right s) = effects s
 
    The return values of both streams are returned.
 
+@
 \>\>\> S.print $ merge (each [1,3,5]) (each [2,4])
 1
 2
@@ -311,6 +320,7 @@ extractResult (Right s) = effects s
 4
 5
 ((), ())
+@
 
 -}
 merge :: (Control.Monad m, Ord a) =>

--- a/src/Streaming/Internal/Process.hs
+++ b/src/Streaming/Internal/Process.hs
@@ -192,7 +192,7 @@ splitAt n stream = loop n stream where
 {-| Split a stream of elements wherever a given element arises.
     The action is like that of 'Prelude.words'.
 
->>> S.stdoutLn $ mapped S.toList $ S.split ' ' $ each' "hello world  "
+\>\>\> S.stdoutLn $ mapped S.toList $ S.split ' ' $ each' "hello world  "
 hello
 world
 
@@ -213,10 +213,10 @@ split x stream = loop stream
 {-| Break a sequence upon meeting an element that falls under a predicate,
     keeping it and the rest of the stream as the return value.
 
->>> rest <- S.print $ S.break even $ each' [1,1,2,3]
+\>\>\> rest <- S.print $ S.break even $ each' [1,1,2,3]
 1
 1
->>> S.print rest
+\>\>\> S.print rest
 2
 3
 
@@ -237,10 +237,10 @@ break f stream = loop stream
 {-| Break during periods where the predicate is not satisfied,
    grouping the periods when it is.
 
->>> S.print $ mapped S.toList $ S.breaks not $ S.each' [False,True,True,False,True,True,False]
+\>\>\> S.print $ mapped S.toList $ S.breaks not $ S.each' [False,True,True,False,True,True,False]
 [True,True]
 [True,True]
->>> S.print $ mapped S.toList $ S.breaks id $ S.each' [False,True,True,False,True,True,False]
+\>\>\> S.print $ mapped S.toList $ S.breaks id $ S.each' [False,True,True,False,True,True,False]
 [False]
 [False]
 [False]
@@ -267,12 +267,12 @@ breaks f stream = loop stream
    and the element that breaks it will be put after the break.
    This function is easiest to use with 'Control.Foldl.purely'
 
->>> rest <- each' [1..10] & L.purely S.breakWhen L.sum (>10) & S.print
+\>\>\> rest <- each' [1..10] & L.purely S.breakWhen L.sum (>10) & S.print
 1
 2
 3
 4
->>> S.print rest
+\>\>\> S.print rest
 5
 6
 7
@@ -310,7 +310,7 @@ span f = break (Prelude.not Prelude.. f)
 {-| Group elements of a stream in accordance with the supplied comparison.
 
 
->>> S.print $ mapped S.toList $ S.groupBy (>=) $ each' [1,2,3,1,2,3,4,3,2,4,5,6,7,6,5]
+\>\>\> S.print $ mapped S.toList $ S.groupBy (>=) $ each' [1,2,3,1,2,3,4,3,2,4,5,6,7,6,5]
 [1]
 [2]
 [3,1,2,3]
@@ -341,10 +341,10 @@ groupBy equals stream = loop stream
 
 {-| Group successive equal items together
 
->>> S.toList $ mapped S.toList $ S.group $ each' "baaaaad"
+\>\>\> S.toList $ mapped S.toList $ S.group $ each' "baaaaad"
 ["b","aaaaa","d"] :> ()
 
->>> S.toList $ concats $ maps (S.drained . S.splitAt 1) $ S.group $ each' "baaaaaaad"
+\>\>\> S.toList $ concats $ maps (S.drained . S.splitAt 1) $ S.group $ each' "baaaaaaad"
 "bad" :> ()
 
 -}
@@ -367,12 +367,12 @@ distinguish predicate (a :> b) = case predicate a of
 
 {-| Swap the order of functors in a sum of functors.
 
->>> S.toList $ S.print $ separate $ maps S.switch $ maps (S.distinguish (=='a')) $ S.each' "banana"
+\>\>\> S.toList $ S.print $ separate $ maps S.switch $ maps (S.distinguish (=='a')) $ S.each' "banana"
 'a'
 'a'
 'a'
 "bnn" :> ()
->>> S.toList $ S.print $ separate $ maps (S.distinguish (=='a')) $ S.each' "banana"
+\>\>\> S.toList $ S.print $ separate $ maps (S.distinguish (=='a')) $ S.each' "banana"
 'b'
 'n'
 'n'
@@ -412,14 +412,14 @@ sumToCompose x = case x of
     other material for another treatment. It generalizes
     'Data.Either.partitionEithers', but actually streams properly.
 
->>> let odd_even = S.maps (S.distinguish even) $ S.each' [1..10::Int]
->>> :t separate odd_even
+\>\>\> let odd_even = S.maps (S.distinguish even) $ S.each' [1..10::Int]
+\>\>\> :t separate odd_even
 separate odd_even
   :: Monad m => Stream (Of Int) (Stream (Of Int) m) ()
 
     Now, for example, it is convenient to fold on the left and right values separately:
 
->>> S.toList $ S.toList $ separate odd_even
+\>\>\> S.toList $ S.toList $ separate odd_even
 [2,4,6,8,10] :> ([1,3,5,7,9] :> ())
 
 
@@ -428,7 +428,7 @@ separate odd_even
    Of course, in the special case of @Stream (Of a) m r@, we can achieve the above
    effects more simply by using 'Streaming.Prelude.copy'
 
->>> S.toList . S.filter even $ S.toList . S.filter odd $ S.copy $ each' [1..10::Int]
+\>\>\> S.toList . S.filter even $ S.toList . S.filter odd $ S.copy $ each' [1..10::Int]
 [2,4,6,8,10] :> ([1,3,5,7,9] :> ())
 
 
@@ -575,7 +575,7 @@ hoist f stream = loop stream where
 
 {-| Standard map on the elements of a stream.
 
->>> S.stdoutLn $ S.map reverse $ each' (words "alpha beta")
+\>\>\> S.stdoutLn $ S.map reverse $ each' (words "alpha beta")
 ahpla
 ateb
 -}
@@ -586,7 +586,7 @@ map f = maps (\(x :> rest) -> f x :> rest)
 -- Remark.
 --
 -- The functor transformation in functions like maps, mapped, mapsPost,
--- and such must be linear since the 'Stream' data type holds each 
+-- and such must be linear since the 'Stream' data type holds each
 -- functor step with a linear arrow.
 
 {- | Map layers of one functor to another with a transformation. Compare
@@ -615,7 +615,7 @@ maps phi = loop
 --
 {-| Replace each element of a stream with the result of a monadic action
 
->>> S.print $ S.mapM readIORef $ S.chain (\ior -> modifyIORef ior (*100)) $ S.mapM newIORef $ each' [1..6]
+\>\>\> S.print $ S.mapM readIORef $ S.chain (\ior -> modifyIORef ior (*100)) $ S.mapM newIORef $ each' [1..6]
 100
 200
 300
@@ -662,7 +662,7 @@ mapsPost phi = loop
 {-# INLINABLE mapsPost #-}
 
 {- | Map layers of one functor to another with a transformation involving the base monad.
- 
+
      This function is completely functor-general. It is often useful with the more concrete type
 
 @
@@ -676,7 +676,7 @@ mapped :: (forall x. Stream (Of a) IO x -> IO (Of b x)) -> Stream (Stream (Of a)
      'Streaming.Prelude.mconcat' or 'Streaming.Prelude.toList' are often used
      to define the transformation argument. For example:
 
->>> S.toList_ $ S.mapped S.toList $ S.split 'c' (S.each' "abcde")
+\>\>\> S.toList_ $ S.mapped S.toList $ S.split 'c' (S.each' "abcde")
 ["ab","de"]
 
      'Streaming.Prelude.maps' and 'Streaming.Prelude.mapped' obey these rules:
@@ -777,7 +777,7 @@ for stream expand = loop stream
 > with = flip subst
 > subst = flip with
 
->>> with (each' [1..3]) (yield . Prelude.show) & intercalates (yield "--") & S.stdoutLn
+\>\>\> with (each' [1..3]) (yield . Prelude.show) & intercalates (yield "--") & S.stdoutLn
 1
 --
 2
@@ -815,16 +815,16 @@ subst = flip with where
 {-| Duplicate the content of a stream, so that it can be acted on twice in different ways,
     but without breaking streaming. Thus, with @each' [1,2]@ I might do:
 
->>> S.print $ each' ["one","two"]
+\>\>\> S.print $ each' ["one","two"]
 "one"
 "two"
->>> S.stdoutLn $ each' ["one","two"]
+\>\>\> S.stdoutLn $ each' ["one","two"]
 one
 two
 
     With copy, I can do these simultaneously:
 
->>> S.print $ S.stdoutLn $ S.copy $ each' ["one","two"]
+\>\>\> S.print $ S.stdoutLn $ S.copy $ each' ["one","two"]
 "one"
 one
 "two"
@@ -842,29 +842,29 @@ two
     folds is often more straightforwardly effected with `Control.Foldl`,
     e.g.
 
->>> L.purely S.fold (liftA2 (,) L.sum L.product) $ each' [1..10]
+\>\>\> L.purely S.fold (liftA2 (,) L.sum L.product) $ each' [1..10]
 (55,3628800) :> ()
 
     rather than
 
->>> S.sum $ S.product . S.copy $ each' [1..10]
+\>\>\> S.sum $ S.product . S.copy $ each' [1..10]
 55 :> (3628800 :> ())
 
     A @Control.Foldl@ fold can be altered to act on a selection of elements by
     using 'Control.Foldl.handles' on an appropriate lens. Some such
     manipulations are simpler and more 'Data.List'-like, using 'copy':
 
->>> L.purely S.fold (liftA2 (,) (L.handles (L.filtered odd) L.sum) (L.handles (L.filtered even) L.product)) $ each' [1..10]
+\>\>\> L.purely S.fold (liftA2 (,) (L.handles (L.filtered odd) L.sum) (L.handles (L.filtered even) L.product)) $ each' [1..10]
 (25,3840) :> ()
 
      becomes
 
->>> S.sum $ S.filter odd $ S.product $ S.filter even $ S.copy' $ each' [1..10]
+\>\>\> S.sum $ S.filter odd $ S.product $ S.filter even $ S.copy' $ each' [1..10]
 25 :> (3840 :> ())
 
     or using 'store'
 
->>> S.sum $ S.filter odd $ S.store (S.product . S.filter even) $ each' [1..10]
+\>\>\> S.sum $ S.filter odd $ S.store (S.product . S.filter even) $ each' [1..10]
 25 :> (3840 :> ())
 
     But anything that fold of a @Stream (Of a) m r@ into e.g. an @m (Of b r)@
@@ -872,12 +872,12 @@ two
     e.g. @Control.Monad@, @Control.Functor@, etc. can be used on the stream.
     Thus, I can fold over different groupings of the original stream:
 
->>>  (S.toList . mapped S.toList . chunksOf 5) $  (S.toList . mapped S.toList . chunksOf 3) $ S.copy $ each' [1..10]
+\>\>\>  (S.toList . mapped S.toList . chunksOf 5) $  (S.toList . mapped S.toList . chunksOf 3) $ S.copy $ each' [1..10]
 [[1,2,3,4,5],[6,7,8,9,10]] :> ([[1,2,3],[4,5,6],[7,8,9],[10]] :> ())
 
     The procedure can be iterated as one pleases, as one can see from this (otherwise unadvisable!) example:
 
->>>  (S.toList . mapped S.toList . chunksOf 4) $ (S.toList . mapped S.toList . chunksOf 3) $ S.copy $ (S.toList . mapped S.toList . chunksOf 2) $ S.copy $ each' [1..12]
+\>\>\>  (S.toList . mapped S.toList . chunksOf 4) $ (S.toList . mapped S.toList . chunksOf 3) $ S.copy $ (S.toList . mapped S.toList . chunksOf 2) $ S.copy $ each' [1..12]
 [[1,2,3,4],[5,6,7,8],[9,10,11,12]] :> ([[1,2,3],[4,5,6],[7,8,9],[10,11,12]] :> ([[1,2],[3,4],[5,6],[7,8],[9,10],[11,12]] :> ()))
 
 
@@ -918,14 +918,14 @@ duplicate = copy
 {-| Store the result of any suitable fold over a stream, keeping the stream for
     further manipulation. @store f = f . copy@ :
 
->>> S.print $ S.store S.product $ each' [1..4]
+\>\>\> S.print $ S.store S.product $ each' [1..4]
 1
 2
 3
 4
 24 :> ()
 
->>> S.print $ S.store S.sum $ S.store S.product $ each' [1..4]
+\>\>\> S.print $ S.store S.sum $ S.store S.product $ each' [1..4]
 1
 2
 3
@@ -939,7 +939,7 @@ duplicate = copy
    simultaneously, and in constant memory -- as they would be if,
    say, you linked them together with @Control.Fold@:
 
->>> L.impurely S.foldM (liftA3 (\a b c -> (b, c)) (L.sink Prelude.print) (L.generalize L.sum) (L.generalize L.product)) $ each' [1..4]
+\>\>\> L.impurely S.foldM (liftA3 (\a b c -> (b, c)) (L.sink Prelude.print) (L.generalize L.sum) (L.generalize L.product)) $ each' [1..4]
 1
 2
 3
@@ -953,7 +953,7 @@ duplicate = copy
    But 'store' \/ 'copy' is /much/ more powerful, as you can see by reflecting on
    uses like this:
 
->>> S.sum $ S.store (S.sum . mapped S.product . chunksOf 2) $ S.store (S.product . mapped S.sum . chunksOf 2) $ each' [1..6]
+\>\>\> S.sum $ S.store (S.sum . mapped S.product . chunksOf 2) $ S.store (S.product . mapped S.sum . chunksOf 2) $ each' [1..6]
 21 :> (44 :> (231 :> ()))
 
    It will be clear that this cannot be reproduced with any combination of lenses,
@@ -975,11 +975,11 @@ duplicate = copy
     Thus I can independently filter and write to one file, but
     nub and write to another, or interact with a database and a logfile and the like:
 
->>> (S.writeFile "hello2.txt" . S.nubOrd) $ store (S.writeFile "hello.txt" . S.filter (/= "world")) $ each' ["hello", "world", "goodbye", "world"]
->>> :! cat hello.txt
+\>\>\> (S.writeFile "hello2.txt" . S.nubOrd) $ store (S.writeFile "hello.txt" . S.filter (/= "world")) $ each' ["hello", "world", "goodbye", "world"]
+\>\>\> :! cat hello.txt
 hello
 goodbye
->>> :! cat hello2.txt
+\>\>\> :! cat hello2.txt
 hello
 world
 goodbye
@@ -997,7 +997,7 @@ store f x = f (copy x)
 {-| Apply an action to all values, re-yielding each.
     The return value (@y@) of the function is ignored.
 
->>> S.product $ S.chain Prelude.print $ S.each' [1..5]
+\>\>\> S.product $ S.chain Prelude.print $ S.each' [1..5]
 1
 2
 3
@@ -1115,7 +1115,7 @@ filterM pred = loop
 
 {-| Intersperse given value between each element of the stream.
 
->>> S.print $ S.intersperse 0 $ each [1,2,3]
+\>\>\> S.print $ S.intersperse 0 $ each [1,2,3]
 1
 0
 2
@@ -1141,7 +1141,7 @@ intersperse x stream = stream & \case
 
 {-|  Ignore the first n elements of a stream, but carry out the actions
 
->>> S.toList $ S.drop 2 $ S.replicateM 5 getLine
+\>\>\> S.toList $ S.drop 2 $ S.replicateM 5 getLine
 a<Enter>
 b<Enter>
 c<Enter>
@@ -1152,7 +1152,7 @@ e<Enter>
      Because it retains the final return value, @drop n@  is a suitable argument
      for @maps@:
 
->>> S.toList $ concats $ maps (S.drop 4) $ chunksOf 5 $ each [1..20]
+\>\>\> S.toList $ concats $ maps (S.drop 4) $ chunksOf 5 $ each [1..20]
 [5,10,15,20] :> ()
   -}
 drop :: forall a m r. (HasCallStack, Control.Monad m) =>
@@ -1170,7 +1170,7 @@ drop n stream = case compare n 0 of
 
 {- | Ignore elements of a stream until a test succeeds, retaining the rest.
 
->>> S.print $ S.dropWhile ((< 5) . length) S.stdinLn
+\>\>\> S.print $ S.dropWhile ((< 5) . length) S.stdinLn
 one<Enter>
 two<Enter>
 three<Enter>
@@ -1198,7 +1198,7 @@ dropWhile pred = loop
     is yielded first, before any action of finding the next element is performed.
 
 
->>> S.print $ S.scan (++) "" id $ each' (words "a b c d")
+\>\>\> S.print $ S.scan (++) "" id $ each' (words "a b c d")
 ""
 "a"
 "ab"
@@ -1207,7 +1207,7 @@ dropWhile pred = loop
 
     'scan' is fitted for use with @Control.Foldl@, thus:
 
->>> S.print $ L.purely S.scan L.list $ each' [3..5]
+\>\>\> S.print $ L.purely S.scan L.list $ each' [3..5]
 []
 [3]
 [3,4]
@@ -1234,8 +1234,8 @@ scan step begin done stream = Step (done begin :> loop begin stream)
     'FoldM's from @Control.Foldl@ using 'impurely'. Here we yield
     a succession of vectors each recording
 
->>> let v = L.impurely scanM L.vectorM $ each' [1..4::Int] :: Stream (Of (Vector Int)) IO ()
->>> S.print v
+\>\>\> let v = L.impurely scanM L.vectorM $ each' [1..4::Int] :: Stream (Of (Vector Int)) IO ()
+\>\>\> S.print v
 []
 [1]
 [1,2]
@@ -1266,12 +1266,12 @@ scanM step mx done stream = loop stream
 
 {-| Label each element in a stream with a value accumulated according to a fold.
 
->>> S.print $ S.scanned (*) 1 id $ S.each' [100,200,300]
+\>\>\> S.print $ S.scanned (*) 1 id $ S.each' [100,200,300]
 (100,100)
 (200,20000)
 (300,6000000)
 
->>> S.print $ L.purely S.scanned' L.product $ S.each [100,200,300]
+\>\>\> S.print $ L.purely S.scanned' L.product $ S.each [100,200,300]
 (100,100)
 (200,20000)
 (300,6000000)
@@ -1296,7 +1296,7 @@ scanned step begin done = loop begin
 --
 {- | Make a stream of strings into a stream of parsed values, skipping bad cases
 
->>> S.sum_ $ S.read $ S.takeWhile (/= "total") S.stdinLn :: IO Int
+\>\>\> S.sum_ $ S.read $ S.takeWhile (/= "total") S.stdinLn :: IO Int
 1000<Enter>
 2000<Enter>
 total<Enter>
@@ -1348,7 +1348,7 @@ cons a str = Step (a :> str)
 {-# INLINE cons #-}
 
 -- Note. The action function that is the second argument must be linear since
--- it gets its argument from binding to the first argument, which uses a 
+-- it gets its argument from binding to the first argument, which uses a
 -- control monad.
 --
 {-| Before evaluating the monadic action returning the next step in the 'Stream', @wrapEffect@
@@ -1373,7 +1373,7 @@ wrapEffect ma action stream = stream & \case
      It follows the behavior of the slidingWindow function in
      <https://hackage.haskell.org/package/conduit-combinators-1.0.4/docs/Data-Conduit-Combinators.html#v:slidingWindow conduit-combinators>.
 
->>> S.print $ S.slidingWindow 4 $ S.each "123456"
+\>\>\> S.print $ S.slidingWindow 4 $ S.each "123456"
 fromList "1234"
 fromList "2345"
 fromList "3456"

--- a/src/Streaming/Internal/Produce.hs
+++ b/src/Streaming/Internal/Produce.hs
@@ -64,12 +64,15 @@ import GHC.Stack
 
 {-| A singleton stream
 
+@
 \>\>\> stdoutLn $ yield "hello"
 hello
+@
 
+@
 \>\>\> S.sum $ do {yield 1; yield 2; yield 3}
 6 :> ()
-
+@
 -}
 yield :: Control.Monad m => a -> Stream (Of a) m ()
 yield x = Step $ x :> Return ()
@@ -77,11 +80,12 @@ yield x = Step $ x :> Return ()
 
 {- | Stream the elements of a pure, foldable container.
 
+@
 \>\>\> S.print $ each' [1..3]
 1
 2
 3
-
+@
 -}
 each' :: Control.Monad m => [a] -> Stream (Of a) m ()
 each' xs = Prelude.foldr (\a stream -> Step $ a :> stream) (Return ()) xs
@@ -143,13 +147,14 @@ replicate n a
 
 {-| Repeat an action several times, streaming its results.
 
+@
 \>\>\> import qualified Unsafe.Linear as Unsafe
 \>\>\> import qualified Data.Time as Time
 \>\>\> let getCurrentTime = fromSystemIO (Unsafe.coerce Time.getCurrentTime)
 \>\>\> S.print $ S.replicateM 2 getCurrentTime
 2015-08-18 00:57:36.124508 UTC
 2015-08-18 00:57:36.124785 UTC
-
+@
 -}
 replicateM :: Control.Monad m =>
   Int -> m (Ur a) -> Stream (Of a) m ()
@@ -445,11 +450,12 @@ cycleZip str stream = zip str $ cycle stream
 {-| An finite sequence of enumerable values at a fixed distance, determined
    by the first and second values.
 
+@
 \>\>\> S.print $ S.enumFromThenN 3 100 200
 100
 200
 300
-
+@
 -}
 enumFromThenN :: (Control.Monad m, Enum e) => Int -> e -> e -> Stream (Of e) m ()
 enumFromThenN n e e' = take n $ enumFromThen e e'

--- a/src/Streaming/Internal/Produce.hs
+++ b/src/Streaming/Internal/Produce.hs
@@ -64,10 +64,10 @@ import GHC.Stack
 
 {-| A singleton stream
 
->>> stdoutLn $ yield "hello"
+\>\>\> stdoutLn $ yield "hello"
 hello
 
->>> S.sum $ do {yield 1; yield 2; yield 3}
+\>\>\> S.sum $ do {yield 1; yield 2; yield 3}
 6 :> ()
 
 -}
@@ -77,7 +77,7 @@ yield x = Step $ x :> Return ()
 
 {- | Stream the elements of a pure, foldable container.
 
->>> S.print $ each' [1..3]
+\>\>\> S.print $ each' [1..3]
 1
 2
 3
@@ -143,10 +143,10 @@ replicate n a
 
 {-| Repeat an action several times, streaming its results.
 
->>> import qualified Unsafe.Linear as Unsafe
->>> import qualified Data.Time as Time
->>> let getCurrentTime = fromSystemIO (Unsafe.coerce Time.getCurrentTime)
->>> S.print $ S.replicateM 2 getCurrentTime
+\>\>\> import qualified Unsafe.Linear as Unsafe
+\>\>\> import qualified Data.Time as Time
+\>\>\> let getCurrentTime = fromSystemIO (Unsafe.coerce Time.getCurrentTime)
+\>\>\> S.print $ S.replicateM 2 getCurrentTime
 2015-08-18 00:57:36.124508 UTC
 2015-08-18 00:57:36.124785 UTC
 
@@ -445,7 +445,7 @@ cycleZip str stream = zip str $ cycle stream
 {-| An finite sequence of enumerable values at a fixed distance, determined
    by the first and second values.
 
->>> S.print $ S.enumFromThenN 3 100 200
+\>\>\> S.print $ S.enumFromThenN 3 100 200
 100
 200
 300

--- a/src/Streaming/Linear.hs
+++ b/src/Streaming/Linear.hs
@@ -463,9 +463,9 @@ inspect = loop
 {-| Split a succession of layers after some number, returning a streaming or
     effectful pair.
 
->>> rest <- S.print $ S.splitAt 1 $ each' [1..3]
+\>\>\> rest <- S.print $ S.splitAt 1 $ each' [1..3]
 1
->>> S.print rest
+\>\>\> S.print rest
 2
 3
 
@@ -474,12 +474,12 @@ inspect = loop
 
     Thus, e.g.
 
->>> rest <- S.print $ (\s -> splitsAt 2 s >>= splitsAt 2) each' [1..5]
+\>\>\> rest <- S.print $ (\s -> splitsAt 2 s >>= splitsAt 2) each' [1..5]
 1
 2
 3
 4
->>> S.print rest
+\>\>\> S.print rest
 5
 
 -}
@@ -501,7 +501,7 @@ splitsAt n stream = loop n stream
 
 {-| Break a stream into substreams each with n functorial layers.
 
->>>  S.print $ mapped S.sum $ chunksOf 2 $ each' [1,1,1,1,1]
+\>\>\>  S.print $ mapped S.sum $ chunksOf 2 $ each' [1,1,1,1,1]
 2
 2
 1
@@ -583,27 +583,27 @@ unzips str = destroyExposed
     other material for another treatment. It generalizes
     'Data.Either.partitionEithers', but actually streams properly.
 
->>> let odd_even = S.maps (S.distinguish even) $ S.each' [1..10::Int]
->>> :t separate odd_even
+\>\>\> let odd_even = S.maps (S.distinguish even) $ S.each' [1..10::Int]
+\>\>\> :t separate odd_even
 separate odd_even
   :: Monad m => Stream (Of Int) (Stream (Of Int) m) ()
 
     Now, for example, it is convenient to fold on the left and right values separately:
 
->>> S.toList $ S.toList $ separate odd_even
+\>\>\> S.toList $ S.toList $ separate odd_even
 [2,4,6,8,10] :> ([1,3,5,7,9] :> ())
 
 
    Or we can write them to separate files or whatever:
 
->>> S.writeFile "even.txt" . S.show $ S.writeFile "odd.txt" . S.show $ S.separate odd_even
->>> :! cat even.txt
+\>\>\> S.writeFile "even.txt" . S.show $ S.writeFile "odd.txt" . S.show $ S.separate odd_even
+\>\>\> :! cat even.txt
 2
 4
 6
 8
 10
->>> :! cat odd.txt
+\>\>\> :! cat odd.txt
 1
 3
 5
@@ -613,7 +613,7 @@ separate odd_even
    Of course, in the special case of @Stream (Of a) m r@, we can achieve the above
    effects more simply by using 'Streaming.Prelude.copy'
 
->>> S.toList . S.filter even $ S.toList . S.filter odd $ S.copy $ each [1..10::Int]
+\>\>\> S.toList . S.filter even $ S.toList . S.filter odd $ S.copy $ each [1..10::Int]
 [2,4,6,8,10] :> ([1,3,5,7,9] :> ())
 
 
@@ -736,24 +736,24 @@ run = loop
     to @foldr@  It is more convenient to query in ghci to figure out
     what kind of \'algebra\' you need to write.
 
->>> :t streamFold Control.return Control.join
+\>\>\> :t streamFold Control.return Control.join
 (Control.Monad m, Control.Functor f) =>
      (f (m a) #-> m a) -> Stream f m a #-> m a        -- iterT
 
->>> :t streamFold Control.return (Control.join . Control.lift)
+\>\>\> :t streamFold Control.return (Control.join . Control.lift)
 (Control.Monad m, Control.Monad (t m), Control.Functor f, Control.MonadTrans t) =>
      (f (t m a) #-> t m a) -> Stream f m a #-> t m a  -- iterTM
 
->>> :t streamFold Control.return effect
+\>\>\> :t streamFold Control.return effect
 (Control.Monad m, Control.Functor f, Control.Functor g) =>
      (f (Stream g m r) #-> Stream g m r) -> Stream f m r #-> Stream g m r
 
->>> :t \f -> streamFold Control.return effect (wrap . f)
+\>\>\> :t \f -> streamFold Control.return effect (wrap . f)
 (Control.Monad m, Control.Functor f, Control.Functor g) =>
      (f (Stream g m a) #-> g (Stream g m a))
      -> Stream f m a #-> Stream g m a                 -- maps
 
->>> :t \f -> streamFold Control.return effect (effect . Control.fmap wrap . f)
+\>\>\> :t \f -> streamFold Control.return effect (effect . Control.fmap wrap . f)
 (Control.Monad m, Control.Functor f, Control.Functor g) =>
      (f (Stream g m a) #-> m (g (Stream g m a)))
      -> Stream f m a #-> Stream g m a                 -- mapped

--- a/src/System/IO/Resource.hs
+++ b/src/System/IO/Resource.hs
@@ -20,22 +20,22 @@
 -- run it to get a "System.IO" computation.
 --
 -- = A simple example
--- > {-# LANGUAGE LinearTypes #-}
--- > {-# LANGUAGE QualifiedDo #-}
--- > {-# LANGUAGE NoImplicitPrelude #-}
--- >
--- > import qualified System.IO.Resource as Linear
--- > import qualified Control.Monad.Linear as Control
--- > import qualified Data.Text as Text
--- > import Prelude.Linear
--- > import qualified Prelude
--- >
--- > linearWriteToFile :: IO ()
--- > linearWriteToFile = Linear.run Prelude.$ Control.do
--- >   handle1 <- Linear.openFile "/home/user/test.txt" WriteMode
--- >   handle2 <- Linear.hPutStrLn handle1 (Text.pack "hello there")
--- >   () <- Linear.hClose handle2
--- >   Control.return (Ur ())
+-- >>> :set -XLinearTypes
+-- >>> :set -XQualifiedDo
+-- >>> :set -XNoImplicitPrelude
+-- >>> import qualified System.IO.Resource as Linear
+-- >>> import qualified Control.Monad.Linear as Control
+-- >>> import qualified Data.Text as Text
+-- >>> import Prelude.Linear
+-- >>> import qualified Prelude
+-- >>> :{
+--  linearWriteToFile :: IO ()
+--  linearWriteToFile = Linear.run Prelude.$ Control.do
+--    handle1 <- Linear.openFile "/home/user/test.txt" Linear.WriteMode
+--    handle2 <- Linear.hPutStrLn handle1 (Text.pack "hello there")
+--    () <- Linear.hClose handle2
+--    Control.return (Ur ())
+-- :}
 --
 -- To enable do notation, `QualifiedDo` extension is used. But since QualifiedDo
 -- only modifies the desugaring of binds, we still need to qualify `Control.return`.

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,6 +17,12 @@ extra-deps:
   commit: c98aa9e33bf6871098d6f4ac94eeaac10383d696
   subdirs:
     - hedgehog
+# https://github.com/dreixel/syb/pull/25
+- git: https://github.com/utdemir/syb.git
+  commit: a072e20d7a5806779486646418fa20c5ffd99a4f
+# https://github.com/sol/doctest/pull/272
+- git: https://github.com/utdemir/doctest.git
+  commit: 090cccaf12c5643ca80f8c2afe693a488277d365
 # below is required for getting quickcheck compile
 - random-1.2.0
 - splitmix-0.1.0.1

--- a/test/Doctest.hs
+++ b/test/Doctest.hs
@@ -1,0 +1,12 @@
+module Main where
+
+import Build_doctests (flags, pkgs, module_sources)
+import Data.Foldable (traverse_)
+import Test.DocTest (doctest)
+
+main :: IO ()
+main = do
+   traverse_ putStrLn args
+   doctest args
+  where
+    args = flags ++ pkgs ++ module_sources


### PR DESCRIPTION
Closes #235.

This PR integrates `doctest` library to type-check and test the code examples in our Haddock's.

* It modifies our examples to look like REPL sessions instead of entire modules.
* There is an annoying `doctest` issue where we need to put an empty line after a multiline declaration, which doesn't look great. I'll file an upstream issue.
* As discussed on #232; `Streaming` modules are pretty big, so refactoring their examples would take a long time. So, this PR escapes their examples so they are not recognized by `doctest`.
* We're adding two new overrides for `syb` and `doctest`, both overrides have upstream PR's.

In order to try the tests, run `cabal test linear-base:doctests`, or an equivalent `stack` command. It is also a part of the longer `cabal test` command.
