### PR TITLE
Update GHC and use new linear arrow syntax

### DIFF
--- a/examples/Foreign/Heap.hs
+++ b/examples/Foreign/Heap.hs
@@ -34,45 +34,45 @@ instance (Manual.Representable k, Manual.Representable a) => Manual.Representabl
 
 -- * Non-empty heap primitives
 
-singletonN :: (Manual.Representable k, Manual.Representable a) => k #-> a #-> Pool #-> NEHeap k a
+singletonN :: (Manual.Representable k, Manual.Representable a) => k %1-> a %1-> Pool %1-> NEHeap k a
 singletonN k a pool = Heap k a (Manual.alloc List.Nil pool)
 
 -- XXX: (Movable k, Ord k) is a bit stronger than strictly required. We could
 -- give a linear version of `Ord` instead.
-mergeN :: forall k a. (Manual.Representable k, Manual.Representable a, Movable k, Ord k) => NEHeap k a #-> NEHeap k a #-> Pool #-> NEHeap k a
+mergeN :: forall k a. (Manual.Representable k, Manual.Representable a, Movable k, Ord k) => NEHeap k a %1-> NEHeap k a %1-> Pool %1-> NEHeap k a
 mergeN (Heap k1 a1 h1) (Heap k2 a2 h2) pool =
     testAndRebuild (move k1) a1 h1 (move k2) a2 h2 pool
   where
     --- XXX: this is a good example of why we need a working `case` and/or
     --- `let`.
-    testAndRebuild :: Ur k #-> a #-> Box (List (NEHeap k a)) #-> Ur k #-> a #-> Box (List (NEHeap k a)) #-> Pool #-> NEHeap k a
+    testAndRebuild :: Ur k %1-> a %1-> Box (List (NEHeap k a)) %1-> Ur k %1-> a %1-> Box (List (NEHeap k a)) %1-> Pool %1-> NEHeap k a
     testAndRebuild (Ur k1') a1' h1' (Ur k2') a2' h2' =
       if k1' <= k2'
         then helper k1' a1' k2' a2' h1' h2'
         else helper k2' a2' k1' a1' h2' h1'
 
-    helper :: k -> a #-> k -> a #-> Box (List (NEHeap k a)) #-> Box (List (NEHeap k a)) #-> Pool #-> NEHeap k a
-    helper k1'' a1'' k2'' a2'' h1'' h2'' pool'' = Heap k1'' a1'' (Manual.alloc ((List.Cons :: b #-> Box (List b) #-> List b) ((Heap :: c #-> b #-> Box (List (NEHeap c b)) #-> NEHeap c b) k2'' a2'' h2'') h1'') pool'')
+    helper :: k -> a %1-> k -> a %1-> Box (List (NEHeap k a)) %1-> Box (List (NEHeap k a)) %1-> Pool %1-> NEHeap k a
+    helper k1'' a1'' k2'' a2'' h1'' h2'' pool'' = Heap k1'' a1'' (Manual.alloc ((List.Cons :: b %1-> Box (List b) %1-> List b) ((Heap :: c %1-> b %1-> Box (List (NEHeap c b)) %1-> NEHeap c b) k2'' a2'' h2'') h1'') pool'')
   -- XXX: the type signatures for List.Cons and Heap are necessary for certain
   -- older versions of the compiler, and as such are temporary. See PR #38
   -- and PR #380 in tweag/ghc/linear-types.
 
-mergeN' :: forall k a. (Manual.Representable k, Manual.Representable a, Movable k, Ord k) => NEHeap k a #-> Heap k a #-> Pool #-> NEHeap k a
+mergeN' :: forall k a. (Manual.Representable k, Manual.Representable a, Movable k, Ord k) => NEHeap k a %1-> Heap k a %1-> Pool %1-> NEHeap k a
 mergeN' h Empty pool = pool `lseq` h
 mergeN' h (NonEmpty h') pool = mergeN h (Manual.deconstruct h') pool
 
-extractMinN :: (Manual.Representable k, Manual.Representable a, Movable k, Ord k) => NEHeap k a #-> Pool #-> (k, a, Heap k a)
+extractMinN :: (Manual.Representable k, Manual.Representable a, Movable k, Ord k) => NEHeap k a %1-> Pool %1-> (k, a, Heap k a)
 extractMinN (Heap k a h) pool = (k, a, pairUp (Manual.deconstruct h) pool)
 
-pairUp :: forall k a. (Manual.Representable k, Manual.Representable a, Movable k, Ord k) => List (NEHeap k a) #-> Pool #-> Heap k a
+pairUp :: forall k a. (Manual.Representable k, Manual.Representable a, Movable k, Ord k) => List (NEHeap k a) %1-> Pool %1-> Heap k a
 pairUp List.Nil pool = pool `lseq` Empty
 pairUp (List.Cons h r) pool = pairOne h (Manual.deconstruct r) (dup pool)
   where
-    pairOne :: NEHeap k a #-> List (NEHeap k a) #-> (Pool, Pool) #-> Heap k a
+    pairOne :: NEHeap k a %1-> List (NEHeap k a) %1-> (Pool, Pool) %1-> Heap k a
     pairOne h' r' (pool1, pool2) =
       NonEmpty $ Manual.alloc (pairOne' h' r' (dup3 pool1)) pool2
 
-    pairOne' :: NEHeap k a #-> List (NEHeap k a) #-> (Pool, Pool, Pool) #-> NEHeap k a
+    pairOne' :: NEHeap k a %1-> List (NEHeap k a) %1-> (Pool, Pool, Pool) %1-> NEHeap k a
     pairOne' h1 List.Nil pools =
       pools `lseq` h1
     pairOne' h1 (List.Cons h2 r') (pool1, pool2, pool3) =
@@ -83,63 +83,63 @@ pairUp (List.Cons h r) pool = pairOne h (Manual.deconstruct r) (dup pool)
 empty :: Heap k a
 empty = Empty
 
-singleton :: forall k a. (Manual.Representable k, Manual.Representable a) => k #-> a #-> Pool #-> Heap k a
+singleton :: forall k a. (Manual.Representable k, Manual.Representable a) => k %1-> a %1-> Pool %1-> Heap k a
 singleton k a pool = NonEmpty $ singletonAlloc k a (dup pool)
   where
-    singletonAlloc :: k #-> a #-> (Pool, Pool) #-> Box (NEHeap k a)
+    singletonAlloc :: k %1-> a %1-> (Pool, Pool) %1-> Box (NEHeap k a)
     singletonAlloc k' a' (pool1, pool2) =
       Manual.alloc (singletonN k' a' pool1) pool2
 
-extractMin :: (Manual.Representable k, Manual.Representable a, Movable k, Ord k) => Heap k a #-> Pool #-> Maybe (k, a, Heap k a)
+extractMin :: (Manual.Representable k, Manual.Representable a, Movable k, Ord k) => Heap k a %1-> Pool %1-> Maybe (k, a, Heap k a)
 extractMin Empty pool = pool `lseq` Nothing
 extractMin (NonEmpty h) pool = Just $ extractMinN (Manual.deconstruct h) pool
 
-merge :: forall k a. (Manual.Representable k, Manual.Representable a, Movable k, Ord k) => Heap k a #-> Heap k a #-> Pool #-> Heap k a
+merge :: forall k a. (Manual.Representable k, Manual.Representable a, Movable k, Ord k) => Heap k a %1-> Heap k a %1-> Pool %1-> Heap k a
 merge Empty h' pool = pool `lseq` h'
 merge (NonEmpty h) h' pool = NonEmpty $ neMerge (Manual.deconstruct h) h' (dup pool)
   where
-    neMerge :: NEHeap k a #-> Heap k a #-> (Pool, Pool) #-> Box (NEHeap k a)
+    neMerge :: NEHeap k a %1-> Heap k a %1-> (Pool, Pool) %1-> Box (NEHeap k a)
     neMerge h1 h2 (pool1, pool2) =
       Manual.alloc (mergeN' h1 h2 pool1) pool2
 
 -- * Heap sort
 
 -- | Guaranteed to yield pairs in ascending key order
-foldl :: forall k a b. (Manual.Representable k, Manual.Representable a, Movable k, Ord k) => (b #-> k #-> a #-> b) -> b #-> Heap k a #-> Pool #-> b
+foldl :: forall k a b. (Manual.Representable k, Manual.Representable a, Movable k, Ord k) => (b %1-> k %1-> a %1-> b) -> b %1-> Heap k a %1-> Pool %1-> b
 foldl f acc h pool = go acc h (dup pool)
   where
-    go :: b #-> Heap k a #-> (Pool, Pool) #-> b
+    go :: b %1-> Heap k a %1-> (Pool, Pool) %1-> b
     go acc' h' (pool1, pool2) = dispatch acc' (extractMin h' pool1) pool2
 
-    dispatch :: b #-> Maybe (k, a, Heap k a) #-> Pool #-> b
+    dispatch :: b %1-> Maybe (k, a, Heap k a) %1-> Pool %1-> b
     dispatch acc' Nothing pool' = pool' `lseq` acc'
     dispatch acc' (Just(k, a, h')) pool' =
       foldl f (f acc' k a) h' pool'
 
 -- | Strict: stream must terminate.
-unfold :: forall k a s. (Manual.Representable k, Manual.Representable a, Movable k, Ord k) => (s -> Maybe ((k, a), s)) -> s -> Pool #-> Heap k a
+unfold :: forall k a s. (Manual.Representable k, Manual.Representable a, Movable k, Ord k) => (s -> Maybe ((k, a), s)) -> s -> Pool %1-> Heap k a
 unfold step seed pool = dispatch (step seed) pool
   where
-    dispatch :: (Maybe ((k, a), s)) -> Pool #-> Heap k a
+    dispatch :: (Maybe ((k, a), s)) -> Pool %1-> Heap k a
     dispatch Nothing pool' = pool' `lseq` Empty
     dispatch (Just ((k, a), next)) pool' = mkStep k a next (dup3 pool')
 
-    mkStep :: k -> a -> s -> (Pool, Pool, Pool) #-> Heap k a
+    mkStep :: k -> a -> s -> (Pool, Pool, Pool) %1-> Heap k a
     mkStep k a next (pool1, pool2, pool3) =
       merge (singleton k a pool1) (unfold step next pool2) pool3
 
 -- TODO: linear unfold: could apply to off-heap lists!
 
-ofList :: (Manual.Representable k, Manual.Representable a, Movable k, Ord k) => [(k, a)] -> Pool #-> Heap k a
+ofList :: (Manual.Representable k, Manual.Representable a, Movable k, Ord k) => [(k, a)] -> Pool %1-> Heap k a
 ofList l pool = unfold List.uncons l pool
 
 -- XXX: sorts in reverse
-toList :: (Manual.Representable k, Manual.Representable a, Movable k, Ord k) => Heap k a #-> Pool #-> [(k, a)]
+toList :: (Manual.Representable k, Manual.Representable a, Movable k, Ord k) => Heap k a %1-> Pool %1-> [(k, a)]
 toList h pool = foldl (\l k a -> (k,a):l) [] h pool
 
 sort :: forall k a. (Manual.Representable k, Manual.Representable a, Movable k, Ord k, Movable a) => [(k, a)] -> [(k,a)]
 sort l = unur $ Manual.withPool (\pool -> move $ sort' l (dup pool))
     -- XXX: can we avoid this call to `move`?
   where
-    sort' :: [(k, a)] -> (Pool, Pool) #-> [(k,a)]
+    sort' :: [(k, a)] -> (Pool, Pool) %1-> [(k,a)]
     sort' l' (pool1, pool2) = toList (ofList l' pool1) pool2

--- a/examples/Foreign/List.hs
+++ b/examples/Foreign/List.hs
@@ -37,68 +37,68 @@ instance Manual.Representable a => Manual.Representable (List a) where
 -- Remark: this is a bit wasteful, we could implement an allocation-free map by
 -- reusing the old pointer with realloc.
 --
--- XXX: the mapped function should be of type (a #-> Pool #-> b)
+-- XXX: the mapped function should be of type (a %1-> Pool %1-> b)
 --
 -- Remark: map could be tail-recursive in destination-passing style
-map :: forall a b. (Manual.Representable a, Manual.Representable b) => (a #-> b) -> List a #-> Pool #-> List b
+map :: forall a b. (Manual.Representable a, Manual.Representable b) => (a %1-> b) -> List a %1-> Pool %1-> List b
 map _f Nil pool = pool `lseq` Nil
 map f (Cons a l) pool =
     withPools (dup pool) a (Manual.deconstruct l)
   where
-    withPools :: (Pool, Pool) #-> a #-> List a #-> List b
+    withPools :: (Pool, Pool) %1-> a %1-> List a %1-> List b
     withPools (pool1, pool2) a' l' =
       Cons (f a') (Manual.alloc (map f l' pool1) pool2)
 
-foldr :: forall a b. Manual.Representable a => (a #-> b #-> b) -> b #-> List a #-> b
+foldr :: forall a b. Manual.Representable a => (a %1-> b %1-> b) -> b %1-> List a %1-> b
 foldr _f seed Nil = seed
 foldr f seed (Cons a l) = f a (foldr f seed (Manual.deconstruct l))
 
-foldl :: forall a b. Manual.Representable a => (b #-> a #-> b) -> b #-> List a #-> b
+foldl :: forall a b. Manual.Representable a => (b %1-> a %1-> b) -> b %1-> List a %1-> b
 foldl _f seed Nil = seed
 foldl f seed (Cons a l) = foldl f (f seed a) (Manual.deconstruct l)
 
 -- Remark: could be tail-recursive with destination-passing style
 -- | Make a 'List' from a stream. 'List' is a type of strict lists, therefore
 -- the stream must terminate otherwise 'unfold' will loop. Not tail-recursive.
-unfold :: forall a s. Manual.Representable a => (s -> Maybe (a,s)) -> s -> Pool #-> List a
+unfold :: forall a s. Manual.Representable a => (s -> Maybe (a,s)) -> s -> Pool %1-> List a
 unfold step state pool = dispatch (step state) (dup pool)
   -- XXX: ^ The reason why we need to `dup` the pool before we know whether the
   -- next step is a `Nothing` (in which case we don't need the pool at all) or a
   -- `Just`, is because of the limitation of `case` to the unrestricted
   -- case. Will be fixed.
   where
-    dispatch :: Maybe (a, s) -> (Pool, Pool) #-> List a
+    dispatch :: Maybe (a, s) -> (Pool, Pool) %1-> List a
     dispatch Nothing pools = pools `lseq` Nil
     dispatch (Just (a, next)) (pool1, pool2) =
       Cons a (Manual.alloc (unfold step next pool1) pool2)
 
 -- | Linear variant of 'unfold'. Note how they are implemented exactly
 -- identically. They could be merged if multiplicity polymorphism was supported.
-unfoldL :: forall a s. Manual.Representable a => (s #-> Maybe (a,s)) -> s #-> Pool #-> List a
+unfoldL :: forall a s. Manual.Representable a => (s %1-> Maybe (a,s)) -> s %1-> Pool %1-> List a
 unfoldL step state pool = dispatch (step state) (dup pool)
   where
-    dispatch :: Maybe (a, s) #-> (Pool, Pool) #-> List a
+    dispatch :: Maybe (a, s) %1-> (Pool, Pool) %1-> List a
     dispatch Nothing pools = pools `lseq` Nil
     dispatch (Just (a, next)) (pool1, pool2) =
       Cons a (Manual.alloc (unfoldL step next pool1) pool2)
 
-ofList :: Manual.Representable a => [a] -> Pool #-> List a
+ofList :: Manual.Representable a => [a] -> Pool %1-> List a
 ofList l pool = unfold List.uncons l pool
 
-toList :: Manual.Representable a => List a #-> [a]
+toList :: Manual.Representable a => List a %1-> [a]
 toList l = foldr (:) [] l
 
 -- | Like unfold but builds the list in reverse, and tail recursive
-runfold :: forall a s. Manual.Representable a => (s -> Maybe (a,s)) -> s -> Pool #-> List a
+runfold :: forall a s. Manual.Representable a => (s -> Maybe (a,s)) -> s -> Pool %1-> List a
 runfold step state pool = loop state Nil pool
   where
-    loop :: s -> List a #-> Pool #-> List a
+    loop :: s -> List a %1-> Pool %1-> List a
     loop state' acc pool' = dispatch (step state') acc (dup pool')
 
-    dispatch :: Maybe (a, s) -> List a #-> (Pool, Pool) #-> List a
+    dispatch :: Maybe (a, s) -> List a %1-> (Pool, Pool) %1-> List a
     dispatch Nothing !acc pools = pools `lseq` acc
     dispatch (Just (a, next)) !acc (pool1, pool2) =
       loop next (Cons a (Manual.alloc acc pool1)) pool2
 
-ofRList :: Manual.Representable a => [a] -> Pool #-> List a
+ofRList :: Manual.Representable a => [a] -> Pool %1-> List a
 ofRList l pool = runfold List.uncons l pool

--- a/examples/Simple/FileIO.hs
+++ b/examples/Simple/FileIO.hs
@@ -95,7 +95,7 @@ linearPrintFirstLine fp = do
     for the multiplicity, as descibed in the paper is a work in progress.
     This will hopefully result in using
 
-    `(>>==) RIO 'Many a #-> (a -> RIO p b) #-> RIO p b`
+    `(>>==) RIO 'Many a %1-> (a -> RIO p b) %1-> RIO p b`
 
     as the non-linear bind operation.
     See https://github.com/tweag/linear-base/issues/83.
@@ -111,21 +111,21 @@ type LinHandle = Linear.Handle
 
 -- | Linear bind
 -- Notice the continuation has a linear arrow,
--- i.e., (a #-> RIO b)
-(>>#=) :: RIO a #-> (a #-> RIO b) #-> RIO b
+-- i.e., (a %1-> RIO b)
+(>>#=) :: RIO a %1-> (a %1-> RIO b) %1-> RIO b
 (>>#=) = (Control.>>=)
 
 -- | Non-linear bind
 -- Notice the continuation has a non-linear arrow,
 -- i.e., (() -> RIO b). For simplicity, we don't use
 -- a more general type, like the following:
--- (>>==) :: RIO (Ur a) #-> (a -> RIO b) #-> RIO b
-(>>==) :: RIO () #-> (() -> RIO b) #-> RIO b
+-- (>>==) :: RIO (Ur a) %1-> (a -> RIO b) %1-> RIO b
+(>>==) :: RIO () %1-> (() -> RIO b) %1-> RIO b
 (>>==) ma f = ma Control.>>= (\() -> f ())
 
 -- | Inject
 -- provided just to make the type explicit
-inject :: a #-> RIO a
+inject :: a %1-> RIO a
 inject = Control.return
 
 -- * The explicit example
@@ -139,10 +139,10 @@ getFirstLineExplicit path =
   where
     openFileForReading :: FilePath -> RIO LinHandle
     openFileForReading fp = Linear.openFile fp System.ReadMode
-    readOneLine :: LinHandle #-> RIO (Ur Text, LinHandle)
+    readOneLine :: LinHandle %1-> RIO (Ur Text, LinHandle)
     readOneLine = Linear.hGetLine
     closeAndReturnLine ::
-      (Ur Text, LinHandle) #-> RIO (Ur Text)
+      (Ur Text, LinHandle) %1-> RIO (Ur Text)
     closeAndReturnLine (unrText, handle) =
       Linear.hClose handle >>#= (\() -> inject unrText)
 

--- a/examples/Simple/Pure.hs
+++ b/examples/Simple/Pure.hs
@@ -29,7 +29,7 @@ module Simple.Pure where
    times the argument of f is used in the body.
 -}
 
-linearIdentity :: a #-> a
+linearIdentity :: a %1-> a
 linearIdentity x = x
 
 {-
@@ -43,7 +43,7 @@ linearIdentity x = x
 -}
 
 
-linearSwap :: (a,a) #-> (a,a)
+linearSwap :: (a,a) %1-> (a,a)
 linearSwap (x,y) = (y,x)
 
 {-
@@ -52,7 +52,7 @@ linearSwap (x,y) = (y,x)
    in linear haskell is linear -- i.e., notice the type of the
    constructor:
 
-   (,) :: a #-> b #-> (a,b)
+   (,) :: a %1-> b %1-> (a,b)
 
    Now, this does not mean that if we have some non-linear function with
    an argument (a,b) that `a` and `b` have to be consumed exactly once.
@@ -82,7 +82,7 @@ nonLinearSubsume (x,_) = (x,x)
    the first argument would be linear, and the constructor is linear in both
    components.
 
-   (,) :: a #-> b #-> (a,b)
+   (,) :: a %1-> b %1-> (a,b)
 
    Again, in a linear function, this means the `a` and `b` must be used
    linearly.
@@ -91,14 +91,14 @@ nonLinearSubsume (x,_) = (x,x)
    zero times.
 -}
 
-linearPairIdentity :: (a,a) #-> (a,a)
+linearPairIdentity :: (a,a) %1-> (a,a)
 linearPairIdentity (x,y) = (x,y)
 
 {-
    Here, notice that `(a,a)` is linear, and since `(,)` is linear
    on both arguments, both `a`s must be used linearly, and indeed
    they are. Each is consumed exactly once in a linear input
-   to the constructor `(,) :: a #-> b #-> (a,b)`.
+   to the constructor `(,) :: a %1-> b %1-> (a,b)`.
 
    Notice the general pattern: we consumed `(a,b)` linearly by pattern matching
    into `Constructor arg1 ... argn` and consumed the linearly bound arguments
@@ -107,7 +107,7 @@ linearPairIdentity (x,y) = (x,y)
 -}
 
 
-linearIdentity2 :: a #-> a
+linearIdentity2 :: a %1-> a
 linearIdentity2 x = linearIdentity x
 
 {-
@@ -149,7 +149,7 @@ nonLinearTriple x = (linearIdentity x, linearIdentity (nonLinearPair2 x))
 
    DEFINITION.
    ==========
-   Let f :: A #-> B.  Suppose that we don't have the identity, "f x = x"
+   Let f :: A %1-> B.  Suppose that we don't have the identity, "f x = x"
    which is trivially linear. Then, the thunk (f x) is basically a tree
    composed of function applications, data constructors and case
    statements.
@@ -197,10 +197,10 @@ regularIdentity x = linearIdentity x
 -}
 
 
-(#.) :: (b #-> c) -> (a #-> b) -> (a #-> c)
+(#.) :: (b %1-> c) -> (a %1-> b) -> (a %1-> c)
 g #. f = \a -> g (f a)
 
-linearCompose :: (a,a) #-> (a,a)
+linearCompose :: (a,a) %1-> (a,a)
 linearCompose = linearIdentity #. linearSwap
 
 {-
@@ -209,7 +209,7 @@ linearCompose = linearIdentity #. linearSwap
    functions.  Notice that we cannot write a function of the following
    type:
 
-   (##.) :: (b -> c) -> (a #-> b) -> (a #-> c)
+   (##.) :: (b -> c) -> (a %1-> b) -> (a %1-> c)
 -}
 
 
@@ -223,22 +223,22 @@ linearCompose = linearIdentity #. linearSwap
 -}
 
 data LinearHolder a where
-  LinearHolder :: a #-> LinearHolder a
+  LinearHolder :: a %1-> LinearHolder a
 
-linearHold :: a #-> LinearHolder a
+linearHold :: a %1-> LinearHolder a
 linearHold x = LinearHolder x
 
 {-
-   Note that if the constructor LinearHolder did not have the #-> then
+   Note that if the constructor LinearHolder did not have the %1-> then
    linearHold would not compile, because then you could use the value
    non-linearly.
 -}
 
 
-linearHoldExtract :: LinearHolder a #-> a
+linearHoldExtract :: LinearHolder a %1-> a
 linearHoldExtract (LinearHolder x) = x
 
-linearIdentity3 :: a #-> a
+linearIdentity3 :: a %1-> a
 linearIdentity3 = linearHoldExtract #. linearHold
 
 {-
@@ -246,19 +246,19 @@ linearIdentity3 = linearHoldExtract #. linearHold
    Here, linearHoldExtract must use the inner component linearly.
    Therefore, it's impossible to implement the following function:
 
-   linearHoldPair :: LinearHolder a #-> (a,a)
+   linearHoldPair :: LinearHolder a %1-> (a,a)
    linearHoldPair (LinearHolder x) = (x,x)
 
    In fact, we have the following equivalence:
 
-   (LinearHolder a  #-> b) ≅ (a #-> b)
+   (LinearHolder a  %1-> b) ≅ (a %1-> b)
 -}
 
 
 data LinearHolder2 where
-  LinearHolder2 :: a #-> b -> LinearHolder2
+  LinearHolder2 :: a %1-> b -> LinearHolder2
 
-linearHold' :: a #-> LinearHolder2
+linearHold' :: a %1-> LinearHolder2
 linearHold' x = LinearHolder2 x "hello"
 --linearHold' x = LinearHolder2 "hi" x -- fails to type check
 
@@ -272,7 +272,7 @@ linearHold' x = LinearHolder2 x "hello"
 data ForcedUnlinear a where
   ForcedUnlinear :: a -> ForcedUnlinear a
 
-forcedLinearPair :: ForcedUnlinear a #-> (a,a)
+forcedLinearPair :: ForcedUnlinear a %1-> (a,a)
 forcedLinearPair (ForcedUnlinear x) = (x,x)
 
 {-
@@ -282,14 +282,14 @@ forcedLinearPair (ForcedUnlinear x) = (x,x)
    Hence, we can write the function above but could not write something
    the following type:
 
-   linearPair :: a #-> (a,a)
+   linearPair :: a %1-> (a,a)
 -}
 
 
-demote :: (ForcedUnlinear a #-> b) -> (a -> b)
+demote :: (ForcedUnlinear a %1-> b) -> (a -> b)
 demote f x = f (ForcedUnlinear x)
 
-promote :: (a -> b) -> (ForcedUnlinear a #-> b)
+promote :: (a -> b) -> (ForcedUnlinear a %1-> b)
 promote f (ForcedUnlinear x) = f x
 
 
@@ -297,7 +297,7 @@ promote f (ForcedUnlinear x) = f x
    Another way of saying this is the following equivalence proven by the
    two functions above:
 
-   (ForcedUnlinear a  #-> b) ≅ (a -> b)
+   (ForcedUnlinear a  %1-> b) ≅ (a -> b)
 
    In the Linear Haskell POPL '18 paper, this datatype is called
    Unrestricted.

--- a/examples/Simple/TopSort.hs
+++ b/examples/Simple/TopSort.hs
@@ -56,24 +56,24 @@ topsort = reverse . postOrder . fmap (  \(n,nbrs) -> (n,(nbrs,0))  )
         \hm -> postOrderHM nodes (HMap.insertAll xs hm)
 
 
-postOrderHM :: [Node] -> InDegGraph #-> Ur [Node]
+postOrderHM :: [Node] -> InDegGraph %1-> Ur [Node]
 postOrderHM nodes dag = findSources nodes (computeInDeg nodes dag) & \case
   (dag, Ur sources) -> pluckSources sources [] dag
  where
    -- O(V + N)
-  computeInDeg :: [Node] -> InDegGraph #-> InDegGraph
+  computeInDeg :: [Node] -> InDegGraph %1-> InDegGraph
   computeInDeg nodes dag = Linear.foldl incChildren dag (map Ur nodes)
 
   -- Increment in-degree of all neighbors
-  incChildren :: InDegGraph #-> Ur Node #-> InDegGraph
+  incChildren :: InDegGraph %1-> Ur Node %1-> InDegGraph
   incChildren dag (Ur node) = HMap.lookup node dag & \case
      (Ur Nothing, dag) -> dag
      (Ur (Just (xs,i)), dag) -> incNodes (move xs) dag
     where
-      incNodes :: Ur [Node] #-> InDegGraph #-> InDegGraph
+      incNodes :: Ur [Node] %1-> InDegGraph %1-> InDegGraph
       incNodes (Ur ns) dag = Linear.foldl incNode dag (map Ur ns)
 
-      incNode :: InDegGraph #-> Ur Node #-> InDegGraph
+      incNode :: InDegGraph %1-> Ur Node %1-> InDegGraph
       incNode dag (Ur node) = HMap.lookup node dag & \case
         (Ur Nothing, dag') -> dag'
         (Ur (Just (n,d)), dag') ->
@@ -81,7 +81,7 @@ postOrderHM nodes dag = findSources nodes (computeInDeg nodes dag) & \case
         --HMap.alter dag (\(Just (n,d)) -> Just (n,d+1)) node
 
 -- pluckSources sources postOrdSoFar dag
-pluckSources :: [Node] -> [Node] -> InDegGraph #-> Ur [Node]
+pluckSources :: [Node] -> [Node] -> InDegGraph %1-> Ur [Node]
 pluckSources [] postOrd dag = lseq dag (move postOrd)
 pluckSources (s:ss) postOrd dag = HMap.lookup s dag & \case
   (Ur Nothing, dag) -> pluckSources ss (s:postOrd) dag
@@ -90,12 +90,12 @@ pluckSources (s:ss) postOrd dag = HMap.lookup s dag & \case
         pluckSources (newSrcs ++ ss) (s:postOrd) dag'
   where
     -- decrement degree of children, save newly made sources
-    walk :: [Node] -> InDegGraph #-> (InDegGraph, Ur [Node])
+    walk :: [Node] -> InDegGraph %1-> (InDegGraph, Ur [Node])
     walk children dag =
       second (Data.fmap catMaybes) (mapAccum decDegree children dag)
 
     -- Decrement the degree of a node, save it if it is now a source
-    decDegree :: Node -> InDegGraph #-> (InDegGraph, Ur (Maybe Node))
+    decDegree :: Node -> InDegGraph %1-> (InDegGraph, Ur (Maybe Node))
     decDegree node dag = HMap.lookup node dag & \case
         (Ur Nothing, dag') -> (dag', Ur Nothing)
         (Ur (Just (n,d)), dag') ->
@@ -103,13 +103,13 @@ pluckSources (s:ss) postOrd dag = HMap.lookup s dag & \case
 
 
 -- Given a list of nodes, determines which are sources
-findSources :: [Node] -> InDegGraph #-> (InDegGraph, Ur [Node])
+findSources :: [Node] -> InDegGraph %1-> (InDegGraph, Ur [Node])
 findSources nodes dag =
   second (Data.fmap catMaybes) (mapAccum checkSource nodes dag)
 
 
 -- | Check if a node is a source, and if so return it
-checkSource :: Node -> InDegGraph #-> (InDegGraph, Ur (Maybe Node))
+checkSource :: Node -> InDegGraph %1-> (InDegGraph, Ur (Maybe Node))
 checkSource node dag = HMap.lookup node dag & \case
   (Ur Nothing, dag) -> (dag, Ur Nothing)
   (Ur (Just (xs,0)), dag) ->  (dag, Ur (Just node))
@@ -117,7 +117,7 @@ checkSource node dag = HMap.lookup node dag & \case
 
 
 mapAccum ::
-  (a -> b #-> (b, Ur c)) -> [a] -> b #-> (b, Ur [c])
+  (a -> b %1-> (b, Ur c)) -> [a] -> b %1-> (b, Ur [c])
 mapAccum f [] b =  (b, Ur [])
 mapAccum f (x:xs) b = mapAccum f xs b & \case
   (b, Ur cs) -> second (Data.fmap (:cs)) (f x b)

--- a/examples/Spec.hs
+++ b/examples/Spec.hs
@@ -22,7 +22,7 @@ import Prelude.Linear hiding (void)
 import Test.Hspec
 import Test.QuickCheck
 
-eqList :: forall a. (Manual.Representable a, Movable a, Eq a) => List a #-> List a #-> Ur Bool
+eqList :: forall a. (Manual.Representable a, Movable a, Eq a) => List a %1-> List a %1-> Ur Bool
 eqList l1 l2 = move $ (List.toList l1) == (List.toList l2)
 
 data InjectedError = InjectedError
@@ -37,7 +37,7 @@ main = hspec Prelude.$ do
       it "is invertible" Prelude.$
         property (\(l :: [Int]) -> unur (Manual.withPool $ \pool ->
           let
-            check :: Ur [Int] #-> Ur Bool
+            check :: Ur [Int] %1-> Ur Bool
             check (Ur l') = move $ l' == l
           in
             check $ move (List.toList $ List.ofList l pool)))
@@ -46,7 +46,7 @@ main = hspec Prelude.$ do
       it "of identity is the identity" Prelude.$
         property (\(l :: [Int]) -> unur (Manual.withPool $ \pool ->
           let
-            check :: (Pool, Pool, Pool) #-> Ur Bool
+            check :: (Pool, Pool, Pool) %1-> Ur Bool
             check (pool1, pool2, pool3) =
               eqList
                 (List.map (\x -> x) (List.ofList l pool1) pool2)

--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -8,16 +8,10 @@ author: Tweag
 maintainer: arnaud.spiwack@tweag.io
 copyright: (c) Tweag Holding and affiliates
 category: Prelude
-build-type: Custom
+build-type: Simple
 extra-source-files: README.md
 synopsis: Standard library for linear types.
 description: Please see README.md.
-
-custom-setup
- setup-depends:
-   base >= 4 && <5,
-   Cabal,
-   cabal-doctest
 
 library
   hs-source-dirs: src
@@ -128,15 +122,38 @@ test-suite examples
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   default-language: Haskell2010
 
-test-suite doctests
-  type:                 exitcode-stdio-1.0
-  hs-source-dirs:       test/
-  main-is:              Doctest.hs
-  build-depends:        base
-                      , doctest
-                      , linear-base
-  ghc-options:          -Wall -threaded
-  default-language:     Haskell2010
+-- TODO: Uncomment below block and set 'build-type' to 'Custom' to enable
+-- doctests once cabal-install 3.4 is released.
+--
+-- Longer story:
+--
+-- cabal-install has a piece of code[1] which injects a Cabal upper bound to
+-- packages with custom Setup.hs's. And this happens after the overrides,
+-- so the usual mechanisms of overriding upper bounds does not work.
+--
+-- GHC 9 comes with Cabal 3.4, which is above that bound. So, when using
+-- GHC 9 with cabal-install 3.2; `build-type: Custom` causes another Cabal
+-- library to be built, and that causes a strange type error ("expecting IO,
+-- but got IO"), which I suspect because it conflicts with the existing boot
+-- packages.
+--
+-- [1]: https://github.com/haskell/cabal/blob/d28c80acc69b9e7fa992a0b2b7fced937734b238/cabal-install/src/Distribution/Client/ProjectPlanning.hs#L1132-L1149
+
+-- custom-setup
+--  setup-depends:
+--    base >= 4 && <5,
+--    Cabal,
+--    cabal-doctest
+--
+-- test-suite doctests
+--   type:                 exitcode-stdio-1.0
+--   hs-source-dirs:       test/
+--   main-is:              Doctest.hs
+--   build-depends:        base
+--                       , doctest
+--                       , linear-base
+--   ghc-options:          -Wall -threaded
+--   default-language:     Haskell2010
 
 source-repository head
   type: git

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,7 +1,7 @@
 let
   # https://github.com/tweag/nixpkgs/tree/update-ghchead-20201001
-  rev = "647a878e061b1b63efd2094eb9e546c2a7aa0d58";
-  sha256 = "1cfn53nls9kfh4ql8bn94zgvajm93bd390927fi345d943hnph84";
+  rev = "60a06c5a2ec88392c1eb5e252367dde4e0ead16c";
+  sha256 = "0952kxb7zlw81vwk72dm4cxs01ygqgbxsy0ibqsj7khr7xp115jh";
 in
 import (fetchTarball {
   inherit sha256;

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,9 +1,9 @@
 let
-  # 2020-08-31 master
-  rev = "6716867eb3e763818000eab04f378b86cadc2894";
-  sha256 = "19fnqwpq1rk4iibbgq04j9w72s4n31nlz7m26iqhqd5lh7p8sc42";
+  # https://github.com/tweag/nixpkgs/tree/update-ghchead-20201001
+  rev = "647a878e061b1b63efd2094eb9e546c2a7aa0d58";
+  sha256 = "1cfn53nls9kfh4ql8bn94zgvajm93bd390927fi345d943hnph84";
 in
 import (fetchTarball {
   inherit sha256;
-  url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+  url = "https://github.com/utdemir/nixpkgs/archive/${rev}.tar.gz";
 })

--- a/src/Control/Monad/IO/Class/Linear.hs
+++ b/src/Control/Monad/IO/Class/Linear.hs
@@ -10,7 +10,7 @@ import qualified System.IO.Linear as Linear
 -- | Like 'NonLinear.MonadIO' but allows to lift both linear
 -- and non-linear 'IO' actions into a linear monad.
 class Linear.Monad m => MonadIO m where
-  liftIO :: Linear.IO a #-> m a
+  liftIO :: Linear.IO a %1-> m a
   liftSystemIO :: System.IO a -> m a
   liftSystemIO io = liftIO (Linear.fromSystemIO io)
   liftSystemIOU :: System.IO a -> m (Ur a)

--- a/src/Data/Array/Polarized.hs
+++ b/src/Data/Array/Polarized.hs
@@ -30,19 +30,19 @@ import Data.Vector (Vector)
 -- There are three types of array which are involved, with conversion
 -- functions available between them, the third being an allocated Vector.
 -- The primary conversion functions are:
--- > Polarized.transfer :: Pull.Array a #-> Push.Array a
--- > Push.alloc :: Push.Array a #-> Vector a
--- > Pull.fromVector :: Vector a #-> Pull.Array a
+-- > Polarized.transfer :: Pull.Array a %1-> Push.Array a
+-- > Push.alloc :: Push.Array a %1-> Vector a
+-- > Pull.fromVector :: Vector a %1-> Pull.Array a
 -- In this way, we gain further control over exactly when allocation may occur
 -- in a fusion pipeline.
 -- In such a pipeline converting one allocated array to another, it would be
 -- common to begin with Pull.fromVector, and end with Push.alloc.
 
 -- | Convert a PullArray into a PushArray.
-transfer :: Pull.Array a #-> Push.Array a
+transfer :: Pull.Array a %1-> Push.Array a
 transfer (Pull.Array f n) = Push.Array (\g -> DArray.fromFunction (\i -> g (f i))) n
 
 -- | This is a shortcut convenience function, which does the same thing as
 -- `transfer` . `Pull.fromVector`
-walk :: Vector a #-> Push.Array a
+walk :: Vector a %1-> Push.Array a
 walk = transfer . Pull.fromVector

--- a/src/Data/Array/Polarized/Pull.hs
+++ b/src/Data/Array/Polarized/Pull.hs
@@ -39,18 +39,18 @@ import qualified Data.Vector as Vector
 import qualified Unsafe.Linear as Unsafe
 
 -- | Convert a pull array into a list.
-asList :: Array a #-> [a]
+asList :: Array a %1-> [a]
 asList = foldr (\x xs -> x:xs) []
 
 -- | /!\ Partial! Only works if both arrays have the same length.
-zipWith :: (a #-> b #-> c) -> Array a #-> Array b #-> Array c
+zipWith :: (a %1-> b %1-> c) -> Array a %1-> Array b %1-> Array c
 zipWith f x y = Data.fmap (uncurry f) (zip x y)
 
 -- | Fold a pull array into a monoid.
-foldMap :: Monoid m => (a #-> m) -> Array a #-> m
+foldMap :: Monoid m => (a %1-> m) -> Array a %1-> m
 foldMap f = foldr ((<>) . f) mempty
 
 -- I'm fairly sure this can be used safely
 -- | Convert a Vector to a pull array.
-fromVector :: Vector a #-> Array a
+fromVector :: Vector a %1-> Array a
 fromVector = Unsafe.toLinear $ \v -> fromFunction (v Vector.!) (Vector.length v)

--- a/src/Data/Array/Polarized/Pull/Internal.hs
+++ b/src/Data/Array/Polarized/Pull/Internal.hs
@@ -37,18 +37,18 @@ instance Data.Functor Array where
 -- taken out of the Array (which is interesting in and of itself: I think this
 -- is like an n-ary With), and changing the other arrows makes no difference)
 -- | Produce a pull array consisting of solely the given element.
-singleton :: a #-> Array a
+singleton :: a %1-> Array a
 singleton = Unsafe.toLinear (\x -> fromFunction (\_ -> x) 1)
 
 -- | /!\ Partial! Only works if both arrays have the same length.
 -- Zip both pull arrays together.
-zip :: Array a #-> Array b #-> Array (a,b)
+zip :: Array a %1-> Array b %1-> Array (a,b)
 zip (Array g n) (Array h m)
   | n /= m    = error "Polarized.zip: size mismatch"
   | otherwise = fromFunction (\k -> (g k, h k)) n
 
 -- | Concatenate two pull arrays.
-append :: Array a #-> Array a #-> Array a
+append :: Array a %1-> Array a %1-> Array a
 append (Array f m) (Array g n) = Array h (m + n)
   where h k = if k < m
                  then f k
@@ -62,9 +62,9 @@ instance Semigroup (Array a) where
   (<>) = append
 
 -- A right-fold of a pull array.
-foldr :: (a #-> b #-> b) -> b #-> Array a #-> b
+foldr :: (a %1-> b %1-> b) -> b %1-> Array a %1-> b
 foldr f z (Array g n) = go f z g n
-  where go :: (_ #-> _ #-> _) -> _ #-> _ -> _ -> _
+  where go :: (_ %1-> _ %1-> _) -> _ %1-> _ -> _ -> _
         go _ z' _ 0 = z'
         go f' z' g' k = go f' (f' (g' (k-1)) z') g' (k-1)
         -- go is strict in its last argument
@@ -72,7 +72,7 @@ foldr f z (Array g n) = go f z g n
 -- | Extract the length of an array, and give back the original array. This
 -- is possible since getting the length of an array doesn't count as consuming
 -- it.
-findLength :: Array a #-> (Int, Array a)
+findLength :: Array a %1-> (Int, Array a)
 findLength (Array f n) = (n, Array f n)
 
 -- | A constructor for pull arrays from a function and specified length.
@@ -88,7 +88,7 @@ fromFunction f n = Array f' n
 
 -- | This is a shortcut function, which does the same thing as
 -- `alloc` . `transfer`
-toVector :: Array a #-> Vector a
+toVector :: Array a %1-> Vector a
 toVector (Array f n) = Vector.generate n f
 -- TODO: A test to make sure alloc . transfer == toVector
 
@@ -96,9 +96,9 @@ toVector (Array f n) = Vector.generate n f
 --
 -- 'split' is total: if @n@ is larger than the length of @v@, then @vr@ is
 -- empty.
-split :: Int -> Array a #-> (Array a, Array a)
+split :: Int -> Array a %1-> (Array a, Array a)
 split k (Array f n) = (fromFunction f (min k n), fromFunction (\x -> f (x+k)) (max (n-k) 0))
 
 -- | Reverse a pull array.
-reverse :: Array a #-> Array a
+reverse :: Array a %1-> Array a
 reverse (Array f n) = Array (\x -> f (n+1-x)) n

--- a/src/Data/Bifunctor/Linear.hs
+++ b/src/Data/Bifunctor/Linear.hs
@@ -18,7 +18,7 @@
 -- > import Data.Bifunctor.Linear
 -- >
 -- > -- Map over the second element
--- > negateRight :: (Int, Bool) #-> (Int, Bool)
+-- > negateRight :: (Int, Bool) %1-> (Int, Bool)
 -- > negateRight x = second not x
 module Data.Bifunctor.Linear
   ( Bifunctor(..),
@@ -47,15 +47,15 @@ import Data.Void
 -- @'bimap' f g = 'first' f '.' 'second' g
 class Bifunctor p where
   {-# MINIMAL bimap | (first , second) #-}
-  bimap :: (a #-> b) -> (c #-> d) -> a `p` c #-> b `p` d
+  bimap :: (a %1-> b) -> (c %1-> d) -> a `p` c %1-> b `p` d
   bimap f g x = first f (second g x)
   {-# INLINE bimap #-}
 
-  first :: (a #-> b) -> a `p` c #-> b `p` c
+  first :: (a %1-> b) -> a `p` c %1-> b `p` c
   first f = bimap f id
   {-# INLINE first #-}
 
-  second :: (b #-> c) -> a `p` b #-> a `p` c
+  second :: (b %1-> c) -> a `p` b %1-> a `p` c
   second = bimap id
   {-# INLINE second #-}
 
@@ -72,9 +72,9 @@ instance Bifunctor Either where
 -- This allows you to shuffle around a bifunctor nested in itself and swap the
 -- places of the two types held in the bifunctor. For instance, for tuples:
 --
---  * You can use @lassoc :: (a,(b,c)) #-> ((a,b),c)@ and then use 'first' to access the @a@
---  * You can use the dual, i.e., @ rassoc :: ((a,b),c) #-> (a,(b,c))@ and then 'second'
---  * You can swap the first and second values with @swap :: (a,b) #-> (b,a)@
+--  * You can use @lassoc :: (a,(b,c)) %1-> ((a,b),c)@ and then use 'first' to access the @a@
+--  * You can use the dual, i.e., @ rassoc :: ((a,b),c) %1-> (a,(b,c))@ and then 'second'
+--  * You can swap the first and second values with @swap :: (a,b) %1-> (b,a)@
 --
 --  == Laws
 --
@@ -85,11 +85,11 @@ instance Bifunctor Either where
 class Bifunctor m => SymmetricMonoidal (m :: Type -> Type -> Type) (u :: Type)
     | m -> u, u -> m where
   {-# MINIMAL swap, (rassoc | lassoc) #-}
-  rassoc :: (a `m` b) `m` c #-> a `m` (b `m` c)
+  rassoc :: (a `m` b) `m` c %1-> a `m` (b `m` c)
   rassoc = swap . lassoc . swap . lassoc . swap
-  lassoc :: a `m` (b `m` c) #-> (a `m` b) `m` c
+  lassoc :: a `m` (b `m` c) %1-> (a `m` b) `m` c
   lassoc = swap . rassoc . swap . rassoc . swap
-  swap :: a `m` b #-> b `m` a
+  swap :: a `m` b %1-> b `m` a
 -- XXX: should unitors be added?
 -- XXX: Laws don't seem minimial
 
@@ -100,7 +100,7 @@ instance SymmetricMonoidal (,) () where
 instance SymmetricMonoidal Either Void where
   swap = either Right Left
   rassoc (Left (Left x)) = Left x
-  rassoc (Left (Right x)) = (Right :: a #-> Either b a) (Left x)
-  rassoc (Right x) = (Right :: a #-> Either b a) (Right x)
+  rassoc (Left (Right x)) = (Right :: a %1-> Either b a) (Left x)
+  rassoc (Right x) = (Right :: a %1-> Either b a) (Right x)
 -- XXX: the above type signatures are necessary for certain older versions of
 -- the compiler, and as such are temporary

--- a/src/Data/Bool/Linear.hs
+++ b/src/Data/Bool/Linear.hs
@@ -17,7 +17,7 @@ import Prelude (Bool(..), otherwise)
 
 -- | @True@ iff both are @True@.
 -- __NOTE:__ this is strict and not lazy!
-(&&) :: Bool #-> Bool #-> Bool
+(&&) :: Bool %1-> Bool %1-> Bool
 False && False = False
 False && True = False
 True && x = x
@@ -26,7 +26,7 @@ infixr 3 &&
 
 -- | @True@ iff either is @True@
 -- __NOTE:__ this is strict and not lazy!
-(||) :: Bool #-> Bool #-> Bool
+(||) :: Bool %1-> Bool %1-> Bool
 True || False = True
 True || True = True
 False || x = x
@@ -35,6 +35,6 @@ infixr 2 ||
 
 -- | @not b@ is @True@ iff b is @False@
 -- __NOTE:__ this is strict and not lazy!
-not :: Bool #-> Bool
+not :: Bool %1-> Bool
 not False = True
 not True = False

--- a/src/Data/Either/Linear.hs
+++ b/src/Data/Either/Linear.hs
@@ -26,42 +26,42 @@ import Prelude (Either(..))
 -- | Linearly consume an @Either@ by applying the first linear function on a
 -- value constructed with @Left@ and the second linear function on a value
 -- constructed with @Right@.
-either :: (a #-> c) -> (b #-> c) -> Either a b #-> c
+either :: (a %1-> c) -> (b %1-> c) -> Either a b %1-> c
 either f _ (Left x) = f x
 either _ g (Right y) = g y
 
 
 -- | Get all the left elements in order, and consume the right ones.
-lefts :: Consumable b => [Either a b] #-> [a]
+lefts :: Consumable b => [Either a b] %1-> [a]
 lefts [] = []
 lefts (Left a : xs) = a : lefts xs
 lefts (Right b : xs) = lseq b (lefts xs)
 
 
 -- | Get all the right elements in order, and consume the left ones.
-rights :: Consumable a => [Either a b] #-> [b]
+rights :: Consumable a => [Either a b] %1-> [b]
 rights [] = []
 rights (Left a : xs) = lseq a (rights xs)
 rights (Right b : xs) = b : rights xs
 
 
 -- | Get the left element of a consumable @Either@ with a default
-fromLeft :: (Consumable a, Consumable b) => a #-> Either a b #-> a
+fromLeft :: (Consumable a, Consumable b) => a %1-> Either a b %1-> a
 fromLeft x (Left a) = lseq x a
 fromLeft x (Right b) = lseq b x
 
 -- | Get the right element of a consumable @Either@ with a default
-fromRight :: (Consumable a, Consumable b) => b #-> Either a b #-> b
+fromRight :: (Consumable a, Consumable b) => b %1-> Either a b %1-> b
 fromRight x (Left a) = lseq a x
 fromRight x (Right b) = lseq x b
 
 -- | Partition and consume a list of @Either@s into two lists with all the
 -- lefts in one and the rights in the second, in the order they appeared in the
 -- initial list.
-partitionEithers :: [Either a b] #-> ([a], [b])
+partitionEithers :: [Either a b] %1-> ([a], [b])
 partitionEithers [] = ([], [])
 partitionEithers (x:xs) = fromRecur x (partitionEithers xs)
   where
-    fromRecur :: Either a b #-> ([a], [b]) #-> ([a], [b])
+    fromRecur :: Either a b %1-> ([a], [b]) %1-> ([a], [b])
     fromRecur (Left a) (as, bs) = (a:as, bs)
     fromRecur (Right b) (as, bs) = (as, b:bs)

--- a/src/Data/Eq/Linear.hs
+++ b/src/Data/Eq/Linear.hs
@@ -12,6 +12,7 @@ module Data.Eq.Linear
 
 import Data.Bool.Linear
 import qualified Prelude
+import Prelude.Linear.Internal
 import Data.Unrestricted.Linear
 
 -- | Testing equality on values.
@@ -26,9 +27,9 @@ import Data.Unrestricted.Linear
 --
 class Eq a where
   {-# MINIMAL (==) | (/=) #-}
-  (==) :: a #-> a #-> Bool
+  (==) :: a %1-> a %1-> Bool
   x == y = not (x /= y)
-  (/=) :: a #-> a #-> Bool
+  (/=) :: a %1-> a %1-> Bool
   x /= y = not (x == y)
   infix 4 ==, /=
 
@@ -77,9 +78,9 @@ newtype MovableEq a = MovableEq a
 
 instance (Prelude.Eq a, Movable a) => Eq (MovableEq a) where
   MovableEq ar == MovableEq br
-    | Ur a <- move ar , Ur b <- move br
-    = a Prelude.== b
+    = move (ar, br) & \(Ur (a, b)) ->
+        a Prelude.== b
 
   MovableEq ar /= MovableEq br
-    | Ur a <- move ar , Ur b <- move br
-    = a Prelude./= b
+    = move (ar, br) & \(Ur (a, b)) ->
+        a Prelude./= b

--- a/src/Data/Functor/Linear.hs
+++ b/src/Data/Functor/Linear.hs
@@ -37,5 +37,5 @@ import Data.Unrestricted.Linear
 
 -- | Replace all occurances of @b@ with the given @a@
 -- and consume the functor @f b@.
-(<$) :: (Functor f, Consumable b) => a -> f b #-> f a
+(<$) :: (Functor f, Consumable b) => a -> f b %1-> f a
 a <$ fb = fmap (`lseq` a) fb

--- a/src/Data/Functor/Linear/Internal.hs
+++ b/src/Data/Functor/Linear/Internal.hs
@@ -18,13 +18,13 @@ import qualified Control.Monad.Trans.Except as NonLinear
 import qualified Control.Monad.Trans.State.Strict as Strict
 
 -- | Linear Data Functors should be thought of as containers holding values of
--- type @a@ over which you are able to apply a linear function of type @a #->
+-- type @a@ over which you are able to apply a linear function of type @a %1->
 -- b@ __on each__ value of type @a@ in the functor and consume a given functor
 -- of type @f a@.
 class Functor f where
-  fmap :: (a #-> b) -> f a #-> f b
+  fmap :: (a %1-> b) -> f a %1-> f b
 
-(<$>) :: Functor f => (a #-> b) -> f a #-> f b
+(<$>) :: Functor f => (a %1-> b) -> f a %1-> f b
 (<$>) = fmap
 
 -- | Data 'Applicative'-s can be seen as containers which can be zipped
@@ -33,7 +33,7 @@ class Functor f where
 -- drops values, which we are not allowed to do in a linear container).
 --
 -- In fact, an applicative functor is precisely a functor equipped with (pure
--- and) @liftA2 :: (a #-> b #-> c) -> f a #-> f b #-> f c@. In the case where
+-- and) @liftA2 :: (a %1-> b %1-> c) -> f a %1-> f b %1-> f c@. In the case where
 -- @f = []@, the signature of 'liftA2' would specialise to that of 'zipWith'.
 --
 -- Intuitively, the type of 'liftA2' means that 'Applicative's can be seen as
@@ -48,8 +48,8 @@ class Functor f where
 -- An 'Applicative' is, as in the restricted case, a lax monoidal endofunctor of
 -- the category of linear types. That is, it is equipped with
 --
--- * a (linear) function @() #-> f ()@
--- * a (linear) natural transformation @(f a, f b) #-> f (a, b)@
+-- * a (linear) function @() %1-> f ()@
+-- * a (linear) natural transformation @(f a, f b) %1-> f (a, b)@
 --
 -- It is a simple exercise to verify that these are equivalent to the definition
 -- of 'Applicative'. Hence that the choice of linearity of the various arrow is
@@ -57,9 +57,9 @@ class Functor f where
 class Functor f => Applicative f where
   {-# MINIMAL pure, (liftA2 | (<*>)) #-}
   pure :: a -> f a
-  (<*>) :: f (a #-> b) #-> f a #-> f b
+  (<*>) :: f (a %1-> b) %1-> f a %1-> f b
   f <*> x = liftA2 ($) f x
-  liftA2 :: (a #-> b #-> c) -> f a #-> f b #-> f c
+  liftA2 :: (a %1-> b %1-> c) -> f a %1-> f b %1-> f c
   liftA2 f x y = f <$> x <*> y
 
 ---------------

--- a/src/Data/Functor/Linear/Internal/Traversable.hs
+++ b/src/Data/Functor/Linear/Internal/Traversable.hs
@@ -29,7 +29,7 @@ import Prelude (Maybe(..), Either(..))
 -- TODO: maybe add a Foldable class between Functor and Traversable as well
 
 -- | A linear data traversible is a functor of type @t a@ where you can apply a
--- linear effectful action of type @a #-> f b@ on each value of type @a@ and
+-- linear effectful action of type @a %1-> f b@ on each value of type @a@ and
 -- compose this to perform an action on the whole functor, resulting in a value
 -- of type @f (t b)@.
 --
@@ -53,44 +53,44 @@ import Prelude (Maybe(..), Either(..))
 class Data.Functor t => Traversable t where
   {-# MINIMAL traverse | sequence #-}
 
-  traverse :: Control.Applicative f => (a #-> f b) -> t a #-> f (t b)
+  traverse :: Control.Applicative f => (a %1-> f b) -> t a %1-> f (t b)
   {-# INLINE traverse #-}
   traverse f x = sequence (Data.fmap f x)
 
-  sequence :: Control.Applicative f => t (f a) #-> f (t a)
+  sequence :: Control.Applicative f => t (f a) %1-> f (t a)
   {-# INLINE sequence #-}
   sequence = traverse id
 
-mapM :: (Traversable t, Control.Monad m) => (a #-> m b) -> t a #-> m (t b)
+mapM :: (Traversable t, Control.Monad m) => (a %1-> m b) -> t a %1-> m (t b)
 mapM = traverse
 {-# INLINE mapM #-}
 
-sequenceA :: (Traversable t, Control.Applicative f) => t (f a) #-> f (t a)
+sequenceA :: (Traversable t, Control.Applicative f) => t (f a) %1-> f (t a)
 sequenceA = sequence
 {-# INLINE sequenceA #-}
 
-for :: (Traversable t, Control.Applicative f) => t a #-> (a #-> f b) -> f (t b)
+for :: (Traversable t, Control.Applicative f) => t a %1-> (a %1-> f b) -> f (t b)
 for t f = traverse f t
 {-# INLINE for #-}
 
-forM :: (Traversable t, Control.Monad m) => t a #-> (a #-> m b) -> m (t b)
+forM :: (Traversable t, Control.Monad m) => t a %1-> (a %1-> m b) -> m (t b)
 forM = for
 {-# INLINE forM #-}
 
-mapAccumL :: Traversable t => (a #-> b #-> (a,c)) -> a #-> t b #-> (a, t c)
+mapAccumL :: Traversable t => (a %1-> b %1-> (a,c)) -> a %1-> t b %1-> (a, t c)
 mapAccumL f s t = swap $ Control.runState (traverse (\b -> Control.state $ \i -> swap $ f i b) t) s
 
-mapAccumR :: Traversable t => (a #-> b #-> (a,c)) -> a #-> t b #-> (a, t c)
+mapAccumR :: Traversable t => (a %1-> b %1-> (a,c)) -> a %1-> t b %1-> (a, t c)
 mapAccumR f s t = swap $ runStateR (traverse (\b -> StateR $ \i -> swap $ f i b) t) s
 
-swap :: (a,b) #-> (b,a)
+swap :: (a,b) %1-> (b,a)
 swap (x,y) = (y,x)
 
 -- | A right-to-left state transformer
-newtype StateR s a = StateR (s #-> (a, s))
+newtype StateR s a = StateR (s %1-> (a, s))
   deriving (Data.Functor, Data.Applicative) via Control.Data (StateR s)
 
-runStateR :: StateR s a #-> s #-> (a, s)
+runStateR :: StateR s a %1-> s %1-> (a, s)
 runStateR (StateR f) = f
 
 instance Control.Functor (StateR s) where
@@ -99,7 +99,7 @@ instance Control.Functor (StateR s) where
 instance Control.Applicative (StateR s) where
   pure x = StateR $ \s -> (x,s)
   StateR f <*> StateR x = StateR (go . Control.fmap f . x)
-    where go :: (a, (a #-> b, s)) #-> (b, s)
+    where go :: (a, (a %1-> b, s)) %1-> (b, s)
           go (a, (h, s'')) = (h a, s'')
 
 ------------------------

--- a/src/Data/List/Linear.hs
+++ b/src/Data/List/Linear.hs
@@ -95,16 +95,16 @@ import qualified Data.List as NonLinear
 -- # Basic functions
 --------------------------------------------------
 
-(++) :: [a] #-> [a] #-> [a]
+(++) :: [a] %1-> [a] %1-> [a]
 (++) = Unsafe.toLinear2 (NonLinear.++)
 
-map :: (a #-> b) -> [a] #-> [b]
+map :: (a %1-> b) -> [a] %1-> [b]
 map = fmap
 
 -- | @filter p xs@ returns a list with elements satisfying the predicate.
 --
 -- See 'Data.Maybe.Linear.mapMaybe' if you do not want the 'Dupable' constraint.
-filter :: Dupable a => (a #-> Bool) -> [a] #-> [a]
+filter :: Dupable a => (a %1-> Bool) -> [a] %1-> [a]
 filter _ [] = []
 filter p (x:xs) =
   dup x & \case
@@ -113,15 +113,15 @@ filter p (x:xs) =
       then x'' : filter p xs
       else x'' `lseq` filter p xs
 
-uncons :: [a] #-> Maybe (a, [a])
+uncons :: [a] %1-> Maybe (a, [a])
 uncons [] = Nothing
 uncons (x:xs) = Just (x, xs)
 
-reverse :: [a] #-> [a]
+reverse :: [a] %1-> [a]
 reverse = Unsafe.toLinear NonLinear.reverse
 
 -- | Return the length of the given list alongside with the list itself.
-length :: [a] #-> (Ur Int, [a])
+length :: [a] %1-> (Ur Int, [a])
 length = Unsafe.toLinear $ \xs ->
   (Ur (NonLinear.length xs), xs)
 -- We can only do this because of the fact that 'NonLinear.length'
@@ -129,13 +129,13 @@ length = Unsafe.toLinear $ \xs ->
 
 --  'splitAt' @n xs@ returns a tuple where first element is @xs@ prefix of
 -- length @n@ and second element is the remainder of the list.
-splitAt :: Int -> [a] #-> ([a], [a])
+splitAt :: Int -> [a] %1-> ([a], [a])
 splitAt i = Unsafe.toLinear (Prelude.splitAt i)
 
 -- | 'span', applied to a predicate @p@ and a list @xs@, returns a tuple where
 -- first element is longest prefix (possibly empty) of @xs@ of elements that
 -- satisfy @p@ and second element is the remainder of the list.
-span :: Dupable a => (a #-> Bool) -> [a] #-> ([a], [a])
+span :: Dupable a => (a %1-> Bool) -> [a] %1-> ([a], [a])
 span _ [] = ([], [])
 span f (x:xs) = dup x & \case
   (x', x'') ->
@@ -146,10 +146,10 @@ span f (x:xs) = dup x & \case
 -- The partition function takes a predicate a list and returns the
 -- pair of lists of elements which do and do not satisfy the predicate,
 -- respectively.
-partition :: Dupable a => (a #-> Bool) -> [a] #-> ([a], [a])
+partition :: Dupable a => (a %1-> Bool) -> [a] %1-> ([a], [a])
 partition p (xs :: [a]) = foldr select ([], []) xs
  where
-  select :: a #-> ([a], [a]) #-> ([a], [a])
+  select :: a %1-> ([a], [a]) %1-> ([a], [a])
   select x (ts, fs) =
     dup2 x & \(x', x'') ->
       if p x'
@@ -158,7 +158,7 @@ partition p (xs :: [a]) = foldr select ([], []) xs
 
 -- | __NOTE__: This does not short-circuit and always traverses the
 -- entire list to consume the rest of the elements.
-takeWhile :: Dupable a => (a #-> Bool) -> [a] #-> [a]
+takeWhile :: Dupable a => (a %1-> Bool) -> [a] %1-> [a]
 takeWhile _ [] = []
 takeWhile p (x:xs) =
   dup2 x & \(x', x'') ->
@@ -166,7 +166,7 @@ takeWhile p (x:xs) =
     then x'' : takeWhile p xs
     else (x'', xs) `lseq` []
 
-dropWhile :: Dupable a => (a #-> Bool) -> [a] #-> [a]
+dropWhile :: Dupable a => (a %1-> Bool) -> [a] %1-> [a]
 dropWhile _ [] = []
 dropWhile p (x:xs) =
   dup2 x & \(x', x'') ->
@@ -176,13 +176,13 @@ dropWhile p (x:xs) =
 
 -- | __NOTE__: This does not short-circuit and always traverses the
 -- entire list to consume the rest of the elements.
-take :: Consumable a => Int -> [a] #-> [a]
+take :: Consumable a => Int -> [a] %1-> [a]
 take _ [] = []
 take i (x:xs)
   | i Prelude.< 0 = (x, xs) `lseq` []
   | otherwise = x : take (i-1) xs
 
-drop :: Consumable a => Int -> [a] #-> [a]
+drop :: Consumable a => Int -> [a] %1-> [a]
 drop _ [] = []
 drop i (x:xs)
   | i Prelude.< 0 = x:xs
@@ -191,111 +191,111 @@ drop i (x:xs)
 
 -- | The intersperse function takes an element and a list and
 -- `intersperses' that element between the elements of the list.
-intersperse :: a -> [a] #-> [a]
+intersperse :: a -> [a] %1-> [a]
 intersperse sep = Unsafe.toLinear (NonLinear.intersperse sep)
 
 -- | @intercalate xs xss@ is equivalent to @(concat (intersperse xs
 -- xss))@. It inserts the list xs in between the lists in xss and
 -- concatenates the result.
-intercalate :: [a] -> [[a]] #-> [a]
+intercalate :: [a] -> [[a]] %1-> [a]
 intercalate sep = Unsafe.toLinear (NonLinear.intercalate sep)
 
 -- | The transpose function transposes the rows and columns of its argument.
-transpose :: [[a]] #-> [[a]]
+transpose :: [[a]] %1-> [[a]]
 transpose = Unsafe.toLinear NonLinear.transpose
 
 -- # Folds
 --------------------------------------------------
 
-foldr :: (a #-> b #-> b) -> b #-> [a] #-> b
+foldr :: (a %1-> b %1-> b) -> b %1-> [a] %1-> b
 foldr f = Unsafe.toLinear2 (NonLinear.foldr (\a b -> f a b))
 
-foldr1 :: HasCallStack => (a #-> a #-> a) -> [a] #-> a
+foldr1 :: HasCallStack => (a %1-> a %1-> a) -> [a] %1-> a
 foldr1 f = Unsafe.toLinear (NonLinear.foldr1 (\a b -> f a b))
 
-foldl :: (b #-> a #-> b) -> b #-> [a] #-> b
+foldl :: (b %1-> a %1-> b) -> b %1-> [a] %1-> b
 foldl f = Unsafe.toLinear2 (NonLinear.foldl (\b a -> f b a))
 
-foldl' :: (b #-> a #-> b) -> b #-> [a] #-> b
+foldl' :: (b %1-> a %1-> b) -> b %1-> [a] %1-> b
 foldl' f = Unsafe.toLinear2 (NonLinear.foldl' (\b a -> f b a))
 
-foldl1 :: HasCallStack => (a #-> a #-> a) -> [a] #-> a
+foldl1 :: HasCallStack => (a %1-> a %1-> a) -> [a] %1-> a
 foldl1 f = Unsafe.toLinear (NonLinear.foldl1 (\a b -> f a b))
 
-foldl1' :: HasCallStack => (a #-> a #-> a) -> [a] #-> a
+foldl1' :: HasCallStack => (a %1-> a %1-> a) -> [a] %1-> a
 foldl1' f = Unsafe.toLinear (NonLinear.foldl1' (\a b -> f a b))
 
 -- | Map each element of the structure to a monoid,
 -- and combine the results.
-foldMap :: Monoid m => (a #-> m) -> [a] #-> m
+foldMap :: Monoid m => (a %1-> m) -> [a] %1-> m
 foldMap f = foldr ((<>) . f) mempty
 
 -- | A variant of 'foldMap' that is strict in the accumulator.
-foldMap' :: Monoid m => (a #-> m) ->  [a] #-> m
+foldMap' :: Monoid m => (a %1-> m) ->  [a] %1-> m
 foldMap' f = foldl' (\acc a -> acc <> f a) mempty
 
-concat :: [[a]] #-> [a]
+concat :: [[a]] %1-> [a]
 concat = Unsafe.toLinear NonLinear.concat
 
-concatMap :: (a #-> [b]) -> [a] #-> [b]
+concatMap :: (a %1-> [b]) -> [a] %1-> [b]
 concatMap f = Unsafe.toLinear (NonLinear.concatMap (forget f))
 
-sum :: AddIdentity a => [a] #-> a
+sum :: AddIdentity a => [a] %1-> a
 sum = foldl' (+) zero
 
-product :: MultIdentity a => [a] #-> a
+product :: MultIdentity a => [a] %1-> a
 product = foldl' (*) one
 
 -- | __NOTE:__ This does not short-circuit, and always consumes the
 -- entire container.
-any :: (a #-> Bool) -> [a] #-> Bool
+any :: (a %1-> Bool) -> [a] %1-> Bool
 any p = foldl' (\b a -> b || p a) False
 
 -- | __NOTE:__ This does not short-circuit, and always consumes the
 -- entire container.
-all :: (a #-> Bool) -> [a] #-> Bool
+all :: (a %1-> Bool) -> [a] %1-> Bool
 all p = foldl' (\b a -> b && p a) True
 
 -- | __NOTE:__ This does not short-circuit, and always consumes the
 -- entire container.
-and :: [Bool] #-> Bool
+and :: [Bool] %1-> Bool
 and = foldl' (&&) True
 
 -- | __NOTE:__ This does not short-circuit, and always consumes the
 -- entire container.
-or :: [Bool] #-> Bool
+or :: [Bool] %1-> Bool
 or = foldl' (||) False
 
 -- # Building Lists
 --------------------------------------------------
 
-iterate :: Dupable a => (a #-> a) -> a #-> [a]
+iterate :: Dupable a => (a %1-> a) -> a %1-> [a]
 iterate f a = dup2 a & \(a', a'') ->
   a' : iterate f (f a'')
 
-repeat :: Dupable a => a #-> [a]
+repeat :: Dupable a => a %1-> [a]
 repeat = iterate id
 
-cycle :: (HasCallStack, Dupable a) => [a] #-> [a]
+cycle :: (HasCallStack, Dupable a) => [a] %1-> [a]
 cycle [] = Prelude.error "cycle: empty list"
 cycle xs = dup2 xs & \(xs', xs'') -> xs' ++ cycle xs''
 
-scanl :: Dupable b => (b #-> a #-> b) -> b #-> [a] #-> [b]
+scanl :: Dupable b => (b %1-> a %1-> b) -> b %1-> [a] %1-> [b]
 scanl _ b [] = [b]
 scanl f b (x:xs) = dup2 b & \(b', b'') -> b' : scanl f (f b'' x) xs
 
-scanl1 :: Dupable a => (a #-> a #-> a) -> [a] #-> [a]
+scanl1 :: Dupable a => (a %1-> a %1-> a) -> [a] %1-> [a]
 scanl1 _ [] = []
 scanl1 f (x:xs) = scanl f x xs
 
-scanr :: Dupable b => (a #-> b #-> b) -> b #-> [a] #-> [b]
+scanr :: Dupable b => (a %1-> b %1-> b) -> b %1-> [a] %1-> [b]
 scanr _ b [] =  [b]
 scanr f b (a:as) =
   scanr f b as & \(b':bs') ->
     dup2 b' & \(b'', b''') ->
       f a b'' : b''' : bs'
 
-scanr1 :: Dupable a => (a #-> a #-> a) -> [a] #-> [a]
+scanr1 :: Dupable a => (a %1-> a %1-> a) -> [a] %1-> [a]
 scanr1 _ [] =  []
 scanr1 _ [a] =  [a]
 scanr1 f (a:as) =
@@ -303,49 +303,49 @@ scanr1 f (a:as) =
     dup2 a' & \(a'', a''') ->
       f a a'' : a''' : as'
 
-replicate :: Dupable a => Int -> a #-> [a]
+replicate :: Dupable a => Int -> a %1-> [a]
 replicate i a
   | i Prelude.< 1 = a `lseq` []
   | i Prelude.== 1 = [a]
   | otherwise  = dup2 a & \(a', a'') -> a' : replicate (i-1) a''
 
-unfoldr :: (b #-> Maybe (a, b)) -> b #-> [a]
+unfoldr :: (b %1-> Maybe (a, b)) -> b %1-> [a]
 unfoldr f = Unsafe.toLinear (NonLinear.unfoldr (forget f))
 
 -- # Zipping and unzipping lists
 --------------------------------------------------
 
-zip :: (Consumable a, Consumable b) => [a] #-> [b] #-> [(a, b)]
+zip :: (Consumable a, Consumable b) => [a] %1-> [b] %1-> [(a, b)]
 zip = zipWith (,)
 
 -- | Same as 'zip', but returns the leftovers instead of consuming them.
-zip' :: [a] #-> [b] #-> ([(a, b)], Maybe (Either (NonEmpty a) (NonEmpty b)))
+zip' :: [a] %1-> [b] %1-> ([(a, b)], Maybe (Either (NonEmpty a) (NonEmpty b)))
 zip' = zipWith' (,)
 
-zip3 :: (Consumable a, Consumable b, Consumable c) => [a] #-> [b] #-> [c] #-> [(a, b, c)]
+zip3 :: (Consumable a, Consumable b, Consumable c) => [a] %1-> [b] %1-> [c] %1-> [(a, b, c)]
 zip3 = zipWith3 (,,)
 
-zipWith :: (Consumable a, Consumable b) => (a#->b#->c) -> [a] #-> [b] #-> [c]
+zipWith :: (Consumable a, Consumable b) => (a %1 -> b %1->c) -> [a] %1-> [b] %1-> [c]
 zipWith f xs ys =
   zipWith' f xs ys & \(ret, leftovers) ->
     leftovers `lseq` ret
 
 -- | Same as 'zipWith', but returns the leftovers instead of consuming them.
-zipWith' :: (a#->b#->c) -> [a] #-> [b] #-> ([c], Maybe (Either (NonEmpty a) (NonEmpty b)))
+zipWith' :: (a %1-> b %1-> c) -> [a] %1-> [b] %1-> ([c], Maybe (Either (NonEmpty a) (NonEmpty b)))
 zipWith' _ [] [] = ([], Nothing)
 zipWith' _ (a:as) [] = ([], Just (Left (a :| as)))
 zipWith' _ [] (b:bs) = ([], Just (Right (b :| bs)))
 zipWith' f (a:as) (b:bs) = zipWith' f as bs & \case
   (cs, rest) -> (f a b : cs, rest)
 
-zipWith3 :: forall a b c d. (Consumable a, Consumable b, Consumable c) => (a#->b#->c#->d) -> [a] #-> [b] #-> [c] #-> [d]
+zipWith3 :: forall a b c d. (Consumable a, Consumable b, Consumable c) => (a %1-> b %1-> c %1-> d) -> [a] %1-> [b] %1-> [c] %1-> [d]
 zipWith3 _ [] ys zs = (ys, zs) `lseq` []
 zipWith3 _ xs [] zs = (xs, zs) `lseq` []
 zipWith3 _ xs ys [] = (xs, ys) `lseq` []
 zipWith3 f (x:xs) (y:ys) (z:zs) = f x y z : zipWith3 f xs ys zs
 
-unzip :: [(a, b)] #-> ([a], [b])
+unzip :: [(a, b)] %1-> ([a], [b])
 unzip = Unsafe.toLinear NonLinear.unzip
 
-unzip3 :: [(a, b, c)] #-> ([a], [b], [c])
+unzip3 :: [(a, b, c)] %1-> ([a], [b], [c])
 unzip3 = Unsafe.toLinear NonLinear.unzip3

--- a/src/Data/Maybe/Linear.hs
+++ b/src/Data/Maybe/Linear.hs
@@ -17,29 +17,29 @@ import Prelude (Maybe(..))
 
 -- | @maybe b f m@ returns @(f a)@ where @a@ is in
 -- @m@ if it exists and @b@ otherwise
-maybe :: b -> (a #-> b) -> Maybe a #-> b
+maybe :: b -> (a %1-> b) -> Maybe a %1-> b
 maybe x _ Nothing = x
 maybe _ f (Just y) = f y
 
 -- | @fromMaybe default m@ is the @a@ in
 -- @m@ if it exists and the @default@ otherwise
-fromMaybe :: a -> Maybe a #-> a
+fromMaybe :: a -> Maybe a %1-> a
 fromMaybe a Nothing = a
 fromMaybe _ (Just a') = a'
 
 -- | @maybeToList m@ creates a singleton or an empty list
 -- based on the @Maybe a@.
-maybeToList :: Maybe a #-> [a]
+maybeToList :: Maybe a %1-> [a]
 maybeToList Nothing = []
 maybeToList (Just a) = [a]
 
 -- | @catMaybes xs@ discards the @Nothing@s in @xs@
 -- and extracts the @a@s
-catMaybes :: [Maybe a] #-> [a]
+catMaybes :: [Maybe a] %1-> [a]
 catMaybes [] = []
 catMaybes (Nothing : xs) = catMaybes xs
 catMaybes (Just a : xs) = a : catMaybes xs
 
 -- | @mapMaybe f xs = catMaybes (map f xs)@
-mapMaybe :: (a #-> Maybe b) -> [a] #-> [b]
+mapMaybe :: (a %1-> Maybe b) -> [a] %1-> [b]
 mapMaybe f xs = catMaybes (Linear.fmap f xs)

--- a/src/Data/Monoid/Linear.hs
+++ b/src/Data/Monoid/Linear.hs
@@ -32,7 +32,7 @@ import qualified Prelude
 -- | A linear semigroup @a@ is a type with an associative binary operation @<>@
 -- that linearly consumes two @a@s.
 class Prelude.Semigroup a => Semigroup a where
-  (<>) :: a #-> a #-> a
+  (<>) :: a %1-> a %1-> a
 
 -- | A linear monoid is a linear semigroup with an identity on the binary
 -- operation.
@@ -42,10 +42,10 @@ class (Semigroup a, Prelude.Monoid a) => Monoid a where
   mempty = Prelude.mempty
   -- convenience redefine
 
-mconcat :: Monoid a => [a] #-> a
+mconcat :: Monoid a => [a] %1-> a
 mconcat (xs' :: [a]) = go mempty xs'
   where
-    go :: a #-> [a] #-> a
+    go :: a %1-> [a] %1-> a
     go acc [] = acc
     go acc (x:xs) = go (acc <> x) xs
 
@@ -56,15 +56,15 @@ mconcat (xs' :: [a]) = go mempty xs'
 instance Semigroup () where
   () <> () = ()
 
--- | An @Endo a@ is just a linear function of type @a #-> a@.
+-- | An @Endo a@ is just a linear function of type @a %1-> a@.
 -- This has a classic monoid definition with 'id' and '(.)'.
-newtype Endo a = Endo (a #-> a)
+newtype Endo a = Endo (a %1-> a)
   deriving (Prelude.Semigroup) via NonLinear (Endo a)
 
 -- TODO: have this as a newtype deconstructor once the right type can be
 -- correctly inferred
 -- | A linear application of an 'Endo'.
-appEndo :: Endo a #-> a #-> a
+appEndo :: Endo a %1-> a %1-> a
 appEndo (Endo f) = f
 
 instance Semigroup (Endo a) where
@@ -96,7 +96,7 @@ instance Semigroup Any where
 -- For linear monoids, you should supply a Prelude.Monoid instance and either
 -- declare an empty Monoid instance, or use DeriveAnyClass. For example:
 --
--- > newtype Endo a = Endo (a #-> a)
+-- > newtype Endo a = Endo (a %1-> a)
 -- >   deriving (Prelude.Semigroup) via NonLinear (Endo a)
 newtype NonLinear a = NonLinear a
 

--- a/src/Data/Num/Linear.hs
+++ b/src/Data/Num/Linear.hs
@@ -51,7 +51,7 @@ import Data.Monoid.Linear
 -- > (a + b) + c = a + (b + c)
 -- > a + b = b + c
 class Additive a where
-  (+) :: a #-> a #-> a
+  (+) :: a %1-> a %1-> a
 
 -- | An 'Additive' type with an identity on @(+)@.
 class Additive a => AddIdentity a where
@@ -61,14 +61,14 @@ class Additive a => AddIdentity a where
 -- the laws of an [abelian group](https://en.wikipedia.org/wiki/Abelian_group)
 class AddIdentity a => AdditiveGroup a where
   {-# MINIMAL negate | (-) #-}
-  negate :: a #-> a
+  negate :: a %1-> a
   negate x = zero - x
-  (-) :: a #-> a #-> a
+  (-) :: a %1-> a %1-> a
   x - y = x + negate y
 
 -- | A numeric type with an associative @(*)@ operation
 class Multiplicative a where
-  (*) :: a #-> a #-> a
+  (*) :: a %1-> a %1-> a
 
 -- | A 'Multipcative' type with an identity for @(*)@
 class Multiplicative a => MultIdentity a where
@@ -99,14 +99,14 @@ class (AdditiveGroup a, Semiring a) => Ring a where
 --
 -- For mathy folk: @fromInteger@ should be a homomorphism over @(+)@ and @(*)@.
 class FromInteger a where
-  fromInteger :: Prelude.Integer #-> a
+  fromInteger :: Prelude.Integer %1-> a
 
 -- XXX: subclass of Prelude.Num? subclass of Eq?
 class (Ring a, FromInteger a) => Num a where
   {-# MINIMAL abs, signum #-}
   -- XXX: is it fine to insist abs,signum are linear? I think it is
-  abs :: a #-> a
-  signum :: a #-> a
+  abs :: a %1-> a
+  signum :: a %1-> a
 
 newtype MovableNum a = MovableNum a
   deriving (Consumable, Dupable, Movable, Prelude.Num)
@@ -136,21 +136,21 @@ instance (Movable a, Prelude.Num a) => Num (MovableNum a) where
   abs = liftU Prelude.abs
   signum = liftU Prelude.signum
 
-liftU :: (Movable a) => (a -> b) #-> (a #-> b)
+liftU :: (Movable a) => (a -> b) %1-> (a %1-> b)
 liftU f x = lifted f (move x)
-  where lifted :: (a -> b) #-> (Ur a #-> b)
+  where lifted :: (a -> b) %1-> (Ur a %1-> b)
         lifted g (Ur a) = g a
 
-liftU2 :: (Movable a, Movable b) => (a -> b -> c) #-> (a #-> b #-> c)
+liftU2 :: (Movable a, Movable b) => (a -> b -> c) %1-> (a %1-> b %1-> c)
 liftU2 f x y = lifted f (move x) (move y)
-  where lifted :: (a -> b -> c) #-> (Ur a #-> Ur b #-> c)
+  where lifted :: (a -> b -> c) %1-> (Ur a %1-> Ur b %1-> c)
         lifted g (Ur a) (Ur b) = g a b
 
 -- A newtype wrapper to give the underlying monoid for an additive structure.
 newtype Adding a = Adding a
   deriving Prelude.Semigroup via NonLinear (Adding a)
 
-getAdded :: Adding a #-> a
+getAdded :: Adding a %1-> a
 getAdded (Adding x) = x
 
 instance Additive a => Semigroup (Adding a) where
@@ -163,7 +163,7 @@ instance AddIdentity a => Monoid (Adding a)
 newtype Multiplying a = Multiplying a
   deriving Prelude.Semigroup via NonLinear (Multiplying a)
 
-getMultiplied :: Multiplying a #-> a
+getMultiplied :: Multiplying a %1-> a
 getMultiplied (Multiplying x) = x
 
 instance Multiplicative a => Semigroup (Multiplying a) where

--- a/src/Data/Ord/Linear.hs
+++ b/src/Data/Ord/Linear.hs
@@ -44,18 +44,18 @@ class Eq a => Ord a where
   -- | @compare x y@ returns an @Ordering@ which is
   -- one of @GT@ (greater than), @EQ@ (equal), or @LT@ (less than)
   -- which should be understood as \"x is @(compare x y)@ y\".
-  compare :: a #-> a #-> Ordering
+  compare :: a %1-> a %1-> Ordering
 
-  (<=) :: a #-> a #-> Bool
+  (<=) :: a %1-> a %1-> Bool
   x <= y = not (x > y)
 
-  (<) :: a #-> a #-> Bool
+  (<) :: a %1-> a %1-> Bool
   x < y = compare x y == LT
 
-  (>) :: a #-> a #-> Bool
+  (>) :: a %1-> a %1-> Bool
   x > y = compare x y == GT
 
-  (>=) :: a #-> a #-> Bool
+  (>=) :: a %1-> a %1-> Bool
   x >= y = not (x < y)
 
   infix 4 <=, <, >, >=
@@ -63,7 +63,7 @@ class Eq a => Ord a where
 
 -- | @max x y@ returns the larger input, or  'y'
 -- in case of a tie.
-max :: (Dupable a, Ord a) =>  a #-> a #-> a
+max :: (Dupable a, Ord a) =>  a %1-> a %1-> a
 max x y =
   dup2 x & \(x', x'') ->
     dup2 y & \(y', y'') ->
@@ -73,7 +73,7 @@ max x y =
 
 -- | @min x y@ returns the smaller input, or 'y'
 -- in case of a tie.
-min :: (Dupable a, Ord a) =>  a #-> a #-> a
+min :: (Dupable a, Ord a) =>  a %1-> a %1-> a
 min x y =
   dup2 x & \(x', x'') ->
     dup2 y & \(y', y'') ->
@@ -132,14 +132,14 @@ newtype MovableOrd a = MovableOrd a
 
 instance (Prelude.Eq a, Movable a) => Eq (MovableOrd a) where
   MovableOrd ar == MovableOrd br
-    | Ur a <- move ar , Ur b <- move br
-    = a Prelude.== b
+    = move (ar, br) & \(Ur (a, b)) ->
+        a Prelude.== b
 
   MovableOrd ar /= MovableOrd br
-    | Ur a <- move ar , Ur b <- move br
-    = a Prelude./= b
+    = move (ar, br) & \(Ur (a, b)) ->
+        a Prelude./= b
 
 instance (Prelude.Ord a, Movable a) => Ord (MovableOrd a) where
   MovableOrd ar `compare` MovableOrd br
-    | Ur a <- move ar , Ur b <- move br
-    = a `Prelude.compare` b
+    = move (ar, br) & \(Ur (a, b)) ->
+        a `Prelude.compare` b

--- a/src/Data/Profunctor/Kleisli/Linear.hs
+++ b/src/Data/Profunctor/Kleisli/Linear.hs
@@ -32,7 +32,7 @@ import qualified Data.Functor.Linear as Data
 -- | Linear Kleisli arrows for the monad `m`. These arrows are still useful
 -- in the case where `m` is not a monad however, and some profunctorial
 -- properties still hold in this weaker setting.
-newtype Kleisli m a b = Kleisli { runKleisli :: a #-> m b }
+newtype Kleisli m a b = Kleisli { runKleisli :: a %1-> m b }
 
 instance Data.Functor f => Profunctor (Kleisli f) where
   dimap f g (Kleisli h) = Kleisli (Data.fmap g . h . f)
@@ -63,7 +63,7 @@ instance Control.Applicative f => Wandering (Kleisli f) where
 -- profunctorial properties still hold in this weaker setting.
 -- However stronger requirements on `f` are needed for profunctorial
 -- strength, so we have fewer instances.
-newtype CoKleisli w a b = CoKleisli { runCoKleisli :: w a #-> b }
+newtype CoKleisli w a b = CoKleisli { runCoKleisli :: w a %1-> b }
 
 instance Data.Functor f => Profunctor (CoKleisli f) where
   dimap f g (CoKleisli h) = CoKleisli (g . h . Data.fmap f)

--- a/src/Data/Profunctor/Linear.hs
+++ b/src/Data/Profunctor/Linear.hs
@@ -33,15 +33,15 @@ import Control.Arrow (Kleisli(..))
 class Profunctor (arr :: Type -> Type -> Type) where
   {-# MINIMAL dimap | lmap, rmap #-}
 
-  dimap :: (s #-> a) -> (b #-> t) -> a `arr` b -> s `arr` t
+  dimap :: (s %1-> a) -> (b %1-> t) -> a `arr` b -> s `arr` t
   dimap f g x = lmap f (rmap g x)
   {-# INLINE dimap #-}
 
-  lmap :: (s #-> a) -> a `arr` t -> s `arr` t
+  lmap :: (s %1-> a) -> a `arr` t -> s `arr` t
   lmap f = dimap f id
   {-# INLINE lmap #-}
 
-  rmap :: (b #-> t) -> s `arr` b -> s `arr` t
+  rmap :: (b %1-> t) -> s `arr` b -> s `arr` t
   rmap = dimap id
   {-# INLINE rmap #-}
 
@@ -64,15 +64,15 @@ class (Strong (,) () arr, Strong Either Void arr) => Wandering arr where
   -- | Equivalently but less efficient in general:
   --
   -- > wander :: Data.Traversable f => a `arr` b -> f a `arr` f b
-  wander :: forall s t a b. (forall f. Control.Applicative f => (a #-> f b) -> s #-> f t) -> a `arr` b -> s `arr` t
+  wander :: forall s t a b. (forall f. Control.Applicative f => (a %1-> f b) -> s %1-> f t) -> a `arr` b -> s `arr` t
 
 ---------------
 -- Instances --
 ---------------
 
-newtype LinearArrow a b = LA (a #-> b)
+newtype LinearArrow a b = LA (a %1-> b)
 -- | Temporary deconstructor since inference doesn't get it right
-getLA :: LinearArrow a b #-> a #-> b
+getLA :: LinearArrow a b %1-> a %1-> b
 getLA (LA f) = f
 
 instance Profunctor LinearArrow where
@@ -108,7 +108,7 @@ instance Monoidal Either Void (->) where
   f *** g = Prelude.bimap f g
   unit = \case {}
 
-data Exchange a b s t = Exchange (s #-> a) (b #-> t)
+data Exchange a b s t = Exchange (s %1-> a) (b %1-> t)
 instance Profunctor (Exchange a b) where
   dimap f g (Exchange p q) = Exchange (p . f) (g . q)
 
@@ -134,8 +134,8 @@ instance Prelude.Functor f => Monoidal Either Void (Kleisli f) where
     Right b -> Right Prelude.<$> g b
   unit = Kleisli $ \case {}
 
-data Market a b s t = Market (b #-> t) (s #-> Either t a)
-runMarket :: Market a b s t #-> (b #-> t, s #-> Either t a)
+data Market a b s t = Market (b %1-> t) (s %1-> Either t a)
+runMarket :: Market a b s t %1-> (b %1-> t, s %1-> Either t a)
 runMarket (Market f g) = (f, g)
 
 instance Profunctor (Market a b) where

--- a/src/Data/Set/Mutable/Linear.hs
+++ b/src/Data/Set/Mutable/Linear.hs
@@ -51,41 +51,41 @@ type Keyed a = Linear.Keyed a
 -- # Constructors and Mutators
 -------------------------------------------------------------------------------
 
-empty :: Keyed a => Int -> (Set a #-> Ur b) #-> Ur b
-empty s (f :: Set a #-> Ur b) =
+empty :: Keyed a => Int -> (Set a %1-> Ur b) %1-> Ur b
+empty s (f :: Set a %1-> Ur b) =
   Linear.empty s (\hm -> f (Set hm))
 
-toList :: Keyed a => Set a #-> Ur [a]
+toList :: Keyed a => Set a %1-> Ur [a]
 toList (Set hm) =
   Linear.toList hm
     Linear.& \(Ur xs) -> Ur (Prelude.map Prelude.fst xs)
 
-insert :: Keyed a => a -> Set a #-> Set a
+insert :: Keyed a => a -> Set a %1-> Set a
 insert a (Set hmap) = Set (Linear.insert a () hmap)
 
-delete :: Keyed a => a -> Set a #-> Set a
+delete :: Keyed a => a -> Set a %1-> Set a
 delete a (Set hmap) = Set (Linear.delete a hmap)
 
-union :: Keyed a => Set a #-> Set a #-> Set a
+union :: Keyed a => Set a %1-> Set a %1-> Set a
 union (Set hm1) (Set hm2) =
   Set (Linear.unionWith (\_ _ -> ()) hm1 hm2)
 
-intersection :: Keyed a => Set a #-> Set a #-> Set a
+intersection :: Keyed a => Set a %1-> Set a %1-> Set a
 intersection (Set hm1) (Set hm2) =
   Set (Linear.intersectionWith (\_ _ -> ()) hm1 hm2)
 
 -- # Accessors
 -------------------------------------------------------------------------------
 
-size :: Keyed a => Set a #-> (Ur Int, Set a)
+size :: Keyed a => Set a %1-> (Ur Int, Set a)
 size (Set hm) =
   Linear.size hm Linear.& \(s, hm') -> (s, Set hm')
 
-member :: Keyed a => a -> Set a #-> (Ur Bool, Set a)
+member :: Keyed a => a -> Set a %1-> (Ur Bool, Set a)
 member a (Set hm) =
   Linear.member a hm Linear.& \(b, hm') -> (b, Set hm')
 
-fromList :: Keyed a => [a] -> (Set a #-> Ur b) #-> Ur b
+fromList :: Keyed a => [a] -> (Set a %1-> Ur b) %1-> Ur b
 fromList xs f =
   Linear.fromList (Prelude.map (,()) xs) (\hm -> f (Set hm))
 

--- a/src/Data/Tuple/Linear.hs
+++ b/src/Data/Tuple/Linear.hs
@@ -16,11 +16,11 @@ module Data.Tuple.Linear
 import Prelude.Linear.Internal
 import Data.Unrestricted.Linear
 
-fst :: Consumable b => (a,b) #-> a
+fst :: Consumable b => (a,b) %1-> a
 fst (a,b) = lseq b a
 
-snd :: Consumable a => (a,b) #-> b
+snd :: Consumable a => (a,b) %1-> b
 snd (a,b) = lseq a b
 
-swap :: (a,b) #-> (b,a)
+swap :: (a,b) %1-> (b,a)
 swap (a,b) = (b,a)

--- a/src/Data/Vector/Mutable/Linear.hs
+++ b/src/Data/Vector/Mutable/Linear.hs
@@ -16,7 +16,7 @@
 -- use 'shrinkToFit' to get rid of the wasted space.
 --
 -- To use mutable vectors, create a linear computation of type
--- @Vector a #-> Ur b@ and feed it to 'constant' or 'fromList'.
+-- @Vector a %1-> Ur b@ and feed it to 'constant' or 'fromList'.
 --
 -- == Example
 --
@@ -24,7 +24,7 @@
 -- >>> import Prelude.Linear
 -- >>> import qualified Data.Vector.Mutable.Linear as Vector
 -- >>> :{
---  isFirstZero :: Vector.Vector Int #-> Ur Bool
+--  isFirstZero :: Vector.Vector Int %1-> Ur Bool
 --  isFirstZero vec =
 --    Vector.get 0 vec
 --      & \(Ur ret, vec) -> vec `lseq` Ur (ret == 0)
@@ -95,7 +95,7 @@ data Vector a where
     -- ^ Current size
     Int ->
     -- ^ Underlying array (has size equal to or larger than the vectors)
-    Array a #->
+    Array a %1->
     Vector a
 
 -- # API: Construction, Mutation, Queries
@@ -105,52 +105,52 @@ data Vector a where
 -- equal to the size of the given array.
 --
 -- This is a constant time operation.
-fromArray :: HasCallStack => Array a #-> Vector a
+fromArray :: HasCallStack => Array a %1-> Vector a
 fromArray arr =
   Array.size arr
     & \(Ur size', arr') -> Vec size' arr'
 
 -- Allocate an empty vector
-empty :: (Vector a #-> Ur b) #-> Ur b
+empty :: (Vector a %1-> Ur b) %1-> Ur b
 empty f = Array.fromList [] (f . fromArray)
 
 -- | Allocate a constant vector of a given non-negative size (and error on a
 -- bad size)
 constant :: HasCallStack =>
-  Int -> a -> (Vector a #-> Ur b) #-> Ur b
+  Int -> a -> (Vector a %1-> Ur b) %1-> Ur b
 constant size' x f
   | size' < 0 =
-      (error ("Trying to construct a vector of size " ++ show size') :: x #-> x)
+      (error ("Trying to construct a vector of size " ++ show size') :: x %1-> x)
       (f undefined)
   | otherwise = Array.alloc size' x (f . fromArray)
 
 -- | Allocator from a list
-fromList :: HasCallStack => [a] -> (Vector a #-> Ur b) #-> Ur b
+fromList :: HasCallStack => [a] -> (Vector a %1-> Ur b) %1-> Ur b
 fromList xs f = Array.fromList xs (f . fromArray)
 
 -- | Number of elements inside the vector.
 --
 -- This might be different than how much actual memory the vector is using.
 -- For that, see: 'capacity'.
-size :: Vector a #-> (Ur Int, Vector a)
+size :: Vector a %1-> (Ur Int, Vector a)
 size (Vec size' arr) = (Ur size', Vec size' arr)
 
 -- | Capacity of a vector. In other words, the number of elements
 -- the vector can contain before it is copied to a bigger array.
-capacity :: Vector a #-> (Ur Int, Vector a)
+capacity :: Vector a %1-> (Ur Int, Vector a)
 capacity (Vec s arr) =
   Array.size arr & \(cap, arr') -> (cap, Vec s arr')
 
 -- | Insert at the end of the vector. This will grow the vector if there
 -- is no empty space.
-push :: a -> Vector a #-> Vector a
+push :: a -> Vector a %1-> Vector a
 push x vec =
   growToFit 1 vec & \(Vec s arr) ->
     unsafeSet s x (Vec (s + 1) arr)
 
 -- | Pop from the end of the vector. This will never shrink the vector, use
 -- 'shrinkToFit' to remove the wasted space.
-pop :: Vector a #-> (Ur (Maybe a), Vector a)
+pop :: Vector a %1-> (Ur (Maybe a), Vector a)
 pop vec =
   size vec & \case
     (Ur 0, vec') ->
@@ -163,32 +163,32 @@ pop vec =
 
 -- | Write to an element . Note: this will not write to elements beyond the
 -- current size of the vector and will error instead.
-set :: HasCallStack => Int -> a -> Vector a #-> Vector a
+set :: HasCallStack => Int -> a -> Vector a %1-> Vector a
 set ix val vec =
   unsafeSet ix val (assertIndexInRange ix vec)
 
 -- | Same as 'write', but does not do bounds-checking. The behaviour is undefined
 -- when passed an invalid index.
-unsafeSet :: HasCallStack => Int -> a -> Vector a #-> Vector a
+unsafeSet :: HasCallStack => Int -> a -> Vector a %1-> Vector a
 unsafeSet ix val (Vec size' arr) =
   Vec size' (Array.unsafeSet ix val arr)
 
 -- | Read from a vector, with an in-range index and error for an index that is
 -- out of range (with the usual range @0..size-1@).
-get :: HasCallStack => Int -> Vector a #-> (Ur a, Vector a)
+get :: HasCallStack => Int -> Vector a %1-> (Ur a, Vector a)
 get ix vec =
   unsafeGet ix (assertIndexInRange ix vec)
 
 -- | Same as 'read', but does not do bounds-checking. The behaviour is undefined
 -- when passed an invalid index.
-unsafeGet :: HasCallStack => Int -> Vector a #-> (Ur a, Vector a)
+unsafeGet :: HasCallStack => Int -> Vector a %1-> (Ur a, Vector a)
 unsafeGet ix (Vec size' arr) =
   Array.unsafeGet ix arr
     & \(val, arr') -> (val, Vec size' arr')
 
 -- | Same as 'modify', but does not do bounds-checking.
 unsafeModify :: HasCallStack => (a -> (a, b)) -> Int
-             -> Vector a #-> (Ur b, Vector a)
+             -> Vector a %1-> (Ur b, Vector a)
 unsafeModify f ix (Vec size' arr) =
   Array.unsafeGet ix arr & \(Ur old, arr') ->
     case f old of
@@ -198,24 +198,24 @@ unsafeModify f ix (Vec size' arr) =
 -- | Modify a value inside a vector, with an ability to return an extra
 -- information. Errors if the index is out of bounds.
 modify :: HasCallStack => (a -> (a, b)) -> Int
-       -> Vector a #-> (Ur b, Vector a)
+       -> Vector a %1-> (Ur b, Vector a)
 modify f ix vec = unsafeModify f ix (assertIndexInRange ix vec)
 
 -- | Same as 'modify', but without the ability to return extra information.
-modify_ :: HasCallStack => (a -> a) -> Int -> Vector a #-> Vector a
+modify_ :: HasCallStack => (a -> a) -> Int -> Vector a %1-> Vector a
 modify_ f ix vec =
   modify (\a -> (f a, ())) ix vec
     & \(Ur (), vec') -> vec'
 
 -- | Return the vector elements as a lazy list.
-toList :: Vector a #-> Ur [a]
+toList :: Vector a %1-> Ur [a]
 toList (Vec s arr) =
   Array.toList arr & \(Ur xs) ->
     Ur (Prelude.take s xs)
 
 -- | Filters the vector in-place. It does not deallocate unused capacity,
 -- use 'shrinkToFit' for that if necessary.
-filter :: Vector a #-> (a -> Bool) -> Vector a
+filter :: Vector a %1-> (a -> Bool) -> Vector a
 filter v f = mapMaybe v (\a -> if f a then Just a else Nothing)
 -- TODO A slightly more efficient version exists, where we skip the writes
 -- until the first time the predicate fails. However that requires duplicating
@@ -223,14 +223,14 @@ filter v f = mapMaybe v (\a -> if f a then Just a else Nothing)
 -- see the advantage.
 
 -- | A version of 'fmap' which can throw out elements.
-mapMaybe :: Vector a #-> (a -> Maybe b) -> Vector b
+mapMaybe :: Vector a %1-> (a -> Maybe b) -> Vector b
 mapMaybe vec (f :: a -> Maybe b) =
   size vec & \(Ur s, vec') -> go 0 0 s vec'
  where
   go :: Int -- ^ read cursor
      -> Int -- ^ write cursor
      -> Int -- ^ input size
-     -> Vector a #-> Vector b
+     -> Vector a %1-> Vector b
   go r w s vec'
     -- If we processed all elements, set the capacity after the last written
     -- index and coerce the result to the correct type.
@@ -249,7 +249,7 @@ mapMaybe vec (f :: a -> Maybe b) =
 
 -- | Resize the vector to not have any wasted memory (size == capacity). This
 -- returns a semantically identical vector.
-shrinkToFit :: Vector a #-> Vector a
+shrinkToFit :: Vector a %1-> Vector a
 shrinkToFit vec =
   capacity vec & \(Ur cap, vec') ->
     size vec' & \(Ur s', vec'') ->
@@ -264,7 +264,7 @@ shrinkToFit vec =
 --
 -- This is a constant time operation if the start offset is 0. Use 'shrinkToFit'
 -- to remove the possible wasted space if necessary.
-slice :: Int -> Int -> Vector a #-> Vector a
+slice :: Int -> Int -> Vector a %1-> Vector a
 slice from newSize (Vec oldSize arr) =
   if oldSize < from + newSize
   then arr `lseq` error "Slice index out of bounds"
@@ -275,25 +275,25 @@ slice from newSize (Vec oldSize arr) =
 
 -- | /O(1)/ Convert a 'Vector' to an immutable 'Vector.Vector' (from
 -- 'vector' package).
-freeze :: Vector a #-> Ur (Vector.Vector a)
+freeze :: Vector a %1-> Ur (Vector.Vector a)
 freeze (Vec sz arr) =
   Array.freeze arr
     & \(Ur vec) -> Ur (Vector.take sz vec)
 
 -- | Same as 'set', but takes the 'Vector' as the first parameter.
-write :: HasCallStack => Vector a #-> Int -> a -> Vector a
+write :: HasCallStack => Vector a %1-> Int -> a -> Vector a
 write arr i a = set i a arr
 
 -- | Same as 'unsafeSafe', but takes the 'Vector' as the first parameter.
-unsafeWrite ::  Vector a #-> Int -> a -> Vector a
+unsafeWrite ::  Vector a %1-> Int -> a -> Vector a
 unsafeWrite arr i a = unsafeSet i a arr
 
 -- | Same as 'get', but takes the 'Vector' as the first parameter.
-read :: HasCallStack => Vector a #-> Int -> (Ur a, Vector a)
+read :: HasCallStack => Vector a %1-> Int -> (Ur a, Vector a)
 read arr i = get i arr
 
 -- | Same as 'unsafeGet', but takes the 'Vector' as the first parameter.
-unsafeRead :: Vector a #-> Int -> (Ur a, Vector a)
+unsafeRead :: Vector a %1-> Int -> (Ur a, Vector a)
 unsafeRead arr i = unsafeGet i arr
 
 -- # Instances
@@ -319,7 +319,7 @@ instance Semigroup (Vector a) where
         toList v2' & \(Ur xs) ->
           go xs v1'
    where
-     go :: [a] -> Vector a #-> Vector a
+     go :: [a] -> Vector a %1-> Vector a
      go [] vec = vec
      go (x:xs) (Vec sz arr) =
        unsafeSet sz x (Vec (sz+1) arr)
@@ -333,7 +333,7 @@ instance Data.Functor Vector where
 
 -- | Grows the vector to the closest power of growthFactor to
 -- fit at least n more elements.
-growToFit :: HasCallStack => Int -> Vector a #-> Vector a
+growToFit :: HasCallStack => Int -> Vector a %1-> Vector a
 growToFit n vec =
   capacity vec & \(Ur cap, vec') ->
     size vec' & \(Ur s', vec'') ->
@@ -356,7 +356,7 @@ growToFit n vec =
 
 -- | Resize the vector to a non-negative size. In-range elements are preserved,
 -- the possible new elements are bottoms.
-unsafeResize :: HasCallStack => Int -> Vector a #-> Vector a
+unsafeResize :: HasCallStack => Int -> Vector a %1-> Vector a
 unsafeResize newSize (Vec size' ma) =
   Vec
     (min size' newSize)
@@ -367,7 +367,7 @@ unsafeResize newSize (Vec size' ma) =
     )
 
 -- | Check if given index is within the Vector, otherwise panic.
-assertIndexInRange :: HasCallStack => Int -> Vector a #-> Vector a
+assertIndexInRange :: HasCallStack => Int -> Vector a %1-> Vector a
 assertIndexInRange i vec =
   size vec & \(Ur s, vec') ->
     if 0 <= i && i < s

--- a/src/Debug/Trace/Linear.hs
+++ b/src/Debug/Trace/Linear.hs
@@ -35,31 +35,31 @@ import Prelude.Linear.Internal
 
 -- | The 'trace' function outputs the trace message given as its first
 -- argument, before returning the second argument as its result.
-trace :: String #-> a #-> a
+trace :: String %1-> a %1-> a
 trace = Unsafe.toLinear2 NonLinear.trace
 
 -- | Like 'trace', but uses 'show' on the argument to convert it to
 -- a 'String'.
-traceShow :: Show a => a -> b #-> b
+traceShow :: Show a => a -> b %1-> b
 traceShow a = Unsafe.toLinear (NonLinear.traceShow a)
 
 -- | Like 'trace' but returns the message instead of a third value.
-traceId :: String #-> String
+traceId :: String %1-> String
 traceId s = dup s & \(s', s'') -> trace s' s''
 
 -- | Like 'trace', but additionally prints a call stack if one is
 -- available.
-traceStack :: String #-> a #-> a
+traceStack :: String %1-> a %1-> a
 traceStack = Unsafe.toLinear2 NonLinear.traceStack
 
 -- | The 'traceIO' function outputs the trace message from the IO monad.
 -- This sequences the output with respect to other IO actions.
-traceIO :: String #-> IO ()
+traceIO :: String %1-> IO ()
 traceIO s = fromSystemIO (Unsafe.toLinear NonLinear.traceIO s)
 
 -- | Like 'trace' but returning unit in an arbitrary 'Applicative'
 -- context. Allows for convenient use in do-notation.
-traceM :: Applicative f => String #-> f ()
+traceM :: Applicative f => String %1-> f ()
 traceM s = trace s $ pure ()
 
 -- | Like 'traceM', but uses 'show' on the argument to convert it to a
@@ -70,23 +70,23 @@ traceShowM a = traceM (show a)
 -- | The 'traceEvent' function behaves like 'trace' with the difference
 -- that the message is emitted to the eventlog, if eventlog profiling is
 -- available and enabled at runtime.
-traceEvent :: String #-> a #-> a
+traceEvent :: String %1-> a %1-> a
 traceEvent = Unsafe.toLinear2 NonLinear.traceEvent
 
 -- | The 'traceEventIO' function emits a message to the eventlog, if
 -- eventlog profiling is available and enabled at runtime.
-traceEventIO :: String #-> IO ()
+traceEventIO :: String %1-> IO ()
 traceEventIO s = fromSystemIO (Unsafe.toLinear NonLinear.traceEventIO s)
 
 -- | The 'traceMarker' function emits a marker to the eventlog, if eventlog
 -- profiling is available and enabled at runtime. The @String@ is the name
 -- of the marker. The name is just used in the profiling tools to help you
 -- keep clear which marker is which.
-traceMarker :: String #-> a #-> a
+traceMarker :: String %1-> a %1-> a
 traceMarker = Unsafe.toLinear2 NonLinear.traceMarker
 
 -- | The 'traceMarkerIO' function emits a marker to the eventlog, if
 -- eventlog profiling is available and enabled at runtime.
-traceMarkerIO :: String #-> IO ()
+traceMarkerIO :: String %1-> IO ()
 traceMarkerIO s = fromSystemIO (Unsafe.toLinear NonLinear.traceMarkerIO s)
 

--- a/src/Prelude/Linear.hs
+++ b/src/Prelude/Linear.hs
@@ -145,7 +145,6 @@ import Data.Ord.Linear
 import Data.Tuple.Linear
 import Data.List.Linear
 import qualified Prelude
-import GHC.Exts (FUN)
 import Prelude.Linear.Internal
 import Data.Eq.Linear
 import Data.String

--- a/src/Prelude/Linear.hs
+++ b/src/Prelude/Linear.hs
@@ -11,13 +11,13 @@
 -- >>> :set -XNoImplicitPrelude
 -- >>> import Prelude.Linear
 -- >>> :{
---   boolToInt :: Bool #-> Int
+--   boolToInt :: Bool %1-> Int
 --   boolToInt False = 0
 --   boolToInt True = 1
 -- :}
 --
 -- >>> :{
---   makeInt :: Either Int Bool #-> Int
+--   makeInt :: Either Int Bool %1-> Int
 --   makeInt = either id boolToInt
 -- :}
 --
@@ -151,9 +151,9 @@ import Data.Eq.Linear
 import Data.String
 
 -- | Replacement for the flip function with generalized multiplicities.
-flip :: FUN r (FUN p a (FUN q b c)) (FUN q b (FUN p a c))
+flip :: (a %p -> b %q -> c) %r -> b %q -> a %p -> c
 flip f b a = f a b
 
 -- | Linearly typed replacement for the standard '(Prelude.<*)' function.
-(<*) :: (Data.Applicative f, Consumable b) => f a #-> f b #-> f a
+(<*) :: (Data.Applicative f, Consumable b) => f a %1-> f b %1-> f a
 fa <* fb = Data.fmap (flip lseq) fa Data.<*> fb

--- a/src/Prelude/Linear/Internal.hs
+++ b/src/Prelude/Linear/Internal.hs
@@ -18,47 +18,47 @@ import qualified Unsafe.Linear as Unsafe
 
 -- | Beware: @($)@ is not compatible with the standard one because it is
 -- higher-order and we don't have multiplicity polymorphism yet.
-($) :: (a #-> b) #-> a #-> b
+($) :: (a %1-> b) %1-> a %1-> b
 -- XXX: Temporary as `($)` should get its typing rule directly from the type
 -- inference mechanism.
 ($) f x = f x
 infixr 0 $
 
-(&) :: a #-> (a #-> b) #-> b
+(&) :: a %1-> (a %1-> b) %1-> b
 x & f = f x
 infixl 1 &
 
-id :: a #-> a
+id :: a %1-> a
 id x = x
 
-const :: a #-> b -> a
+const :: a %1-> b -> a
 const x _ = x
 
-asTypeOf :: a #-> a -> a
+asTypeOf :: a %1-> a -> a
 asTypeOf = const
 
 -- | @seq x y@ only forces @x@ to head normal form, therefore is not guaranteed
 -- to consume @x@ when the resulting computation is consumed. Therefore, @seq@
 -- cannot be linear in it's first argument.
-seq :: a -> b #-> b
+seq :: a -> b %1-> b
 seq x = Unsafe.toLinear (Prelude.seq x)
 
-($!) :: (a #-> b) #-> a #-> b
+($!) :: (a %1-> b) %1-> a %1-> b
 ($!) f !a = f a
 
 -- | Beware, 'curry' is not compatible with the standard one because it is
 -- higher-order and we don't have multiplicity polymorphism yet.
-curry :: ((a, b) #-> c) #-> a #-> b #-> c
+curry :: ((a, b) %1-> c) %1-> a %1-> b %1-> c
 curry f x y = f (x, y)
 
 -- | Beware, 'uncurry' is not compatible with the standard one because it is
 -- higher-order and we don't have multiplicity polymorphism yet.
-uncurry :: (a #-> b #-> c) #-> (a, b) #-> c
+uncurry :: (a %1-> b %1-> c) %1-> (a, b) %1-> c
 uncurry f (x,y) = f x y
 
 -- | Beware: @(.)@ is not compatible with the standard one because it is
 -- higher-order and we don't have multiplicity polymorphism yet.
-(.) :: (b #-> c) #-> (a #-> b) #-> a #-> c
+(.) :: (b %1-> c) %1-> (a %1-> b) %1-> a %1-> c
 f . g = \x -> f (g x)
 
 -- XXX: temporary: with multiplicity polymorphism functions expecting a
@@ -66,5 +66,5 @@ f . g = \x -> f (g x)
 -- redundant
 -- | Convenience operator when a higher-order function expects a non-linear
 -- arrow but we have a linear arrow.
-forget :: (a #-> b) #-> a -> b
+forget :: (a %1-> b) %1-> a -> b
 forget f a = f a

--- a/src/Streaming/Internal/Many.hs
+++ b/src/Streaming/Internal/Many.hs
@@ -77,7 +77,7 @@ S.unzip $ S.each' xs :: Control.Monad m => Stream (Of Int) (Stream (Of String) m
 
     Like any fold, 'toList' takes no notice of the monad of effects.
 
-> toList :: Control.Monad m => Stream (Of a) m r #-> m (Of [a] r)
+> toList :: Control.Monad m => Stream (Of a) m r %1-> m (Of [a] r)
 
     In the case at hand (since I am in @ghci@) @m = Stream (Of String) IO@.
     So when I apply 'toList', I exhaust that stream of integers, folding
@@ -105,11 +105,11 @@ S.toList $ S.unzip $ S.each' xs
 @
 -}
 unzip :: Control.Monad m =>
-  Stream (Of (a, b)) m r #-> Stream (Of a) (Stream (Of b) m) r
+  Stream (Of (a, b)) m r %1-> Stream (Of a) (Stream (Of b) m) r
 unzip = loop
   where
   loop :: Control.Monad m =>
-    Stream (Of (a, b)) m r #-> Stream (Of a) (Stream (Of b) m) r
+    Stream (Of (a, b)) m r %1-> Stream (Of a) (Stream (Of b) m) r
   loop stream = stream & \case
     Return r -> Return r
     Effect m -> Effect $ Control.fmap loop $ Control.lift m
@@ -135,9 +135,9 @@ longer stream.
 -}
 
 data Either3 a b c where
-  Left3 :: a #-> Either3 a b c
-  Middle3 :: b #-> Either3 a b c
-  Right3 :: c #-> Either3 a b c
+  Left3 :: a %1-> Either3 a b c
+  Middle3 :: b %1-> Either3 a b c
+  Right3 :: c %1-> Either3 a b c
 
 -- | The remainder of zipping two streams
 type ZipResidual a b m r1 r2 =
@@ -152,15 +152,15 @@ type ZipResidual a b m r1 r2 =
 -- end-of-stream result, that stream is treated as a residual.
 zipWithR :: Control.Monad m =>
   (a -> b -> c) ->
-  Stream (Of a) m r1 #->
-  Stream (Of b) m r2 #->
+  Stream (Of a) m r1 %1->
+  Stream (Of b) m r2 %1->
   Stream (Of c) m (ZipResidual a b m r1 r2)
 zipWithR = loop
   where
   loop :: Control.Monad m =>
     (a -> b -> c) ->
-    Stream (Of a) m r1 #->
-    Stream (Of b) m r2 #->
+    Stream (Of a) m r1 %1->
+    Stream (Of b) m r2 %1->
     Stream (Of c) m (ZipResidual a b m r1 r2)
   loop f st1 st2 = st1 & \case
     Effect ms -> Effect $ Control.fmap (\s -> loop f s st2) ms
@@ -176,8 +176,8 @@ zipWithR = loop
 
 zipWith :: Control.Monad m =>
   (a -> b -> c) ->
-  Stream (Of a) m r1 #->
-  Stream (Of b) m r2 #->
+  Stream (Of a) m r1 %1->
+  Stream (Of b) m r2 %1->
   Stream (Of c) m (r1,r2)
 zipWith f s1 s2 = Control.do
   result <- zipWithR f s1 s2
@@ -194,16 +194,16 @@ zipWith f s1 s2 = Control.do
 -- | @zip@ zips two streams exhausing the remainder of the longer
 -- stream and consuming its effects.
 zip :: Control.Monad m =>
-  Stream (Of a) m r1 #->
-  Stream (Of b) m r2 #->
+  Stream (Of a) m r1 %1->
+  Stream (Of b) m r2 %1->
   Stream (Of (a,b)) m (r1, r2)
 zip = zipWith (,)
 {-# INLINE zip #-}
 
 -- | @zipR@ zips two streams keeping the remainder if there is one.
 zipR :: Control.Monad m =>
-  Stream (Of a) m r1 #->
-  Stream (Of b) m r2 #->
+  Stream (Of a) m r1 %1->
+  Stream (Of b) m r2 %1->
   Stream (Of (a,b)) m (ZipResidual a b m r1 r2)
 zipR = zipWithR (,)
 {-# INLINE zipR #-}
@@ -224,17 +224,17 @@ type ZipResidual3 a b c m r1 r2 r3 =
 -- | Like @zipWithR@ but with three streams.
 zipWith3R :: Control.Monad m =>
   (a -> b -> c -> d) ->
-  Stream (Of a) m r1 #->
-  Stream (Of b) m r2 #->
-  Stream (Of c) m r3 #->
+  Stream (Of a) m r1 %1->
+  Stream (Of b) m r2 %1->
+  Stream (Of c) m r3 %1->
   Stream (Of d) m (ZipResidual3 a b c m r1 r2 r3)
 zipWith3R = loop
   where
   loop :: Control.Monad m =>
     (a -> b -> c -> d) ->
-    Stream (Of a) m r1 #->
-    Stream (Of b) m r2 #->
-    Stream (Of c) m r3 #->
+    Stream (Of a) m r1 %1->
+    Stream (Of b) m r2 %1->
+    Stream (Of c) m r3 %1->
     Stream (Of d) m (ZipResidual3 a b c m r1 r2 r3)
   loop f s1 s2 s3 = s1 & \case
     Effect ms -> Effect $ Control.fmap (\s -> loop f s s2 s3) ms
@@ -256,9 +256,9 @@ zipWith3R = loop
 -- | Like @zipWith@ but with three streams
 zipWith3 :: Control.Monad m =>
   (a -> b -> c -> d) ->
-  Stream (Of a) m r1 #->
-  Stream (Of b) m r2 #->
-  Stream (Of c) m r3 #->
+  Stream (Of a) m r1 %1->
+  Stream (Of b) m r2 %1->
+  Stream (Of c) m r3 %1->
   Stream (Of d) m (r1, r2, r3)
 zipWith3 f s1 s2 s3 = Control.do
   result <- zipWith3R f s1 s2 s3
@@ -272,25 +272,25 @@ zipWith3 f s1 s2 s3 = Control.do
 
 -- | Like @zipR@ but with three streams.
 zip3 :: Control.Monad m =>
-  Stream (Of a) m r1 #->
-  Stream (Of b) m r2 #->
-  Stream (Of c) m r3 #->
+  Stream (Of a) m r1 %1->
+  Stream (Of b) m r2 %1->
+  Stream (Of c) m r3 %1->
   Stream (Of (a,b,c)) m (r1, r2, r3)
 zip3 = zipWith3 (,,)
 {-# INLINABLE zip3 #-}
 
 -- | Like @zipR@ but with three streams.
 zip3R :: Control.Monad m =>
-  Stream (Of a) m r1 #->
-  Stream (Of b) m r2 #->
-  Stream (Of c) m r3 #->
+  Stream (Of a) m r1 %1->
+  Stream (Of b) m r2 %1->
+  Stream (Of c) m r3 %1->
   Stream (Of (a,b,c)) m (ZipResidual3 a b c m r1 r2 r3)
 zip3R = zipWith3R (,,)
 {-# INLINABLE zip3R #-}
 
 -- | Internal function to consume a stream remainder to
 -- get the payload
-extractResult :: Control.Monad m => Either r (Stream (Of a) m r) #-> m r
+extractResult :: Control.Monad m => Either r (Stream (Of a) m r) %1-> m r
 extractResult (Left r) = Control.return r
 extractResult (Right s) = effects s
 
@@ -324,7 +324,7 @@ extractResult (Right s) = effects s
 
 -}
 merge :: (Control.Monad m, Ord a) =>
-  Stream (Of a) m r #-> Stream (Of a) m s #-> Stream (Of a) m (r,s)
+  Stream (Of a) m r %1-> Stream (Of a) m s %1-> Stream (Of a) m (r,s)
 merge = mergeBy compare
 {-# INLINE merge #-}
 
@@ -335,8 +335,8 @@ merge = mergeBy compare
 -}
 mergeOn :: (Control.Monad m, Ord b) =>
   (a -> b) ->
-  Stream (Of a) m r #->
-  Stream (Of a) m s #->
+  Stream (Of a) m r %1->
+  Stream (Of a) m s %1->
   Stream (Of a) m (r,s)
 mergeOn f = mergeBy (\x y -> compare (f x) (f y))
 {-# INLINE mergeOn #-}
@@ -347,12 +347,12 @@ mergeOn f = mergeBy (\x y -> compare (f x) (f y))
 -}
 mergeBy :: forall m a r s . Control.Monad m =>
   (a -> a -> Ordering) ->
-  Stream (Of a) m r #->
-  Stream (Of a) m s #->
+  Stream (Of a) m r %1->
+  Stream (Of a) m s %1->
   Stream (Of a) m (r,s)
 mergeBy comp s1 s2 = loop s1 s2
   where
-    loop :: Stream (Of a) m r #-> Stream (Of a) m s #-> Stream (Of a) m (r,s)
+    loop :: Stream (Of a) m r %1-> Stream (Of a) m s %1-> Stream (Of a) m (r,s)
     loop s1 s2 = s1 & \case
       Return r ->
         Effect $ effects s2 Control.>>= \s -> Control.return $ Return (r, s)

--- a/src/Streaming/Internal/Type.hs
+++ b/src/Streaming/Internal/Type.hs
@@ -48,13 +48,13 @@ import Prelude.Linear (($), (.))
     \- or, in the producer case, 'Streaming.Prelude.next'
 -}
 data Stream f m r where
-  Step :: !(f (Stream f m r)) #-> Stream f m r
-  Effect :: m (Stream f m r) #-> Stream f m r
-  Return :: r #-> Stream f m r
+  Step :: !(f (Stream f m r)) %1-> Stream f m r
+  Effect :: m (Stream f m r) %1-> Stream f m r
+  Return :: r %1-> Stream f m r
 
 -- | A left-strict pair; the base functor for streams of individual elements.
 data Of a b where
-  (:>) :: !a -> b #-> Of a b
+  (:>) :: !a -> b %1-> Of a b
 
 infixr 5 :>
 
@@ -69,12 +69,12 @@ infixr 5 :>
 -- Data.Functor m and Data.Functor m.
 instance (Data.Functor m, Data.Functor f) => Data.Functor (Stream f m) where
   fmap :: (Data.Functor m, Data.Functor f) =>
-    (a #-> b) -> Stream f m a #-> Stream f m b
+    (a %1-> b) -> Stream f m a %1-> Stream f m b
   fmap f s = fmap' f s
   {-# INLINABLE fmap #-}
 
 fmap' :: (Data.Functor m, Data.Functor f) =>
-  (a #-> b) -> Stream f m a #-> Stream f m b
+  (a %1-> b) -> Stream f m a %1-> Stream f m b
 fmap' f (Return r) = Return (f r)
 fmap' f (Step fs) = Step $ Data.fmap (Data.fmap f) fs
 fmap' f (Effect ms) = Effect $ Data.fmap (Data.fmap f) ms
@@ -88,12 +88,12 @@ instance (Control.Functor m, Control.Functor f) =>
   {-# INLINE pure #-}
 
   (<*>) :: (Control.Functor m, Control.Functor f) =>
-    Stream f m (a #-> b) #-> Stream f m a #-> Stream f m b
+    Stream f m (a %1-> b) %1-> Stream f m a %1-> Stream f m b
   (<*>) s1 s2 = app s1 s2
   {-# INLINABLE (<*>) #-}
 
 app :: (Control.Functor m, Control.Functor f) =>
-  Stream f m (a #-> b) #-> Stream f m a #-> Stream f m b
+  Stream f m (a %1-> b) %1-> Stream f m a %1-> Stream f m b
 app (Return f) stream = Control.fmap f stream
 app (Step fs) stream = Step $ Control.fmap (Data.<*> stream) fs
 app (Effect ms) stream = Effect $ Control.fmap (Data.<*> stream) ms
@@ -103,12 +103,12 @@ app (Effect ms) stream = Effect $ Control.fmap (Data.<*> stream) ms
 instance (Control.Functor m, Control.Functor f) =>
   Control.Functor (Stream f m) where
   fmap :: (Data.Functor m, Data.Functor f) =>
-    (a #-> b) #-> Stream f m a #-> Stream f m b
+    (a %1-> b) %1-> Stream f m a %1-> Stream f m b
   fmap f s = fmap'' f s
   {-# INLINABLE fmap #-}
 
 fmap'' :: (Control.Functor m, Control.Functor f) =>
-  (a #-> b) #-> Stream f m a #-> Stream f m b
+  (a %1-> b) %1-> Stream f m a %1-> Stream f m b
 fmap'' f (Return r) = Return (f r)
 fmap'' f (Step fs) = Step $ Control.fmap (Control.fmap f) fs
 fmap'' f (Effect ms) = Effect $ Control.fmap (Control.fmap f) ms
@@ -116,23 +116,23 @@ fmap'' f (Effect ms) = Effect $ Control.fmap (Control.fmap f) ms
 
 instance (Control.Functor m, Control.Functor f) =>
   Control.Applicative (Stream f m) where
-  pure :: a #-> Stream f m a
+  pure :: a %1-> Stream f m a
   pure = Return
   {-# INLINE pure #-}
 
   (<*>) :: (Control.Functor m, Control.Functor f) =>
-    Stream f m (a #-> b) #-> Stream f m a #-> Stream f m b
+    Stream f m (a %1-> b) %1-> Stream f m a %1-> Stream f m b
   (<*>) = (Data.<*>)
   {-# INLINE (<*>) #-}
 
 instance (Control.Functor m, Control.Functor f) =>
   Control.Monad (Stream f m) where
-  (>>=) :: Stream f m a #-> (a #-> Stream f m b) #-> Stream f m b
+  (>>=) :: Stream f m a %1-> (a %1-> Stream f m b) %1-> Stream f m b
   (>>=) = bind
   {-# INLINABLE (>>=) #-}
 
 bind :: (Control.Functor m, Control.Functor f) =>
-  Stream f m a #-> (a #-> Stream f m b) #-> Stream f m b
+  Stream f m a %1-> (a %1-> Stream f m b) %1-> Stream f m b
 bind (Return a) f = f a
 bind (Step fs) f = Step $ Control.fmap (Control.>>= f) fs
 bind (Effect ms) f = Effect $ Control.fmap (Control.>>= f) ms
@@ -142,7 +142,7 @@ bind (Effect ms) f = Effect $ Control.fmap (Control.>>= f) ms
 -------------------------------------------------------------------------------
 
 instance Control.Functor f => Control.MonadTrans (Stream f) where
-  lift :: (Control.Functor m, Control.Functor f) => m a #-> Stream f m a
+  lift :: (Control.Functor m, Control.Functor f) => m a %1-> Stream f m a
   lift = Effect . Control.fmap Control.return
   {-# INLINE lift #-}
 
@@ -150,7 +150,7 @@ instance Control.Functor f => Control.MonadTrans (Stream f) where
 -- # Control.Functor for (Of)
 -------------------------------------------------------------------------------
 
-ofFmap :: (a #-> b) #-> (Of x a) #-> (Of x b)
+ofFmap :: (a %1-> b) %1-> (Of x a) %1-> (Of x b)
 ofFmap f (a :> b) = a :> f b
 {-# INLINE ofFmap #-}
 

--- a/src/System/IO/Linear.hs
+++ b/src/System/IO/Linear.hs
@@ -77,18 +77,18 @@ import qualified System.IO as System
 -- linear arrow enforcing the implicit invariant that IO actions linearly
 -- thread the state of the real world. Hence, we can safely release the
 -- constructor to this newtype.
-newtype IO a = IO (State# RealWorld #-> (# State# RealWorld, a #))
+newtype IO a = IO (State# RealWorld %1-> (# State# RealWorld, a #))
   deriving (Data.Functor, Data.Applicative) via (Control.Data IO)
 type role IO representational
 
 -- Defined separately because projections from newtypes are considered like
 -- general projections of data types, which take an unrestricted argument.
-unIO :: IO a #-> State# RealWorld #-> (# State# RealWorld, a #)
+unIO :: IO a %1-> State# RealWorld %1-> (# State# RealWorld, a #)
 unIO (IO action) = action
 
 -- | Coerces a standard IO action into a linear IO action.
 -- Note that the value @a@ must be used linearly in the linear IO monad.
-fromSystemIO :: System.IO a #-> IO a
+fromSystemIO :: System.IO a %1-> IO a
 -- The implementation relies on the fact that the monad abstraction for IO
 -- actually enforces linear use of the @RealWorld@ token.
 --
@@ -107,7 +107,7 @@ fromSystemIOU action =
   fromSystemIO (Ur Prelude.<$> action)
 
 -- | Convert a linear IO action to a "System.IO" action.
-toSystemIO :: IO a #-> System.IO a
+toSystemIO :: IO a %1-> System.IO a
 toSystemIO = Unsafe.coerce -- basically just subtyping
 
 -- | Use at the top of @main@ function in your program to switch to the
@@ -123,35 +123,35 @@ withLinearIO action = (\x -> unur x) Prelude.<$> (toSystemIO action)
 -- * Monadic interface
 
 instance Control.Functor IO where
-  fmap :: forall a b. (a #-> b) #-> IO a #-> IO b
+  fmap :: forall a b. (a %1-> b) %1-> IO a %1-> IO b
   fmap f x = IO $ \s ->
       cont (unIO x s) f
     where
       -- XXX: long line
-      cont :: (# State# RealWorld, a #) #-> (a #-> b) #-> (# State# RealWorld, b #)
+      cont :: (# State# RealWorld, a #) %1-> (a %1-> b) %1-> (# State# RealWorld, b #)
       cont (# s', a #) f' = (# s', f' a #)
 
 instance Control.Applicative IO where
-  pure :: forall a. a #-> IO a
+  pure :: forall a. a %1-> IO a
   pure a = IO $ \s -> (# s, a #)
 
-  (<*>) :: forall a b. IO (a #-> b) #-> IO a #-> IO b
+  (<*>) :: forall a b. IO (a %1-> b) %1-> IO a %1-> IO b
   (<*>) = Control.ap
 
 instance Control.Monad IO where
-  (>>=) :: forall a b. IO a #-> (a #-> IO b) #-> IO b
+  (>>=) :: forall a b. IO a %1-> (a %1-> IO b) %1-> IO b
   x >>= f = IO $ \s ->
       cont (unIO x s) f
     where
       -- XXX: long line
-      cont :: (# State# RealWorld, a #) #-> (a #-> IO b) #-> (# State# RealWorld, b #)
+      cont :: (# State# RealWorld, a #) %1-> (a %1-> IO b) %1-> (# State# RealWorld, b #)
       cont (# s', a #) f' = unIO (f' a) s'
 
-  (>>) :: forall b. IO () #-> IO b #-> IO b
+  (>>) :: forall b. IO () %1-> IO b %1-> IO b
   x >> y = IO $ \s ->
       cont (unIO x s) y
     where
-      cont :: (# State# RealWorld, () #) #-> IO b #-> (# State# RealWorld, b #)
+      cont :: (# State# RealWorld, () #) %1-> IO b %1-> (# State# RealWorld, b #)
       cont (# s', () #) y' = unIO y' s'
 
 -- $ioref

--- a/src/Unsafe/Linear.hs
+++ b/src/Unsafe/Linear.hs
@@ -13,7 +13,7 @@
 --
 -- * Import this module qualifed as Unsafe.
 -- * Do not use this unless you have to. Specifically, if you can write a
--- linear function @f :: A #-> B@, do not write a non-linear version and coerce
+-- linear function @f :: A %1-> B@, do not write a non-linear version and coerce
 -- it.
 
 module Unsafe.Linear
@@ -29,23 +29,23 @@ import qualified Unsafe.Coerce as NonLinear
 import GHC.Exts (TYPE, RuntimeRep)
 
 -- | Linearly typed @unsafeCoerce@
-coerce :: a #-> b
+coerce :: a %1-> b
 coerce = NonLinear.unsafeCoerce NonLinear.unsafeCoerce
 
 -- | Converts an unrestricted function into a linear function
 toLinear
   :: forall (r1 :: RuntimeRep) (r2 :: RuntimeRep)
      (a :: TYPE r1) (b :: TYPE r2).
-     (a -> b) #-> (a #-> b)
+     (a -> b) %1-> (a %1-> b)
 toLinear = coerce
 
 -- | Like 'toLinear' but for two-argument functions
 toLinear2
   :: forall (r1 :: RuntimeRep) (r2 :: RuntimeRep) (r3 :: RuntimeRep)
      (a :: TYPE r1) (b :: TYPE r2) (c :: TYPE r3).
-     (a -> b -> c) #-> (a #-> b #-> c)
+     (a -> b -> c) %1-> (a %1-> b %1-> c)
 toLinear2 = coerce
 
 -- | Like 'toLinear' but for three-argument functions
-toLinear3 :: (a -> b -> c -> d) #-> (a #-> b #-> c #-> d)
+toLinear3 :: (a -> b -> c -> d) %1-> (a %1-> b %1-> c %1-> d)
 toLinear3 = coerce

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 # See https://hub.docker.com/r/tweag/linear-types/
 resolver: lts-16.15
-compiler: ghc-8.11
+compiler: ghc-9.1
 allow-newer: true
 system-ghc: true
 

--- a/test/Test/Data/Mutable/Array.hs
+++ b/test/Test/Data/Mutable/Array.hs
@@ -81,7 +81,7 @@ group =
 -- # Internal Library
 --------------------------------------------------------------------------------
 
-type ArrayTester = Array.Array Int #-> Ur (TestT IO ())
+type ArrayTester = Array.Array Int %1-> Ur (TestT IO ())
 
 nonEmptyList :: Gen [Int]
 nonEmptyList = Gen.list (Range.linear 1 1000) value
@@ -94,13 +94,13 @@ value :: Gen Int
 value = Gen.int (Range.linear (-1000) 1000)
 
 compInts ::
-  Ur Int #->
-  Ur Int #->
+  Ur Int %1->
+  Ur Int %1->
   Ur (TestT IO ())
 compInts (Ur x) (Ur y) = Ur (x === y)
 
 -- XXX: This is a terrible name
-getFst :: Consumable b => (a, b) #-> a
+getFst :: Consumable b => (a, b) %1-> a
 getFst (a, b) = lseq b a
 
 
@@ -162,7 +162,7 @@ readWrite2Test :: Int -> Int -> Int -> ArrayTester
 readWrite2Test ix jx val arr = fromRead (Array.read arr ix)
   where
     fromRead ::
-      (Ur Int, Array.Array Int) #-> Ur (TestT IO ())
+      (Ur Int, Array.Array Int) %1-> Ur (TestT IO ())
     fromRead (val1, arr) =
       compInts
         val1
@@ -260,7 +260,7 @@ refFmap :: Property
 refFmap = property $ do
   xs <- forAll list
   let -- An arbitrary function
-      f :: Int #-> Bool
+      f :: Int %1-> Bool
       f = (Linear.> 0)
       expected = map (Linear.forget f) xs
       Ur actual =
@@ -291,7 +291,7 @@ readAndWriteTest :: Property
 readAndWriteTest = withTests 1 . property $
   unur (Array.fromList "a" test) === 'a'
   where
-    test :: Array.Array Char #-> Ur Char
+    test :: Array.Array Char %1-> Ur Char
     test arr =
       Array.read arr 0 Linear.& \(before, arr') ->
         Array.write arr' 0 'b' Linear.& \arr'' ->
@@ -302,7 +302,7 @@ strictnessTest :: Property
 strictnessTest = withTests 1 . property $
   unur (Array.fromList [()] test) === ()
   where
-    test :: Array.Array () #-> Ur ()
+    test :: Array.Array () %1-> Ur ()
     test arr =
       Array.write arr 0 (error "this should not be evaluated") Linear.& \arr ->
       Array.read arr 0 Linear.& \(Ur _, arr) ->

--- a/test/Test/Data/Mutable/HashMap.hs
+++ b/test/Test/Data/Mutable/HashMap.hs
@@ -62,7 +62,7 @@ group =
 type HMap = HashMap.HashMap Int String
 
 -- | A test checks a boolean property on a hashmap and consumes it
-type HMTest = HMap #-> Ur Bool
+type HMTest = HMap %1-> Ur Bool
 
 
 maxSize :: Int
@@ -83,7 +83,7 @@ testKVPairExists :: (Int, String) -> HMTest
 testKVPairExists (k, v) hmap =
   fromLookup Linear.$ getFst Linear.$ HashMap.lookup k hmap
   where
-    fromLookup :: Ur (Maybe String) #-> Ur Bool
+    fromLookup :: Ur (Maybe String) %1-> Ur Bool
     fromLookup (Ur Nothing) = Ur False
     fromLookup (Ur (Just v')) = Ur (v' == v)
 
@@ -98,27 +98,27 @@ testKeyMissing :: Int -> HMTest
 testKeyMissing key hmap =
   fromLookup Linear.$ getFst Linear.$ HashMap.lookup key hmap
   where
-    fromLookup :: Ur (Maybe String) #-> Ur Bool
+    fromLookup :: Ur (Maybe String) %1-> Ur Bool
     fromLookup (Ur Nothing) = Ur True
     fromLookup (Ur _) = Ur False
 
-testLookupUnchanged :: (HMap #-> HMap) -> Int -> HMTest
+testLookupUnchanged :: (HMap %1-> HMap) -> Int -> HMTest
 testLookupUnchanged f k hmap = fromLookup (HashMap.lookup k hmap)
   where
-    fromLookup :: (Ur (Maybe String), HMap) #-> Ur Bool
+    fromLookup :: (Ur (Maybe String), HMap) %1-> Ur Bool
     fromLookup (look1, hmap') =
       compareMaybes look1 (getFst Linear.$ HashMap.lookup k (f hmap'))
 
-insertPair :: (Int, String) -> HMap #-> HMap
+insertPair :: (Int, String) -> HMap %1-> HMap
 insertPair (k, v) hmap = HashMap.insert k v hmap
 
 -- XXX: This is a terrible name
-getFst :: (Consumable b) => (a, b) #-> a
+getFst :: (Consumable b) => (a, b) %1-> a
 getFst (a, b) = lseq b a
 
 compareMaybes :: Eq a =>
-  Ur (Maybe a) #->
-  Ur (Maybe a) #->
+  Ur (Maybe a) %1->
+  Ur (Maybe a) %1->
   Ur Bool
 compareMaybes (Ur a) (Ur b) = Ur (a == b)
 
@@ -203,13 +203,13 @@ sizeInsert = testOnAnyHM $ do
 checkSizeAfterInsert :: (Int, String) -> HMTest
 checkSizeAfterInsert (k, v) hmap = withSize Linear.$ HashMap.size hmap
   where
-    withSize :: (Ur Int, HMap) #-> Ur Bool
+    withSize :: (Ur Int, HMap) %1-> Ur Bool
     withSize (oldSize, hmap) =
       checkSize oldSize
         Linear.$ getFst
         Linear.$ HashMap.size
         Linear.$ HashMap.insert k v hmap
-    checkSize :: Ur Int #-> Ur Int #-> Ur Bool
+    checkSize :: Ur Int %1-> Ur Int %1-> Ur Bool
     checkSize (Ur old) (Ur new) =
       Ur ((old + 1) == new)
 
@@ -224,12 +224,12 @@ deleteSize = testOnAnyHM $ do
 checkSizeAfterDelete :: Int -> HMTest
 checkSizeAfterDelete key hmap = fromSize (HashMap.size hmap)
   where
-    fromSize :: (Ur Int, HMap) #-> Ur Bool
+    fromSize :: (Ur Int, HMap) %1-> Ur Bool
     fromSize (orgSize, hmap) =
       compSizes orgSize
         Linear.$ getFst
         Linear.$ HashMap.size (HashMap.delete key hmap)
-    compSizes :: Ur Int #-> Ur Int #-> Ur Bool
+    compSizes :: Ur Int %1-> Ur Int %1-> Ur Bool
     compSizes (Ur orgSize) (Ur newSize) =
       Ur ((newSize + 1) == orgSize)
 

--- a/test/Test/Data/Mutable/Set.hs
+++ b/test/Test/Data/Mutable/Set.hs
@@ -43,7 +43,7 @@ group =
 -- # Internal Library
 --------------------------------------------------------------------------------
 
-type SetTester = Set.Set Int #-> Ur (TestT IO ())
+type SetTester = Set.Set Int %1-> Ur (TestT IO ())
 
 -- | A random list
 nonemptyList :: Gen [Int]
@@ -57,13 +57,13 @@ value :: Gen Int
 value = Gen.int (Range.linear (-100) 100)
 
 testEqual :: (Show a, Eq a) =>
-  Ur a #->
-  Ur a #->
+  Ur a %1->
+  Ur a %1->
   Ur (TestT IO ())
 testEqual (Ur x) (Ur y) = Ur (x === y)
 
 -- XXX: This is a terrible name
-getFst :: Consumable b => (a, b) #-> a
+getFst :: Consumable b => (a, b) %1-> a
 getFst (a, b) = lseq b a
 
 -- # Tests
@@ -93,7 +93,7 @@ memberInsert2 = property $ do
 memberInsert2Test :: Int -> Int -> SetTester
 memberInsert2Test val1 val2 set = fromRead (Set.member val2 set)
   where
-    fromRead :: (Ur Bool, Set.Set Int) #-> Ur (TestT IO ())
+    fromRead :: (Ur Bool, Set.Set Int) %1-> Ur (TestT IO ())
     fromRead (memberVal2, set) =
       testEqual
         memberVal2
@@ -123,7 +123,7 @@ memberDelete2 = property $ do
 memberDelete2Test :: Int -> Int -> SetTester
 memberDelete2Test val1 val2 set = fromRead (Set.member val2 set)
   where
-    fromRead :: (Ur Bool, Set.Set Int) #-> Ur (TestT IO ())
+    fromRead :: (Ur Bool, Set.Set Int) %1-> Ur (TestT IO ())
     fromRead (memberVal2, set) =
       testEqual
         memberVal2
@@ -139,7 +139,7 @@ sizeInsert1 = property $ do
 sizeInsert1Test :: Int -> SetTester
 sizeInsert1Test val set = fromRead (Set.size set)
   where
-    fromRead :: (Ur Int, Set.Set Int) #-> Ur (TestT IO ())
+    fromRead :: (Ur Int, Set.Set Int) %1-> Ur (TestT IO ())
     fromRead (sizeOriginal, set) =
       testEqual
         sizeOriginal
@@ -155,7 +155,7 @@ sizeInsert2 = property $ do
 sizeInsert2Test :: Int -> SetTester
 sizeInsert2Test val set = fromRead (Set.size set)
   where
-    fromRead :: (Ur Int, Set.Set Int) #-> Ur (TestT IO ())
+    fromRead :: (Ur Int, Set.Set Int) %1-> Ur (TestT IO ())
     fromRead (sizeOriginal, set) =
       testEqual
         ((Linear.+ 1) Data.<$> sizeOriginal)
@@ -171,7 +171,7 @@ sizeDelete1 = property $ do
 sizeDelete1Test :: Int -> SetTester
 sizeDelete1Test val set = fromRead (Set.size set)
   where
-    fromRead :: (Ur Int, Set.Set Int) #-> Ur (TestT IO ())
+    fromRead :: (Ur Int, Set.Set Int) %1-> Ur (TestT IO ())
     fromRead (sizeOriginal, set) =
       testEqual
         ((Linear.- 1) Data.<$> sizeOriginal)
@@ -187,7 +187,7 @@ sizeDelete2 = property $ do
 sizeDelete2Test :: Int -> SetTester
 sizeDelete2Test val set = fromRead (Set.size set)
   where
-    fromRead :: (Ur Int, Set.Set Int) #-> Ur (TestT IO ())
+    fromRead :: (Ur Int, Set.Set Int) %1-> Ur (TestT IO ())
     fromRead (sizeOriginal, set) =
       testEqual
         sizeOriginal

--- a/test/Test/Data/Mutable/Vector.hs
+++ b/test/Test/Data/Mutable/Vector.hs
@@ -68,7 +68,7 @@ group =
 -- # Internal Library
 --------------------------------------------------------------------------------
 
-type VectorTester = Vector.Vector Int #-> Ur (TestT IO ())
+type VectorTester = Vector.Vector Int %1-> Ur (TestT IO ())
 
 nonEmptyList :: Gen [Int]
 nonEmptyList = Gen.list (Range.linear 1 1000) val
@@ -80,13 +80,13 @@ val :: Gen Int
 val = Gen.int (Range.linear (-1000) 1000)
 
 compInts ::
-  Ur Int #->
-  Ur Int #->
+  Ur Int %1->
+  Ur Int %1->
   Ur (TestT IO ())
 compInts (Ur x) (Ur y) = Ur (x === y)
 
 -- XXX: This is a terrible name
-getFst :: Consumable b => (a, b) #-> a
+getFst :: Consumable b => (a, b) %1-> a
 getFst (a, b) = lseq b a
 
 
@@ -140,7 +140,7 @@ readWrite2 = property $ do
 readWrite2Test :: Int -> Int -> Int -> VectorTester
 readWrite2Test ix jx val vec = fromRead (Vector.read vec ix)
   where
-    fromRead :: (Ur Int, Vector.Vector Int) #-> Ur (TestT IO ())
+    fromRead :: (Ur Int, Vector.Vector Int) %1-> Ur (TestT IO ())
     fromRead (val1, vec) =
       compInts
         val1
@@ -158,7 +158,7 @@ readPush1 = property $ do
 readPush1Test :: Int -> Int -> VectorTester
 readPush1Test val ix vec = fromRead (Vector.read vec ix)
   where
-    fromRead :: (Ur Int, Vector.Vector Int) #-> Ur (TestT IO ())
+    fromRead :: (Ur Int, Vector.Vector Int) %1-> Ur (TestT IO ())
     fromRead (val', vec) =
       compInts (getFst (Vector.get ix (Vector.push val vec))) val'
 
@@ -174,7 +174,7 @@ readPush2Test :: Int -> VectorTester
 readPush2Test val vec = fromLen (Vector.size vec)
   where
     fromLen ::
-      (Ur Int, Vector.Vector Int) #->
+      (Ur Int, Vector.Vector Int) %1->
       Ur (TestT IO ())
     fromLen (Ur len, vec) =
       compInts (getFst (Vector.get len (Vector.push val vec))) (move val)
@@ -215,7 +215,7 @@ lenPushTest :: Int -> VectorTester
 lenPushTest val vec = fromLen Linear.$ Vector.size vec
   where
     fromLen ::
-      (Ur Int, Vector.Vector Int) #->
+      (Ur Int, Vector.Vector Int) %1->
       Ur (TestT IO ())
     fromLen (Ur len, vec) =
       compInts (move (len+1)) (getFst (Vector.size (Vector.push val vec)))
@@ -266,7 +266,7 @@ refToListViaPop = property $ do
         Vector.fromList xs (popAll [])
   xs === actual
  where
-   popAll :: [a] -> Vector.Vector a #-> Ur [a]
+   popAll :: [a] -> Vector.Vector a %1-> Ur [a]
    popAll acc vec =
      Vector.pop vec Linear.& \case
        (Ur Nothing, vec') -> vec' `lseq` Ur acc
@@ -280,7 +280,7 @@ refFromListViaPush = property $ do
           Vector.toList Linear.. pushAll xs
   xs === actual
  where
-   pushAll :: [a] -> Vector.Vector a #-> Vector.Vector a
+   pushAll :: [a] -> Vector.Vector a %1-> Vector.Vector a
    pushAll [] vec = vec
    pushAll (x:xs) vec = Vector.push x vec Linear.& pushAll xs
 
@@ -311,7 +311,7 @@ refFmap :: Property
 refFmap = property $ do
   xs <- forAll list
   let -- An arbitrary function
-      f :: Int #-> Bool
+      f :: Int %1-> Bool
       f = (Linear.> 0)
       expected = map (Linear.forget f) xs
       Ur actual =
@@ -371,7 +371,7 @@ readAndWriteTest :: Property
 readAndWriteTest = withTests 1 . property $
   unur (Vector.fromList "a" test) === 'a'
   where
-    test :: Vector.Vector Char #-> Ur Char
+    test :: Vector.Vector Char %1-> Ur Char
     test vec =
       Vector.read vec 0 Linear.& \(before, vec') ->
         Vector.write vec' 0 'b' Linear.& \vec'' ->


### PR DESCRIPTION
This PR updates GHC to a newer revision, which comes with the new linear arrow syntax (`%p ->`).

* Uses https://github.com/tweag/nixpkgs/commit/60a06c5a2ec88392c1eb5e252367dde4e0ead16c to update GHC. I haven't sent a PR upstream because it has an annoying locale fix which probably won't work on all GHC variants (I'm thinking about `musl`); and I couldn't find time to test them.
* I replaced most uses of `#->` with crude search & replace (`sed -i 's/#->/%1->/g' {src,test,examples}/**/*.hs`), so it's possible that it missed something.
* There is one behaviour change that I don't know the reason of; it seems like now the pattern guards does not bind linearly, so I had to apply this kind of change on a few places:

```haskell
instance (Prelude.Eq a, Movable a) => Eq (MovableEq a) where
  MovableEq ar == MovableEq br
-    | Ur a <- move ar , Ur b <- move br
-    = a Prelude.== b
+    = move (ar, br) & \(Ur (a, b)) ->
+        a Prelude.== b
```

The most important one is that, I had to disable our doctests. I added a comment explaining why to `linear-base.cabal` , quoted below:

> -- cabal-install has a piece of code[1] which injects a Cabal upper bound to
-- packages with custom Setup.hs's. And this happens after the overrides,
-- so the usual mechanisms of overriding upper bounds does not work.
--
-- GHC 9 comes with Cabal 3.4, which is above that bound. So, when using
-- GHC 9 with cabal-install 3.2; `build-type: Custom` causes another Cabal
-- library to be built, and that causes a strange type error ("expecting IO,
-- but got IO"), which I suspect because it conflicts with the existing boot
-- packages.
--
-- [1]: https://github.com/haskell/cabal/blob/d28c80acc69b9e7fa992a0b2b7fced937734b238/cabal-install/src/Distribution/Client/ProjectPlanning.hs#L1132-L1149

I don't like it, but it is the easiest workaround until GHC 9 is released hopefully within a few weeks.