### PR TITLE
Doc/optics

### DIFF
--- a/src/Control/Optics/Linear.hs
+++ b/src/Control/Optics/Linear.hs
@@ -1,7 +1,7 @@
--- | This module provides linear optics.
+-- | This module provides linear optics
 --
--- Documentation for specific optics: lenses, prisms, traversals and
--- isomorphisms are provided in their respective modules.
+-- Documentation for specific optics (lenses, prisms, traversals and
+-- isomorphisms) are provided in their respective modules.
 --
 -- Here we just provide an overview.
 --

--- a/src/Control/Optics/Linear.hs
+++ b/src/Control/Optics/Linear.hs
@@ -1,4 +1,4 @@
--- | This module provides linear optics
+-- | This module provides linear optics.
 --
 -- Documentation for specific optics (lenses, prisms, traversals and
 -- isomorphisms) are provided in their respective modules.

--- a/src/Control/Optics/Linear.hs
+++ b/src/Control/Optics/Linear.hs
@@ -1,3 +1,136 @@
+-- | This module provides linear optics.
+--
+-- Documentation for specific optics: lenses, prisms, traversals and
+-- isomorphisms are provided in their respective modules.
+--
+-- Here we just provide an overview.
+--
+-- Some familiarity with optics is needed to understand linear optics.
+-- Please go through the (hopefully friendly!) background material section
+-- if you are unfamiliar with lenses, prisms, traversals or isomorphisms.
+--
+-- == Background Material
+--
+-- If you don't know anything about optics, we suggest looking at the
+-- resources below and playing with the @lens@ package.
+--
+--  * [A great intro-to-lenses talk by Simon Peyton Jones](https://skillsmatter.com/skillscasts/4251-lenses-compositional-data-access-and-manipulation)
+--  * [A nice introductory blog post](https://tech.fpcomplete.com/haskell/tutorial/lens)
+--  * [A friendly introduction to prisms and isos](https://www.schoolofhaskell.com/school/to-infinity-and-beyond/pick-of-the-week/a-little-lens-starter-tutorial)
+--  * [The wiki of the @lens@ package](https://github.com/ekmett/lens/wiki)
+--  that contains some nice examples
+--
+-- == Conceptualizing and using optics
+--
+-- === What are /linear/ optics?
+--
+-- Optics can be conceptualized as a first class object with which you can
+-- view and map functions over sub-structure(s) within a larger structure.
+--
+-- __ /Linear/ optics are optics where the \"viewing\" and \"mapping\" are__
+-- __done with linear functions (and any corresponding structures hold values__
+-- __linearly, i.e., with constructors that use linear arrows).__
+--
+-- In types: a (linear) optic of type @Optic s t a b@ is a way of viewing the
+-- sub-structure(s) of type @a@ in the structure of type @s@ and mapping a
+-- function from an @a@ to a @b@ on those sub-structures in @s@ which change an
+-- @s@ to a @t@. The non-polymorphic version of the optic is specialized
+-- to the types @Optic s s a a@ and is usually defined with a tick mark,
+-- e.g., the non-polymorphic @Lens@ is @Lens'@.
+--
+-- There are four basic optics: traversals, lenses, prisms and isomorphisms.
+--
+-- === Sub-typing diagram of optics
+--
+-- \[ \texttt{Traversal} \]
+-- \[ \Huge \nearrow ~~~~~ \nwarrow \]
+-- \[ \texttt{Lens}\hspace{6em}\texttt{Prism} \]
+-- \[ \Huge \nwarrow ~~~~~ \nearrow \]
+-- \[ \texttt{Iso} \]
+--
+-- In the diagram above, the arrows @X --> Y@ mean any of the following
+-- equivalent things:
+--
+--  * X is a specialization of Y
+--  * X is a strict subset of Y
+--  * You can (basically) implement @f :: X -> Y@ with @f = id@
+--  but you can't implement @f :: Y -> X@.
+--
+-- === A bird's eye view of the types
+--
+-- The types of linear optics are generalizations of the standard optic
+-- types from the @lens@ package.
+--
+-- These are the standard optic types:
+--
+-- > type Traversal s t a b =
+-- >   forall f. Applicative f => (a -> f b) -> s -> f t
+-- > type Lens s t a b =
+-- >   forall f. Functor f => (a -> f b) -> (s -> f t)
+-- > type Prism s t a b =
+-- >   forall p f. (Choice p, Applicative f) => p a (f b) -> p s (f t)
+-- > type Iso s t a b =
+-- >   forall p f. (Profunctor p, Functor f) => a `p` (f b) -> s `p` (f t)
+--
+-- These are (basically) the linear optic types:
+--
+-- > type Traversal a b s t =
+-- >   forall arr.  Wandering arr => (a `arr` b) -> (s `arr` t)
+-- > type Lens a b s t =
+-- >   forall arr. Strong (,) () arr => (a `arr` b) -> (s `arr` t)
+-- > type Prism a b s t =
+-- >   forall arr. Strong Either Void arr => (a `arr` b) -> (s `arr` t)
+-- > type Iso a b s t =
+-- >   forall arr. Profunctor arr => (a `arr` b) -> (s `arr` t)
+--
+-- Below is a table that lists the instances of the typeclasses which
+-- generalize the standard optics.
+--
+-- Note that Kleisli arrows basically defined like so:
+--
+-- > type Kleisli f a b = a #-> f b
+--
+-- /Note: We abbreviate Control for Control.Monad.Linear./
+--
+-- +-----------------+------------+---------------+--------------------+-----------+
+-- |                 | Profunctor | Strong (,) () | Strong Either Void | Wandering |
+-- +=================+============+===============+====================+===========+
+-- |     @(->)@      |     X      |       X       |         X          |           |
+-- +-----------------+------------+---------------+--------------------+-----------+
+-- |    @(\#->)@     |     X      |       X       |         X          |           |
+-- +-----------------+------------+---------------+--------------------+-----------+
+-- |    (Prelude)    |            |               |                    |           |
+-- |  @Functor f@    |            |               |                    |           |
+-- | @=> Kleisli f@  |     X (4)  |       X       |                    |           |
+-- +-----------------+------------+---------------+--------------------+-----------+
+-- | (Data.Functor)  |            |               |                    |           |
+-- |  @Functor f@    |            |               |                    |           |
+-- | @=> Kleisli f@  |     X      |               |                    |           |
+-- +-----------------+------------+---------------+--------------------+-----------+
+-- |    (Prelude)    |            |               |                    |           |
+-- | @Applicative f@ |            |               |                    |           |
+-- | @=> Kleisli f@  |     X      |       X       |         X   (3)    |           |
+-- +-----------------+------------+---------------+--------------------+-----------+
+-- |    (Control)    |            |               |                    |           |
+-- |   @Functor f@   |            |               |                    |           |
+-- | @=> Kleisli f@  |     X      |       X (2)   |                    |           |
+-- +-----------------+------------+---------------+--------------------+-----------+
+-- |    (Control)    |            |               |                    |           |
+-- | @Applicative f@ |            |               |                    |           |
+-- | @=> Kleisli f@  |     X      |       X       |         X          |     X (1) |
+-- +-----------------+------------+---------------+--------------------+-----------+
+--
+-- Essentially:
+--
+--  * The instance marked (1) implies that the linear traversal definition
+--    includes the standard one
+--  * The instance marked by (2) implies that the linear lens definition
+--    includes the standard one
+--  * The instance marked by (3) implies that the linear prism definition
+--    includes the standard one
+--  * The instance marked by (4) implies that the linear iso definition
+--    includes the standard one
+--
 module Control.Optics.Linear
   ( Optic_(..)
   , Optic

--- a/src/Control/Optics/Linear/Iso.hs
+++ b/src/Control/Optics/Linear/Iso.hs
@@ -22,6 +22,12 @@
 -- import Data.Vector (Vector)
 -- import Data.Unrestricted.Linear
 --
+-- -- We can use an isomorphism to apply a mutable quicksort implementation
+-- -- on immutable vectors
+-- quickSort :: Vector Int -> Vector Int
+-- quickSort v = unur $
+--   withIso isoListArray (\_ onVecs -> onVecs (Array.freeze . arrQuicksort)) v
+--
 -- isoListArray :: Iso' (Vector a -> Ur b) (Array a %1-> Ur b)
 -- isoListArray = iso byVecs byArrays where
 --   byVecs :: (Vector a -> Ur b) %1-> Array a %1-> Ur b
@@ -29,11 +35,6 @@
 --
 --   byArrays :: (Array a %1-> Ur b) %1-> Vector a -> Ur b
 --   byArrays onArrs vec = Array.fromList (Vector.toList vec) onArrs
---
--- -- | Apply a mutable quicksort implementation on immutable vectors
--- quickSort :: Vector Int -> Vector Int
--- quickSort v = unur $
---   withIso isoListArray (\_ onVecs -> onVecs (Array.freeze . arrQuicksort)) v
 --
 -- -- Not important to know the details for this example of optics ...
 -- -- but here is an imperative representation of quicksort:

--- a/src/Control/Optics/Linear/Iso.hs
+++ b/src/Control/Optics/Linear/Iso.hs
@@ -8,6 +8,66 @@
 --
 -- = Example
 --
+-- @
+-- {-# LANGUAGE LinearTypes #-}
+-- {-# LANGUAGE LambdaCase #-}
+-- {-# LANGUAGE FlexibleContexts #-}
+-- {-# LANGUAGE GADTs #-}
+-- import qualified Data.Array.Mutable.Linear as Array
+-- import Data.Array.Mutable.Linear (Array)
+-- import Prelude.Linear (($), (&), Int, Bool(..), (.))
+-- import qualified Prelude as Ur
+-- import Prelude ((+), (-), Ord(..))
+-- import qualified Data.Vector as Vector
+-- import Data.Vector (Vector)
+-- import Data.Unrestricted.Linear
+--
+-- isoListArray :: Iso' (Vector a -> Ur b) (Array a %1-> Ur b)
+-- isoListArray = iso byVecs byArrays where
+--   byVecs :: (Vector a -> Ur b) %1-> Array a %1-> Ur b
+--   byVecs onVecs arr = Array.freeze arr & \(Ur vec) -> onVecs vec
+--
+--   byArrays :: (Array a %1-> Ur b) %1-> Vector a -> Ur b
+--   byArrays onArrs vec = Array.fromList (Vector.toList vec) onArrs
+--
+-- -- | Apply a mutable quicksort implementation on immutable vectors
+-- quickSort :: Vector Int -> Vector Int
+-- quickSort v = unur $
+--   withIso isoListArray (\_ onVecs -> onVecs (Array.freeze . arrQuicksort)) v
+--
+-- -- Not important to know the details for this example of optics ...
+-- -- but here is an imperative representation of quicksort:
+--
+-- arrQuicksort :: Array Int %1-> Array Int
+-- arrQuicksort arr = Array.size arr & \case
+--   (Ur len, arr') -> go 0 (len-1) arr' where
+--     go :: Int -> Int -> Array Int %1-> Array Int
+--     go lo hi arr = case lo >= hi of
+--       True -> arr
+--       False -> Array.read arr lo & \case
+--         (Ur pivot, arr0) -> partition arr0 pivot lo hi & \case
+--           (arr1, Ur ix) -> swapix arr1 lo ix & \case
+--             arr2 -> go lo ix arr2 & \case
+--               arr3 -> go (ix+1) hi arr3
+--
+-- partition :: Array Int %1-> Int -> Int -> Int -> (Array Int, Ur Int)
+-- partition arr pivot lx rx
+--   | (rx < lx) = (arr, Ur rx)
+--   | True = Array.read arr lx & \case
+--       (Ur lVal, arr1) -> Array.read arr1 rx & \case
+--         (Ur rVal, arr2) -> case (lVal <= pivot, pivot < rVal) of
+--           (True, True) -> partition arr2 pivot (lx+1) (rx-1)
+--           (True, False) -> partition arr2 pivot (lx+1) rx
+--           (False, True) -> partition arr2 pivot (lx-1) (rx-1)
+--           (False, False) -> swapix arr2 lx rx & \case
+--             arr3 -> partition arr3 pivot (lx+1) (rx-1)
+--
+-- swapix :: Array Int %1-> Int -> Int -> Array Int
+-- swapix arr i j = Array.read arr i & \case
+--   (Ur ival, arr1) -> Array.read arr1 j & \case
+--     (Ur jval, arr2) -> Array.write (Array.write arr2 i jval) j ival
+-- @
+--
 module Control.Optics.Linear.Iso
   ( -- * Types
     Iso, Iso'

--- a/src/Control/Optics/Linear/Iso.hs
+++ b/src/Control/Optics/Linear/Iso.hs
@@ -1,3 +1,13 @@
+-- | This module provides linear isomorphisms
+--
+-- An @Iso a b s t@ is equivalent to a @(s \#-> a, b \#-> t)@.  In the simple
+-- case of an @Iso' a s@, this is equivalent to inverse functions
+-- @(s \#-> a, a \#-> s)@.  In the general case an @Iso a b s t@ means if you
+-- have the isomorphisms @(a \#-> b, b \#-> a)@ and @(s \#-> t, t \#-> s)@, then
+-- you can form isomorphisms between @s@, @t@, @a@ and @b@.
+--
+-- = Example
+--
 module Control.Optics.Linear.Iso
   ( -- * Types
     Iso, Iso'

--- a/src/Control/Optics/Linear/Lens.hs
+++ b/src/Control/Optics/Linear/Lens.hs
@@ -14,6 +14,13 @@
 --
 -- import qualified Data.Num.Linear as Linear
 --
+-- -- We can use a lens to, for instance, linearly modify a sub-piece in
+-- -- a nested record
+-- modPersonZip :: Person %1-> Person
+-- modPersonZip = over personZipLens addOne where
+--   addOne :: Int %1-> Int
+--   addOne x = x Linear.+ 1
+--
 -- -- A person has a name and location
 -- data Person = Person String Location
 --
@@ -23,11 +30,6 @@
 -- personZipLens :: Lens' Person Int
 -- personZipLens = lens $ \(Person nm (Location zip adr)) ->
 --   (zip, \z -> Person nm (Location z adr))
---
--- modPersonZip :: Person %1-> Person
--- modPersonZip = over personZipLens addOne where
---   addOne :: Int %1-> Int
---   addOne x = x Linear.+ 1
 -- @
 --
 module Control.Optics.Linear.Lens

--- a/src/Control/Optics/Linear/Lens.hs
+++ b/src/Control/Optics/Linear/Lens.hs
@@ -1,4 +1,7 @@
--- | This module provides linear lenses
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE FlexibleContexts #-}
+-- | This module provides linear lenses.
 --
 -- A @Lens s t a b@ is equivalent to a @(s \#-> (a,b \#-> t)@.  It is a way to
 -- cut up an instance of a /product type/ @s@ into an @a@ and a way to take a
@@ -11,15 +14,17 @@
 -- @
 -- {-# LANGUAGE LinearTypes #-}
 -- {-# LANGUAGE FlexibleContexts #-}
+-- {-# LANGUAGE NoImplicitPrelude #-}
 --
--- import qualified Data.Num.Linear as Linear
+-- import Control.Optics.Linear.Internal
+-- import Prelude.Linear
 --
+-- import Control.Optics.Linear.Internal
+-- import Prelude.Linear
 -- -- We can use a lens to, for instance, linearly modify a sub-piece in
 -- -- a nested record
 -- modPersonZip :: Person %1-> Person
--- modPersonZip = over personZipLens addOne where
---   addOne :: Int %1-> Int
---   addOne x = x Linear.+ 1
+-- modPersonZip = over (personLocL .> locZipL)  (\x -> x + 1)
 --
 -- -- A person has a name and location
 -- data Person = Person String Location
@@ -27,9 +32,11 @@
 -- -- A location is a zip code and address
 -- data Location = Location Int String
 --
--- personZipLens :: Lens' Person Int
--- personZipLens = lens $ \(Person nm (Location zip adr)) ->
---   (zip, \z -> Person nm (Location z adr))
+-- personLocL :: Lens' Person Location
+-- personLocL = lens (\(Person s l) -> (l, \l' -> Person s l'))
+--
+-- locZipL :: Lens' Location Int
+-- locZipL = lens (\(Location i s) -> (i, \i' -> Location i' s))
 -- @
 --
 module Control.Optics.Linear.Lens

--- a/src/Control/Optics/Linear/Lens.hs
+++ b/src/Control/Optics/Linear/Lens.hs
@@ -8,6 +8,28 @@
 --
 -- = Example
 --
+-- @
+-- {-# LANGUAGE LinearTypes #-}
+-- {-# LANGUAGE FlexibleContexts #-}
+--
+-- import qualified Data.Num.Linear as Linear
+--
+-- -- A person has a name and location
+-- data Person = Person String Location
+--
+-- -- A location is a zip code and address
+-- data Location = Location Int String
+--
+-- personZipLens :: Lens' Person Int
+-- personZipLens = lens $ \(Person nm (Location zip adr)) ->
+--   (zip, \z -> Person nm (Location z adr))
+--
+-- modPersonZip :: Person %1-> Person
+-- modPersonZip = over personZipLens addOne where
+--   addOne :: Int %1-> Int
+--   addOne x = x Linear.+ 1
+-- @
+--
 module Control.Optics.Linear.Lens
   ( -- * Types
     Lens, Lens'

--- a/src/Control/Optics/Linear/Lens.hs
+++ b/src/Control/Optics/Linear/Lens.hs
@@ -1,3 +1,13 @@
+-- | This module provides linear lenses
+--
+-- A @Lens s t a b@ is equivalent to a @(s \#-> (a,b \#-> t)@.  It is a way to
+-- cut up an instance of a /product type/ @s@ into an @a@ and a way to take a
+-- @b@ to fill the place of the @a@ in @s@ which yields a @t@. When @a=b@ and
+-- @s=t@, this type is much more intuitive: @(s \#-> (a,a \#-> s))@.  This is a
+-- traversal on exactly one @a@ in a @s@.
+--
+-- = Example
+--
 module Control.Optics.Linear.Lens
   ( -- * Types
     Lens, Lens'

--- a/src/Control/Optics/Linear/Prism.hs
+++ b/src/Control/Optics/Linear/Prism.hs
@@ -1,12 +1,49 @@
 -- | This module provides linear prisms
 --
 -- A @Prism s t a b@ is equivalent to @(s \#-> Either a t, b \#-> t)@ for some
--- /sum type/ @s@. In the non-polymorphic version, this is a
--- @(s \#-> Either a s, a \#-> s)@ which represents taking one case of a sum type
--- and a way to build the sum-type given that one case. A prism is a
--- traversal focusing on one branch or case that a sum type could be.
+-- /sum type/ @s@. In the non-polymorphic version, this is a @(s \#-> Either a
+-- s, a \#-> s)@ which represents taking one case of a sum type and a way to
+-- build the sum-type given that one case. A prism is a traversal focusing on
+-- one branch or case that a sum type could be.
 --
 -- = Example
+--
+-- @
+-- {-# LANGUAGE LinearTypes #-}
+-- {-# LANGUAGE LambdaCase #-}
+-- {-# LANGUAGE FlexibleContexts #-}
+-- {-# LANGUAGE GADTs #-}
+--
+-- import Prelude hiding ((++))
+-- import Data.List.Linear ((++))
+-- import Prelude.Linear ((&))
+-- import qualified Data.Functor.Linear as Data
+--
+-- data PersonId where
+--   IdLiscence :: Liscence %1-> PersonId
+--   SSN :: Int %1-> PersonId
+--   BirthCertif :: String %1-> PersonId
+--   StateVoterId :: Int %1-> PersonId
+--   CensusId :: Int %1-> PersonId
+--
+-- -- A Liscence is a name and number
+-- data Liscence = Liscence String Int
+--
+-- pIdLiscPrism :: Prism' PersonId Liscence
+-- pIdLiscPrism = prism IdLiscence decompose where
+--   decompose :: PersonId %1-> Either PersonId Liscence
+--   decompose (IdLiscence l) = Right l
+--   decompose x = Left x
+--
+-- formatLiscenceName :: PersonId %1-> PersonId
+-- formatLiscenceName personId =
+--   Data.fmap modLisc (match pIdLiscPrism personId) & \case
+--     Left personId' -> personId'
+--     Right lisc -> build pIdLiscPrism lisc
+--   where
+--     modLisc :: Liscence %1-> Liscence
+--     modLisc (Liscence nm x) = Liscence (nm ++ "\n") x
+-- @
 --
 module Control.Optics.Linear.Prism
   ( -- * Types

--- a/src/Control/Optics/Linear/Prism.hs
+++ b/src/Control/Optics/Linear/Prism.hs
@@ -1,4 +1,4 @@
--- | This module provides linear prisms
+-- | This module provides linear prisms.
 --
 -- A @Prism s t a b@ is equivalent to @(s \#-> Either a t, b \#-> t)@ for some
 -- /sum type/ @s@. In the non-polymorphic version, this is a @(s \#-> Either a
@@ -12,37 +12,37 @@
 -- {-# LANGUAGE LinearTypes #-}
 -- {-# LANGUAGE LambdaCase #-}
 -- {-# LANGUAGE FlexibleContexts #-}
+-- {-# LANGUAGE NoImplicitPrelude #-}
 -- {-# LANGUAGE GADTs #-}
 --
--- import Prelude hiding ((++))
--- import Data.List.Linear ((++))
--- import Prelude.Linear ((&))
+-- import Control.Optics.Linear.Internal
+-- import Prelude.Linear
 -- import qualified Data.Functor.Linear as Data
 --
 -- -- We can use a prism to do operations on one branch of a sum-type
--- formatLiscenceName :: PersonId %1-> PersonId
--- formatLiscenceName personId =
+-- -- (This is a bit of a toy example since we could use @over@ for this.)
+-- formatLicenceName :: PersonId %1-> PersonId
+-- formatLicenceName personId =
 --   Data.fmap modLisc (match pIdLiscPrism personId) & \case
 --     Left personId' -> personId'
 --     Right lisc -> build pIdLiscPrism lisc
 --   where
---     modLisc :: Liscence %1-> Liscence
---     modLisc (Liscence nm x) = Liscence (nm ++ "\n") x
+--     modLisc :: Licence %1-> Licence
+--     modLisc (Licence nm x) = Licence (nm ++ "\n") x
 --
 -- data PersonId where
---   IdLiscence :: Liscence %1-> PersonId
+--   IdLicence :: Licence %1-> PersonId
 --   SSN :: Int %1-> PersonId
 --   BirthCertif :: String %1-> PersonId
---   StateVoterId :: Int %1-> PersonId
---   CensusId :: Int %1-> PersonId
+--   -- And there could be many more constructors ...
 --
--- -- A Liscence is a name and number
--- data Liscence = Liscence String Int
+-- -- A Licence is a name and number
+-- data Licence = Licence String Int
 --
--- pIdLiscPrism :: Prism' PersonId Liscence
--- pIdLiscPrism = prism IdLiscence decompose where
---   decompose :: PersonId %1-> Either PersonId Liscence
---   decompose (IdLiscence l) = Right l
+-- pIdLiscPrism :: Prism' PersonId Licence
+-- pIdLiscPrism = prism IdLicence decompose where
+--   decompose :: PersonId %1-> Either PersonId Licence
+--   decompose (IdLicence l) = Right l
 --   decompose x = Left x
 -- @
 --

--- a/src/Control/Optics/Linear/Prism.hs
+++ b/src/Control/Optics/Linear/Prism.hs
@@ -1,3 +1,13 @@
+-- | This module provides linear prisms
+--
+-- A @Prism s t a b@ is equivalent to @(s \#-> Either a t, b \#-> t)@ for some
+-- /sum type/ @s@. In the non-polymorphic version, this is a
+-- @(s \#-> Either a s, a \#-> s)@ which represents taking one case of a sum type
+-- and a way to build the sum-type given that one case. A prism is a
+-- traversal focusing on one branch or case that a sum type could be.
+--
+-- = Example
+--
 module Control.Optics.Linear.Prism
   ( -- * Types
     Prism, Prism'

--- a/src/Control/Optics/Linear/Prism.hs
+++ b/src/Control/Optics/Linear/Prism.hs
@@ -19,6 +19,16 @@
 -- import Prelude.Linear ((&))
 -- import qualified Data.Functor.Linear as Data
 --
+-- -- We can use a prism to do operations on one branch of a sum-type
+-- formatLiscenceName :: PersonId %1-> PersonId
+-- formatLiscenceName personId =
+--   Data.fmap modLisc (match pIdLiscPrism personId) & \case
+--     Left personId' -> personId'
+--     Right lisc -> build pIdLiscPrism lisc
+--   where
+--     modLisc :: Liscence %1-> Liscence
+--     modLisc (Liscence nm x) = Liscence (nm ++ "\n") x
+--
 -- data PersonId where
 --   IdLiscence :: Liscence %1-> PersonId
 --   SSN :: Int %1-> PersonId
@@ -34,15 +44,6 @@
 --   decompose :: PersonId %1-> Either PersonId Liscence
 --   decompose (IdLiscence l) = Right l
 --   decompose x = Left x
---
--- formatLiscenceName :: PersonId %1-> PersonId
--- formatLiscenceName personId =
---   Data.fmap modLisc (match pIdLiscPrism personId) & \case
---     Left personId' -> personId'
---     Right lisc -> build pIdLiscPrism lisc
---   where
---     modLisc :: Liscence %1-> Liscence
---     modLisc (Liscence nm x) = Liscence (nm ++ "\n") x
 -- @
 --
 module Control.Optics.Linear.Prism

--- a/src/Control/Optics/Linear/Traversal.hs
+++ b/src/Control/Optics/Linear/Traversal.hs
@@ -1,25 +1,27 @@
-{-# LANGUAGE LinearTypes #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE GADTs #-}
--- | This module provides linear traversals
+-- | This module provides linear traversals.
 --
 --  Traversals provides a means of accessing several @a@s organized in some
 --  structural way in an @s@, and a means of changing them to @b@s to create a
 --  @t@. In very ordinary language, it's like walking or traversing the data
---  structure, going across cases and inside definitions. In more imaganitive
+--  structure, going across cases and inside definitions. In more imaginative
 --  language, it's like selecting some specific @a@s by looking at each
---  constructor of a data definition and recursing on each non-base type.
+--  constructor of a data definition and recursing on each non-basic type
+--  (where basic types are things like @Int@, @Bool@ or @Char@).
 --
 -- = Example
 --
 -- @
--- import Prelude (String, Int)
--- import Prelude.Linear ((&))
--- import qualified Control.Monad.Linear as Control
--- import Data.List.Linear (traverse', (++))
--- import Control.Monad.Linear ((<$>), (<*>))
+-- {-# LANGUAGE LinearTypes #-}
+-- {-# LANGUAGE NoImplicitPrelude #-}
+-- {-# LANGUAGE RankNTypes #-}
+-- {-# LANGUAGE GADTs #-}
 --
--- -- We can use a traversal to append a string only to the 
+-- import Control.Optics.Linear.Internal
+-- import qualified Control.Monad.Linear as Control
+-- import Control.Monad.Linear ((<$>), (<*>), pure)
+-- import Prelude.Linear
+--
+-- -- We can use a traversal to append a string only to the
 -- -- human names in a classroom struct
 -- appendToNames :: String -> Classroom %1-> Classroom
 -- appendToNames s = over classroomNamesTrav (\name -> name ++ s)
@@ -40,12 +42,13 @@
 -- classroomNamesTrav = traversal traverseClassStr where
 --   traverseClassStr :: forall f. Control.Applicative f =>
 --     (String %1-> f String) -> Classroom %1-> f Classroom
---   traverseClassStr onName classroom = classroom &
---     \(Classroom cname teachname x students texts) ->
---       ((\tn studs -> Classroom cname tn x studs texts) -- Giving type since
---         :: String %1-> [Student] %1-> Classroom) <$>   -- inference is imperfect
---       onName teachname <*>
---       traverse' (\(Student n x) -> (\n' -> Student n' x) <$> onName n) students
+--   traverseClassStr onName (Classroom cname teachname x students texts) =
+--     Classroom <$>
+--     pure cname <*>
+--     onName teachname <*>
+--     pure x <*>
+--     traverse' (\(Student s i) -> Student <$> onName s <*> pure i) students <*>
+--     pure texts
 -- @
 --
 module Control.Optics.Linear.Traversal

--- a/src/Control/Optics/Linear/Traversal.hs
+++ b/src/Control/Optics/Linear/Traversal.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE GADTs #-}
 -- | This module provides linear traversals
 --
 --  Traversals provides a means of accessing several @a@s organized in some
@@ -8,6 +11,42 @@
 --  constructor of a data definition and recursing on each non-base type.
 --
 -- = Example
+--
+-- @
+-- import Prelude (String, Int)
+-- import Prelude.Linear ((&))
+-- import qualified Control.Monad.Linear as Control
+-- import Data.List.Linear (traverse', (++))
+-- import Control.Monad.Linear ((<$>), (<*>))
+--
+-- -- We can use a traversal to append a string only to the 
+-- -- human names in a classroom struct
+-- appendToNames :: String -> Classroom %1-> Classroom
+-- appendToNames s = over classroomNamesTrav (\name -> name ++ s)
+--
+-- data Classroom where
+--   Classroom ::
+--     { className :: String
+--     , teacherName :: String
+--     , classNum :: Int
+--     , students :: [Student]
+--     , textbooks :: [String]
+--     } %1-> Classroom
+--
+-- -- A Student is a name and a student id number
+-- data Student = Student String Int
+--
+-- classroomNamesTrav :: Traversal' Classroom String
+-- classroomNamesTrav = traversal traverseClassStr where
+--   traverseClassStr :: forall f. Control.Applicative f =>
+--     (String %1-> f String) -> Classroom %1-> f Classroom
+--   traverseClassStr onName classroom = classroom &
+--     \(Classroom cname teachname x students texts) ->
+--       ((\tn studs -> Classroom cname tn x studs texts) -- Giving type since
+--         :: String %1-> [Student] %1-> Classroom) <$>   -- inference is imperfect
+--       onName teachname <*>
+--       traverse' (\(Student n x) -> (\n' -> Student n' x) <$> onName n) students
+-- @
 --
 module Control.Optics.Linear.Traversal
   ( -- * Types

--- a/src/Control/Optics/Linear/Traversal.hs
+++ b/src/Control/Optics/Linear/Traversal.hs
@@ -1,3 +1,14 @@
+-- | This module provides linear traversals
+--
+--  Traversals provides a means of accessing several @a@s organized in some
+--  structural way in an @s@, and a means of changing them to @b@s to create a
+--  @t@. In very ordinary language, it's like walking or traversing the data
+--  structure, going across cases and inside definitions. In more imaganitive
+--  language, it's like selecting some specific @a@s by looking at each
+--  constructor of a data definition and recursing on each non-base type.
+--
+-- = Example
+--
 module Control.Optics.Linear.Traversal
   ( -- * Types
     Traversal, Traversal'

--- a/src/Data/List/Linear.hs
+++ b/src/Data/List/Linear.hs
@@ -24,6 +24,7 @@ module Data.List.Linear
   , NonLinear.lookup
   , length
   , NonLinear.null
+  , traverse'
     -- * Extracting sublists
   , take
   , drop
@@ -91,6 +92,7 @@ import Data.Num.Linear
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import GHC.Stack
 import qualified Data.List as NonLinear
+import qualified Data.Functor.Linear as Data
 
 -- # Basic functions
 --------------------------------------------------
@@ -203,6 +205,10 @@ intercalate sep = Unsafe.toLinear (NonLinear.intercalate sep)
 -- | The transpose function transposes the rows and columns of its argument.
 transpose :: [[a]] %1-> [[a]]
 transpose = Unsafe.toLinear NonLinear.transpose
+
+traverse' :: Data.Applicative f => (a %1-> f b) -> [a] %1-> f [b]
+traverse' _ [] = Data.pure []
+traverse' f (a:as) = (:) <$> f a <*> traverse' f as
 
 -- # Folds
 --------------------------------------------------

--- a/src/Data/Profunctor/Kleisli/Linear.hs
+++ b/src/Data/Profunctor/Kleisli/Linear.hs
@@ -6,14 +6,37 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TupleSections #-}
 
--- | This module is intended to be imported qualified
-
+-- | This module provides (linear) Kleisli and CoKleisli arrows
+--
+-- This module is meant to be imported qualified, perhaps as below.
+--
+-- > import qualified Data.Productor.Kleisli as Linear
+--
+-- == What are Kleisli arrows?
+--
+-- The basic idea is that a Kleisli arrow is like a function arrow
+-- and @Kleisli m a b@ is similar to a function from @a@ to @b@. Basically:
+--
+-- > type Kleisili m a b = a #-> m b
+--
+-- == Why make this definition?
+--
+-- It let's us view @Kleisili m@ for a certain @m@ as a certain kind of
+-- function arrow, give it instances, abstract over it an so on.
+--
+-- For instance, if @m@ is any functor, @Kleisli m@ is a @Profunctor@.
+--
+-- == CoKleisli
+--
+-- A CoKleisli arrow is just one that represents a computation from
+-- a @m a@ to an @a@ via a linear arrow. (It's a Co-something because it
+-- reverses the order of the function arrows in the something.)
+--
 module Data.Profunctor.Kleisli.Linear
   ( Kleisli(..)
   , CoKleisli(..)
   )
   where
-
 
 import Data.Profunctor.Linear
 import Data.Void

--- a/src/Data/Profunctor/Kleisli/Linear.hs
+++ b/src/Data/Profunctor/Kleisli/Linear.hs
@@ -10,18 +10,18 @@
 --
 -- This module is meant to be imported qualified, perhaps as below.
 --
--- > import qualified Data.Productor.Kleisli as Linear
+-- > import qualified Data.Profunctor.Kleisli as Linear
 --
 -- == What are Kleisli arrows?
 --
 -- The basic idea is that a Kleisli arrow is like a function arrow
 -- and @Kleisli m a b@ is similar to a function from @a@ to @b@. Basically:
 --
--- > type Kleisili m a b = a #-> m b
+-- > type Kleisli m a b = a #-> m b
 --
 -- == Why make this definition?
 --
--- It let's us view @Kleisili m@ for a certain @m@ as a certain kind of
+-- It let's us view @Kleisli m@ for a certain @m@ as a certain kind of
 -- function arrow, give it instances, abstract over it an so on.
 --
 -- For instance, if @m@ is any functor, @Kleisli m@ is a @Profunctor@.

--- a/src/Data/Profunctor/Linear.hs
+++ b/src/Data/Profunctor/Linear.hs
@@ -34,8 +34,10 @@ module Data.Profunctor.Linear
   ) where
 
 import qualified Control.Monad.Linear as Control
+import Control.Monad.Linear.Internal (runIdentity')
 import Data.Bifunctor.Linear hiding (first, second)
 import qualified Data.Bifunctor as Prelude
+import Data.Functor.Identity
 import Prelude.Linear
 import Data.Kind (Type)
 import Data.Void
@@ -135,12 +137,9 @@ class (Strong (,) () arr, Strong Either Void arr) => Wandering arr where
 -- Instances --
 ---------------
 
-<<<<<<< ca1ae741a3e2fb9718edf13f32c45f82e397623c
-newtype LinearArrow a b = LA (a %1-> b)
-=======
 -- | This newtype is needed to implement 'Profunctor' instances of @#->@.
-newtype LinearArrow a b = LA (a #-> b)
->>>>>>> Profunctor and Kleisli documentation
+newtype LinearArrow a b = LA (a %1-> b)
+
 -- | Temporary deconstructor since inference doesn't get it right
 getLA :: LinearArrow a b %1-> a %1-> b
 getLA (LA f) = f
@@ -155,6 +154,9 @@ instance Strong (,) () LinearArrow where
 instance Strong Either Void LinearArrow where
   first  (LA f) = LA $ either (Left . f) Right
   second (LA g) = LA $ either Left (Right . g)
+
+instance Wandering LinearArrow where
+  wander f (LA a_to_b) = LA $ \s -> runIdentity' $ f (Identity . a_to_b) s
 
 instance Monoidal (,) () LinearArrow where
   LA f *** LA g = LA $ \(a,x) -> (f a, g x)

--- a/src/Data/Profunctor/Linear.hs
+++ b/src/Data/Profunctor/Linear.hs
@@ -9,6 +9,20 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeOperators #-}
 
+-- | This module provides profunctor classes and instances
+--
+-- Please import this module qualified.
+--
+-- This module is heavily connected to and motivated by linear optics.
+-- Please see @Control.Optics.Linear@ and other optics modules
+-- for motivations for the definitions provided here.
+--
+-- == Connections to Linear Optics
+--
+-- * @Strong@ and @Wandering@ are classes drawn from
+-- [this paper](https://www.cs.ox.ac.uk/jeremy.gibbons/publications/proyo.pdf)
+-- * 'Exchange' and 'Market' are ways of encoding isomorphisms and prisms
+--
 module Data.Profunctor.Linear
   ( Profunctor(..)
   , Monoidal(..)
@@ -28,8 +42,21 @@ import Data.Void
 import qualified Prelude
 import Control.Arrow (Kleisli(..))
 
--- TODO: write laws
 
+-- | A Profunctor can be thought of as a computation that involves taking
+-- @a@(s) as input and returning @b@(s). These computations compose with
+-- (linear) functions. Profunctors generalize the function arrow @->@.
+--
+-- Hence, think of a value of type @x `arr` y@ for profunctor @arr@ to be
+-- something like a function from @x@ to @y@.
+--
+-- Laws:
+--
+-- > lmap id = id
+-- > lmap (f . g) = lmap f . lmap g
+-- > rmap id = id
+-- > rmap (f . g) = rmap f . rmap g
+--
 class Profunctor (arr :: Type -> Type -> Type) where
   {-# MINIMAL dimap | lmap, rmap #-}
 
@@ -45,10 +72,30 @@ class Profunctor (arr :: Type -> Type -> Type) where
   rmap = dimap id
   {-# INLINE rmap #-}
 
+-- | A @(Monoidal m u arr)@ is a profunctor @arr@ that can be sequenced
+-- with the bifunctor @m@. In rough terms, you can combine two function-like
+-- things to one function-like thing that holds both input and output types
+-- with the bifunctor @m@.
 class (SymmetricMonoidal m u, Profunctor arr) => Monoidal m u arr where
   (***) :: a `arr` b -> x `arr` y -> (a `m` x) `arr` (b `m` y)
   unit :: u `arr` u
 
+-- | A @(Strong m u arr)@ instance means that the function-like thing
+-- of type @a `arr` b@ can be extended to pass along a value of type @c@
+-- as a constant via the bifunctor of type @m@.
+--
+-- This typeclass is used primarily to generalize common patterns
+-- and instances that are defined when defining optics. The two uses
+-- below are used in defining lenses and prisms respectively in
+-- "Control.Optics.Linear.Internal":
+--
+-- If @m@ is the tuple
+-- type constructor @(,)@ then we can create a function-like thing
+-- of type @(a,c) `arr` (b,c)@ passing along @c@ as a constant.
+--
+-- If @m@ is @Either@ then we can create a function-like thing of type
+-- @Either a c `arr` Either b c@ that either does the original function
+-- or behaves like the constant function.
 class (SymmetricMonoidal m u, Profunctor arr) => Strong m u arr where
   {-# MINIMAL first | second #-}
 
@@ -60,6 +107,24 @@ class (SymmetricMonoidal m u, Profunctor arr) => Strong m u arr where
   second arr = dimap swap swap (first arr)
   {-# INLINE second #-}
 
+-- | A @Wandering arr@ instance means that there is a @wander@ function
+-- which is the traversable generalization of the classic lens function:
+--
+-- > forall f. Functor f => (a -> f b) -> (s -> f t)
+--
+-- in our notation:
+--
+-- > forall arr. (HasKleisliFunctor arr) => (a `arr` b) -> (s `arr` t)
+--
+-- @wander@ specializes the @Functor@ constraint to a control applicative:
+--
+-- > forall f. Applicative f => (a -> f b) -> (s -> f t)
+-- > forall arr. (HasKleisliApplicative arr) => (a `arr` b) -> (s `arr` t)
+--
+-- where @HasKleisliFunctor@ or @HasKleisliApplicative@ are some constraints
+-- which allow for the @arr@ to be @Kleisli f@ for control functors
+-- or applicatives @f@.
+--
 class (Strong (,) () arr, Strong Either Void arr) => Wandering arr where
   -- | Equivalently but less efficient in general:
   --
@@ -70,7 +135,12 @@ class (Strong (,) () arr, Strong Either Void arr) => Wandering arr where
 -- Instances --
 ---------------
 
+<<<<<<< ca1ae741a3e2fb9718edf13f32c45f82e397623c
 newtype LinearArrow a b = LA (a %1-> b)
+=======
+-- | This newtype is needed to implement 'Profunctor' instances of @#->@.
+newtype LinearArrow a b = LA (a #-> b)
+>>>>>>> Profunctor and Kleisli documentation
 -- | Temporary deconstructor since inference doesn't get it right
 getLA :: LinearArrow a b %1-> a %1-> b
 getLA (LA f) = f
@@ -108,6 +178,8 @@ instance Monoidal Either Void (->) where
   f *** g = Prelude.bimap f g
   unit = \case {}
 
+-- | An exchange is a pair of translation functions that encode an
+-- isomorphism; an @Exchange a b s t@ is equivalent to a @Iso a b s t@.
 data Exchange a b s t = Exchange (s %1-> a) (b %1-> t)
 instance Profunctor (Exchange a b) where
   dimap f g (Exchange p q) = Exchange (p . f) (g . q)
@@ -134,6 +206,8 @@ instance Prelude.Functor f => Monoidal Either Void (Kleisli f) where
     Right b -> Right Prelude.<$> g b
   unit = Kleisli $ \case {}
 
+-- | A market is a pair of constructor and deconstructor functions that encode
+-- a prism; a @Market a b s t@ is equivalent to a @Prism a b s t@.
 data Market a b s t = Market (b %1-> t) (s %1-> Either t a)
 runMarket :: Market a b s t %1-> (b %1-> t, s %1-> Either t a)
 runMarket (Market f g) = (f, g)

--- a/src/Data/Profunctor/Linear.hs
+++ b/src/Data/Profunctor/Linear.hs
@@ -9,13 +9,13 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeOperators #-}
 
--- | This module provides profunctor classes and instances
+-- | This module provides profunctor classes and instances.
 --
 -- Please import this module qualified.
 --
--- This module is heavily connected to and motivated by linear optics.
--- Please see @Control.Optics.Linear@ and other optics modules
--- for motivations for the definitions provided here.
+-- Some of the definitions in this module are heavily connected to and
+-- motivated by linear optics. Please see @Control.Optics.Linear@ and other
+-- optics modules for motivations for the definitions provided here.
 --
 -- == Connections to Linear Optics
 --


### PR DESCRIPTION
This replaces #108 and documents optics and related `Data.Profunctor.Linear` and `Data.Profunctor.Kleisli.Linear` modules.

I had to add a `traverse'` specialization of traverse in `Data.List.Linear` and a simple trivial instance of `Wandering LinearArrow`. I hope these are trivial and non-controversial.

I made the requested changes from #108 and tried to keep everything super minimal and practical.