### PR TITLE
Renamed Data.HashMap.Linear to Data.HashMap.Mutable.Linear

### DIFF
--- a/examples/Simple/TopSort.hs
+++ b/examples/Simple/TopSort.hs
@@ -11,8 +11,8 @@ module Simple.TopSort where
 import qualified Prelude.Linear as Linear
 import Prelude.Linear ((&))
 import Data.Unrestricted.Linear
-import qualified Data.HashMap.Linear as HMap
-import Data.HashMap.Linear (HashMap)
+import qualified Data.HashMap.Mutable.Linear as HMap
+import Data.HashMap.Mutable.Linear (HashMap)
 import Data.Bifunctor.Linear (second)
 import Data.Maybe.Linear (catMaybes)
 import qualified Data.Functor.Linear as Data

--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -39,7 +39,7 @@ library
     Data.Functor.Linear
     Data.Functor.Linear.Internal
     Data.Functor.Linear.Internal.Traversable
-    Data.HashMap.Linear
+    Data.HashMap.Mutable.Linear
     Data.List.Linear
     Data.Maybe.Linear
     Data.Monoid.Linear

--- a/src/Data/HashMap/Mutable/Linear.hs
+++ b/src/Data/HashMap/Mutable/Linear.hs
@@ -18,7 +18,7 @@
 --
 -- It is implemented with Robin Hood hashing which has amortized
 -- constant time lookups and updates.
-module Data.HashMap.Linear
+module Data.HashMap.Mutable.Linear
   ( -- * A mutable hashmap
     HashMap,
     Keyed,

--- a/src/Data/Set/Mutable/Linear.hs
+++ b/src/Data/Set/Mutable/Linear.hs
@@ -31,7 +31,7 @@ module Data.Set.Mutable.Linear
   )
 where
 
-import qualified Data.HashMap.Linear as Linear
+import qualified Data.HashMap.Mutable.Linear as Linear
 import qualified Prelude.Linear as Linear hiding (insert)
 import Prelude (Int, Bool)
 import qualified Prelude

--- a/test/Test/Data/Mutable/HashMap.hs
+++ b/test/Test/Data/Mutable/HashMap.hs
@@ -13,7 +13,7 @@ module Test.Data.Mutable.HashMap
 where
 
 import qualified Data.Functor.Linear as Linear
-import qualified Data.HashMap.Linear as HashMap
+import qualified Data.HashMap.Mutable.Linear as HashMap
 import Data.Unrestricted.Linear
 import Data.Function ((&))
 import Hedgehog


### PR DESCRIPTION
Renamed to be consistent with `Data.Set.Mutable.Linear` and the layout of the tests in `/tests` and the overall naming convention used throughout.