### PR TITLE
Add a (<&>) combinator

### DIFF
--- a/src/Control/Monad/Linear.hs
+++ b/src/Control/Monad/Linear.hs
@@ -20,6 +20,7 @@ module Control.Monad.Linear
     -- $monad
     Functor(..)
   , (<$>)
+  , (<&>)
   , (<$)
   , dataFmapDefault
   , Applicative(..)

--- a/src/Control/Monad/Linear/Internal.hs
+++ b/src/Control/Monad/Linear/Internal.hs
@@ -94,6 +94,13 @@ dataPureDefault x = pure x
 (<$>) :: Functor f => (a #-> b) #-> f a #-> f b
 (<$>) = fmap
 
+-- |  @
+--    ('<&>') = 'flip' 'fmap'
+--    @
+(<&>) :: Functor f => f a #-> (a #-> b) #-> f b
+(<&>) a f = f <$> a
+{-# INLINE (<&>) #-}
+
 {-# INLINE return #-}
 return :: Monad m => a #-> m a
 return x = pure x


### PR DESCRIPTION
It's a flipped `(<$>)`. Just like `(&)` is a flipped `($)`. It will be
useful for the pattern `u <&> \case …`.