### PR TITLE
Created a Data.Semigroup.Linear module

### DIFF
--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -47,6 +47,7 @@ library
     Data.Ord.Linear
     Data.Profunctor.Kleisli.Linear
     Data.Profunctor.Linear
+    Data.Semigroup.Linear
     Data.Set.Mutable.Linear
     Data.Tuple.Linear
     Data.Unrestricted.Linear

--- a/src/Data/Monoid/Linear.hs
+++ b/src/Data/Monoid/Linear.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -12,27 +13,18 @@
 -- [post](https://www.schoolofhaskell.com/user/mgsloan/monoids-tour).
 
 module Data.Monoid.Linear
-  ( -- * Monoids and related classes
-    Semigroup(..)
-  , Monoid(..)
+  ( -- * Monoid operations
+    Monoid(..)
   , mconcat
-  -- * Endo
-  , Endo(..), appEndo
-  , NonLinear(..)
-  , module Data.Semigroup
+  -- * Semigroup operations
+  , module Data.Semigroup.Linear
   )
   where
 
 import Prelude.Linear.Internal
-import Data.Semigroup hiding (Semigroup(..), Endo(..))
-import qualified Data.Semigroup as Prelude
+import Data.Semigroup.Linear
 import GHC.Types hiding (Any)
 import qualified Prelude
-
--- | A linear semigroup @a@ is a type with an associative binary operation @<>@
--- that linearly consumes two @a@s.
-class Prelude.Semigroup a => Semigroup a where
-  (<>) :: a %1-> a %1-> a
 
 -- | A linear monoid is a linear semigroup with an identity on the binary
 -- operation.
@@ -53,66 +45,13 @@ mconcat (xs' :: [a]) = go mempty xs'
 -- Instances --
 ---------------
 
-instance Semigroup () where
-  () <> () = ()
-
--- | An @Endo a@ is just a linear function of type @a %1-> a@.
--- This has a classic monoid definition with 'id' and '(.)'.
-newtype Endo a = Endo (a %1-> a)
-  deriving (Prelude.Semigroup) via NonLinear (Endo a)
-
--- TODO: have this as a newtype deconstructor once the right type can be
--- correctly inferred
--- | A linear application of an 'Endo'.
-appEndo :: Endo a %1-> a %1-> a
-appEndo (Endo f) = f
-
-instance Semigroup (Endo a) where
-  Endo f <> Endo g = Endo (f . g)
 instance Prelude.Monoid (Endo a) where
   mempty = Endo id
 instance Monoid (Endo a)
 
-instance (Semigroup a, Semigroup b) => Semigroup (a,b) where
-  (a,x) <> (b,y) = (a <> b, x <> y)
 instance (Monoid a, Monoid b) => Monoid (a,b)
 
-instance Semigroup a => Semigroup (Dual a) where
-  Dual x <> Dual y = Dual (y <> x)
 instance Monoid a => Monoid (Dual a)
-
-instance Semigroup All where
-  All False <> All False = All False
-  All False <> All True = All False
-  All True  <> All False = All False
-  All True  <> All True = All True
-instance Semigroup Any where
-  Any False <> Any False = Any False
-  Any False <> Any True = Any True
-  Any True  <> Any False = Any True
-  Any True  <> Any True = Any True
-
--- | DerivingVia combinator for Prelude.Semigroup given (linear) Semigroup.
--- For linear monoids, you should supply a Prelude.Monoid instance and either
--- declare an empty Monoid instance, or use DeriveAnyClass. For example:
---
--- > newtype Endo a = Endo (a %1-> a)
--- >   deriving (Prelude.Semigroup) via NonLinear (Endo a)
-newtype NonLinear a = NonLinear a
-
-instance Semigroup a => Prelude.Semigroup (NonLinear a) where
-  NonLinear a <> NonLinear b = NonLinear (a <> b)
-
-instance Semigroup Ordering where
-    LT <> LT = LT
-    LT <> GT = LT
-    LT <> EQ = LT
-    EQ <> y = y
-    GT <> LT = GT
-    GT <> GT = GT
-    GT <> EQ = GT
-    -- We can not use `lseq` above because of an import loop.
-    -- So it's easier to just expand the cases here.
 
 instance Monoid Ordering where
     mempty = EQ

--- a/src/Data/Semigroup/Linear.hs
+++ b/src/Data/Semigroup/Linear.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+-- | This module provides a linear version of 'Semigroup'.
+
+module Data.Semigroup.Linear
+  ( -- * Semigroup
+    Semigroup(..)
+    -- * Endo
+  , Endo(..), appEndo
+  , NonLinear(..)
+  , module Data.Semigroup
+  )
+  where
+
+import Prelude.Linear.Internal
+import Data.Semigroup hiding (Semigroup(..), Endo(..))
+import qualified Data.Semigroup as Prelude
+import GHC.Types hiding (Any)
+
+-- | A linear semigroup @a@ is a type with an associative binary operation @<>@
+-- that linearly consumes two @a@s.
+class Prelude.Semigroup a => Semigroup a where
+  (<>) :: a %1-> a %1-> a
+
+---------------
+-- Instances --
+---------------
+
+instance Semigroup () where
+  () <> () = ()
+
+-- | An @Endo a@ is just a linear function of type @a %1-> a@.
+-- This has a classic monoid definition with 'id' and '(.)'.
+newtype Endo a = Endo (a %1-> a)
+  deriving (Prelude.Semigroup) via NonLinear (Endo a)
+
+-- TODO: have this as a newtype deconstructor once the right type can be
+-- correctly inferred
+-- | A linear application of an 'Endo'.
+appEndo :: Endo a %1-> a %1-> a
+appEndo (Endo f) = f
+
+instance Semigroup (Endo a) where
+  Endo f <> Endo g = Endo (f . g)
+
+instance (Semigroup a, Semigroup b) => Semigroup (a,b) where
+  (a,x) <> (b,y) = (a <> b, x <> y)
+
+instance Semigroup a => Semigroup (Dual a) where
+  Dual x <> Dual y = Dual (y <> x)
+
+instance Semigroup All where
+  All False <> All False = All False
+  All False <> All True = All False
+  All True  <> All False = All False
+  All True  <> All True = All True
+instance Semigroup Any where
+  Any False <> Any False = Any False
+  Any False <> Any True = Any True
+  Any True  <> Any False = Any True
+  Any True  <> Any True = Any True
+
+-- | DerivingVia combinator for Prelude.Semigroup given (linear) Semigroup.
+-- For linear monoids, you should supply a Prelude.Monoid instance and either
+-- declare an empty Monoid instance, or use DeriveAnyClass. For example:
+--
+-- > newtype Endo a = Endo (a %1-> a)
+-- >   deriving (Prelude.Semigroup) via NonLinear (Endo a)
+newtype NonLinear a = NonLinear a
+
+instance Semigroup a => Prelude.Semigroup (NonLinear a) where
+  NonLinear a <> NonLinear b = NonLinear (a <> b)
+
+instance Semigroup Ordering where
+    LT <> LT = LT
+    LT <> GT = LT
+    LT <> EQ = LT
+    EQ <> y = y
+    GT <> LT = GT
+    GT <> GT = GT
+    GT <> EQ = GT
+    -- We can not use `lseq` above because of an import loop.
+    -- So it's easier to just expand the cases here.


### PR DESCRIPTION
I put the `Data.Semigroup` stuff into a separate module. I had to allow orphan instances since `Endo` would be defined in the semigroup module. I hope that's not a dealbreaker.