### PR TITLE
Made toLinear parametric in input functions multiplicity

### DIFF
--- a/src/Unsafe/Linear.hs
+++ b/src/Unsafe/Linear.hs
@@ -35,17 +35,21 @@ coerce = NonLinear.unsafeCoerce NonLinear.unsafeCoerce
 -- | Converts an unrestricted function into a linear function
 toLinear
   :: forall (r1 :: RuntimeRep) (r2 :: RuntimeRep)
-     (a :: TYPE r1) (b :: TYPE r2).
-     (a -> b) %1-> (a %1-> b)
+     (a :: TYPE r1) (b :: TYPE r2) p.
+     (a %p-> b) %1-> (a %1-> b)
 toLinear = coerce
 
 -- | Like 'toLinear' but for two-argument functions
 toLinear2
   :: forall (r1 :: RuntimeRep) (r2 :: RuntimeRep) (r3 :: RuntimeRep)
-     (a :: TYPE r1) (b :: TYPE r2) (c :: TYPE r3).
-     (a -> b -> c) %1-> (a %1-> b %1-> c)
+     (a :: TYPE r1) (b :: TYPE r2) (c :: TYPE r3) p q.
+     (a %p-> b %q-> c) %1-> (a %1-> b %1-> c)
 toLinear2 = coerce
 
 -- | Like 'toLinear' but for three-argument functions
-toLinear3 :: (a -> b -> c -> d) %1-> (a %1-> b %1-> c %1-> d)
+toLinear3
+  :: forall (r1 :: RuntimeRep) (r2 :: RuntimeRep)
+     (r3 :: RuntimeRep) (r4 :: RuntimeRep)
+     (a :: TYPE r1) (b :: TYPE r2) (c :: TYPE r3) (d :: TYPE r4) p q r.
+     (a %p-> b %q-> c %r-> d) %1-> (a %1-> b %1-> c %1-> d)
 toLinear3 = coerce


### PR DESCRIPTION
Sometimes it's annoying to use `Unsafe.toLinear` or variants if a function is linear on some later argument and currying is tricky. This just makes that easier:

Before:
```haskell
toLinear2 :: (a -> b -> c) %1-> (a %1-> b %1-> c)
```

After:
```haskell
toLinear2 :: (a %p-> b %q-> c) %1-> (a %1-> b %1-> c)
```