### PR TITLE
Consistent parameter ordering of linear collections

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -77,10 +77,10 @@ We have established the following conventions in this project:
   instance, import `Data.Functor.Linear` as `Linear` and not as `F`
   for functor.
 * All public modules have an export list.
-* For things which is meant te be used in pure contexts, take the
-thing as the last parameter (similar to `Data.Map`). If it is meant
-to be used in monadic contexts, take the thing as the first parameter
-(eg. `Control.Concurrent.MVar`). See [issue #147][issue-147] for some
+* Pure functions which modify a container take the
+container as the last parameter (similar to functions in `Data.Map`). Monadic functions on containers
+take the containers as the first parameter
+(similar to functions in `Control.Concurrent.MVar`). See [issue #147][issue-147] for some
 more details.
 
 [functors]: https://www.tweag.io/posts/2020-01-16-data-vs-control.html

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -77,6 +77,11 @@ We have established the following conventions in this project:
   instance, import `Data.Functor.Linear` as `Linear` and not as `F`
   for functor.
 * All public modules have an export list.
+* For things which is meant te be used in pure contexts, take the
+thing as the last parameter (similar to `Data.Map`). If it is meant
+to be used in monadic contexts, take the thing as the first parameter
+(eg. `Control.Concurrent.MVar`). See [issue #147][issue-147] for some
+more details.
 
 [functors]: https://www.tweag.io/posts/2020-01-16-data-vs-control.html
 [examples/Simple/FileIO.hs]: https://github.com/tweag/linear-base/tree/master/examples/Simple/FileIO.hs
@@ -87,3 +92,4 @@ We have established the following conventions in this project:
 [blog post]: https://www.tweag.io/posts/2020-01-16-data-vs-control.html
 [contributor's guide]: ../CONTRIBUTING.md
 [`System.IO.Resource`]: https://github.com/tweag/linear-base/blob/master/src/System/IO/Resource.hs
+[issue-147]: https://github.com/tweag/linear-base/issues/147

--- a/examples/Simple/TopSort.hs
+++ b/examples/Simple/TopSort.hs
@@ -66,7 +66,7 @@ postOrderHM nodes dag = findSources nodes (computeInDeg nodes dag) & \case
 
   -- Increment in-degree of all neighbors
   incChildren :: InDegGraph #-> Ur Node #-> InDegGraph
-  incChildren dag (Ur node) = HMap.lookup dag node & \case
+  incChildren dag (Ur node) = HMap.lookup node dag & \case
      (Ur Nothing, dag) -> dag
      (Ur (Just (xs,i)), dag) -> incNodes (move xs) dag
     where
@@ -74,16 +74,16 @@ postOrderHM nodes dag = findSources nodes (computeInDeg nodes dag) & \case
       incNodes (Ur ns) dag = Linear.foldl incNode dag (map Ur ns)
 
       incNode :: InDegGraph #-> Ur Node #-> InDegGraph
-      incNode dag (Ur node) = HMap.lookup dag node & \case
+      incNode dag (Ur node) = HMap.lookup node dag & \case
         (Ur Nothing, dag') -> dag'
         (Ur (Just (n,d)), dag') ->
-          HMap.insert dag' node (n,d+1)
+          HMap.insert node (n,d+1) dag'
         --HMap.alter dag (\(Just (n,d)) -> Just (n,d+1)) node
 
 -- pluckSources sources postOrdSoFar dag
 pluckSources :: [Node] -> [Node] -> InDegGraph #-> Ur [Node]
 pluckSources [] postOrd dag = lseq dag (move postOrd)
-pluckSources (s:ss) postOrd dag = HMap.lookup dag s & \case
+pluckSources (s:ss) postOrd dag = HMap.lookup s dag & \case
   (Ur Nothing, dag) -> pluckSources ss (s:postOrd) dag
   (Ur (Just (xs,i)), dag) -> walk xs dag & \case
       (dag', Ur newSrcs) ->
@@ -96,10 +96,10 @@ pluckSources (s:ss) postOrd dag = HMap.lookup dag s & \case
 
     -- Decrement the degree of a node, save it if it is now a source
     decDegree :: Node -> InDegGraph #-> (InDegGraph, Ur (Maybe Node))
-    decDegree node dag = HMap.lookup dag node & \case
+    decDegree node dag = HMap.lookup node dag & \case
         (Ur Nothing, dag') -> (dag', Ur Nothing)
         (Ur (Just (n,d)), dag') ->
-          checkSource node (HMap.insert dag' node (n,d-1))
+          checkSource node (HMap.insert node (n,d-1) dag')
 
 
 -- Given a list of nodes, determines which are sources
@@ -110,7 +110,7 @@ findSources nodes dag =
 
 -- | Check if a node is a source, and if so return it
 checkSource :: Node -> InDegGraph #-> (InDegGraph, Ur (Maybe Node))
-checkSource node dag = HMap.lookup dag node & \case
+checkSource node dag = HMap.lookup node dag & \case
   (Ur Nothing, dag) -> (dag, Ur Nothing)
   (Ur (Just (xs,0)), dag) ->  (dag, Ur (Just node))
   (Ur (Just (xs,n)), dag) -> (dag, Ur Nothing)

--- a/src/Data/Set/Mutable/Linear.hs
+++ b/src/Data/Set/Mutable/Linear.hs
@@ -60,11 +60,11 @@ toList (Set hm) =
   Linear.toList hm
     Linear.& \(Ur xs) -> Ur (Prelude.map Prelude.fst xs)
 
-insert :: Keyed a => Set a #-> a -> Set a
-insert (Set hmap) a = Set (Linear.insert hmap a ())
+insert :: Keyed a => a -> Set a #-> Set a
+insert a (Set hmap) = Set (Linear.insert a () hmap)
 
-delete :: Keyed a => Set a #-> a -> Set a
-delete (Set hmap) a = Set (Linear.delete hmap a)
+delete :: Keyed a => a -> Set a #-> Set a
+delete a (Set hmap) = Set (Linear.delete a hmap)
 
 union :: Keyed a => Set a #-> Set a #-> Set a
 union (Set hm1) (Set hm2) =
@@ -81,9 +81,9 @@ size :: Keyed a => Set a #-> (Ur Int, Set a)
 size (Set hm) =
   Linear.size hm Linear.& \(s, hm') -> (s, Set hm')
 
-member :: Keyed a => Set a #-> a -> (Ur Bool, Set a)
-member (Set hm) a =
-  Linear.member hm a Linear.& \(b, hm') -> (b, Set hm')
+member :: Keyed a => a -> Set a #-> (Ur Bool, Set a)
+member a (Set hm) =
+  Linear.member a hm Linear.& \(b, hm') -> (b, Set hm')
 
 fromList :: Keyed a => [a] -> (Set a #-> Ur b) #-> Ur b
 fromList xs f =

--- a/test/Test/Data/Mutable/Set.hs
+++ b/test/Test/Data/Mutable/Set.hs
@@ -80,7 +80,7 @@ memberInsert1Test :: Int -> SetTester
 memberInsert1Test val set =
   testEqual
     (Ur True)
-    (getFst (Set.member (Set.insert set val) val))
+    (getFst (Set.member val (Set.insert val set)))
 
 memberInsert2 :: Property
 memberInsert2 = property $ do
@@ -91,13 +91,13 @@ memberInsert2 = property $ do
   test $ unur Linear.$ Set.fromList l tester
 
 memberInsert2Test :: Int -> Int -> SetTester
-memberInsert2Test val1 val2 set = fromRead (Set.member set val2)
+memberInsert2Test val1 val2 set = fromRead (Set.member val2 set)
   where
     fromRead :: (Ur Bool, Set.Set Int) #-> Ur (TestT IO ())
     fromRead (memberVal2, set) =
       testEqual
         memberVal2
-        (getFst (Set.member (Set.insert set val1) val2))
+        (getFst (Set.member val2 (Set.insert val1 set)))
 
 memberDelete1 :: Property
 memberDelete1 = property $ do
@@ -110,7 +110,7 @@ memberDelete1Test :: Int -> SetTester
 memberDelete1Test val set =
   testEqual
     (Ur False)
-    (getFst (Set.member (Set.delete set val) val))
+    (getFst (Set.member val (Set.delete val set)))
 
 memberDelete2 :: Property
 memberDelete2 = property $ do
@@ -121,13 +121,13 @@ memberDelete2 = property $ do
   test $ unur Linear.$ Set.fromList l tester
 
 memberDelete2Test :: Int -> Int -> SetTester
-memberDelete2Test val1 val2 set = fromRead (Set.member set val2)
+memberDelete2Test val1 val2 set = fromRead (Set.member val2 set)
   where
     fromRead :: (Ur Bool, Set.Set Int) #-> Ur (TestT IO ())
     fromRead (memberVal2, set) =
       testEqual
         memberVal2
-        (getFst Linear.$ Set.member (Set.delete set val1) val2)
+        (getFst Linear.$ Set.member val2 (Set.delete val1 set))
 
 sizeInsert1 :: Property
 sizeInsert1 = property $ do
@@ -143,7 +143,7 @@ sizeInsert1Test val set = fromRead (Set.size set)
     fromRead (sizeOriginal, set) =
       testEqual
         sizeOriginal
-        (getFst Linear.$ (Set.size (Set.insert set val)))
+        (getFst Linear.$ (Set.size (Set.insert val set)))
 
 sizeInsert2 :: Property
 sizeInsert2 = property $ do
@@ -159,7 +159,7 @@ sizeInsert2Test val set = fromRead (Set.size set)
     fromRead (sizeOriginal, set) =
       testEqual
         ((Linear.+ 1) Data.<$> sizeOriginal)
-        (getFst Linear.$ (Set.size (Set.insert set val)))
+        (getFst Linear.$ (Set.size (Set.insert val set)))
 
 sizeDelete1 :: Property
 sizeDelete1 = property $ do
@@ -175,7 +175,7 @@ sizeDelete1Test val set = fromRead (Set.size set)
     fromRead (sizeOriginal, set) =
       testEqual
         ((Linear.- 1) Data.<$> sizeOriginal)
-        (getFst Linear.$ (Set.size (Set.delete set val)))
+        (getFst Linear.$ (Set.size (Set.delete val set)))
 
 sizeDelete2 :: Property
 sizeDelete2 = property $ do
@@ -191,4 +191,4 @@ sizeDelete2Test val set = fromRead (Set.size set)
     fromRead (sizeOriginal, set) =
       testEqual
         sizeOriginal
-        (getFst Linear.$ (Set.size (Set.delete set val)))
+        (getFst Linear.$ (Set.size (Set.delete val set)))


### PR DESCRIPTION
Closes #147 .

This PR updates the mutable collections API slightly to have consistency on order of parameters. The issue #147 has more reasoning behind the changes, but in short:

* The pure-looking names take the collection as the last parameter (`set`, `get`, `lookup`)
* Imperative-looking names take the collection as the first parameter (`read`, `write`)

For arrays and vectors, we both `set` and `get` methods alongside with the flipped versions as `read` and `write` (and their unsafe variants). However, unlifted arrays, maps and sets only have an entirely pure-looking interface. The only reason is that I did not find much value duplicating the entire API and making up new names for imperative-looking counterparts.

Let me know if you have another preference.