### PR TITLE
Testing set intersect and union

### DIFF
--- a/test/Test/Data/Mutable/Set.hs
+++ b/test/Test/Data/Mutable/Set.hs
@@ -7,8 +7,8 @@
 --
 -- = How we designed the tests
 --
--- We use hedgehog to test properties that are axioms that fully define the
--- behavior of sets. There is at least one axiom per each combination of
+-- We use hedgehog to test properties that are axioms that funtionally define
+-- the behavior of sets. There is at least one axiom per each combination of
 -- accessor and constructor/mutator. So for the accessor @f@, and
 -- constructor/mutator @g@, we have one axiom of the form @f (g (...)) = ...@.
 --
@@ -20,10 +20,22 @@
 -- the union as sets, converting back with @Set.toList@ and then sorting
 -- the output list.
 --
--- To have such a test replace an axiom, however, we need to have "homomorphisms"
--- for each accessor. E.g., for all x and l, @member x (fromList l) = elem x l@.
+-- To have such a test replace an axiom, however, we need to have
+-- "homomorphisms" for each accessor or modifier. In general, we want to be
+-- able to say for any modifier or accessor @f@,
 --
--- So now, for instance, we can prove
+-- >  toList (f set) = f' (toList set)
+--
+-- where @f'@ is some reference implementation we know. The key idea is a kind
+-- of "homomorphism" between @f@ and a reference implementation @f'@ that
+-- holds across the conversion function @toList@.
+--
+-- Note: We could also formulate this in terms of @fromList@.
+--
+-- For example, we'd want to have @member x (fromList l) = elem x l@
+-- for any @x@ and @l@.
+--
+-- With this we can prove
 --
 -- >  member x (intersect set1 set2) = member x set1 && member x set2
 --
@@ -77,14 +89,14 @@ group =
   , testProperty "∀ s, x \\in s. size (delete s x) = size s - 1" sizeDelete1
   , testProperty "∀ s, x \\notin s. size (delete s x) = size s" sizeDelete2
   -- Homomorphism tests
-  , testProperty "sort . nub = sort . toList . fromList" toListFromList
-  , testProperty "member x (fromList l) = elem x l" memberHomomorphism
-  , testProperty "size . fromList = length . nub" sizeHomomorphism
+  , testProperty "sort . nub = sort . toList" toListFromList
+  , testProperty "member x s = elem x (toList s)" memberHomomorphism
+  , testProperty "size = length . toList" sizeHomomorphism
   , testProperty
-      "sort . nub (l ∪ m) = sort . toList (fromList l ∪ fromList m)"
+      "sort . nub ((toList s) ∪ (toList s')) = sort . toList (s ∪ s')"
       unionHomomorphism
   , testProperty
-      "sort . nub (l ∩ m) = sort . toList (fromList l ∩ fromList m)"
+      "sort . nub ((toList s) ∩ (toList s')) = sort . toList (s ∩ s')"
       intersectHomomorphism
   ]
 

--- a/test/Test/Data/Mutable/Set.hs
+++ b/test/Test/Data/Mutable/Set.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE LinearTypes #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
-
 -- |
 -- Tests for mutable sets.
 
@@ -12,8 +11,10 @@ module Test.Data.Mutable.Set
 where
 
 import qualified Data.Set.Mutable.Linear as Set
+import Data.Set.Mutable.Linear (Set)
 import Data.Unrestricted.Linear
 import Hedgehog
+import qualified Data.List as List
 import qualified Data.Functor.Linear as Data
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
@@ -23,6 +24,27 @@ import Test.Tasty.Hedgehog (testProperty)
 
 -- # Exported Tests
 --------------------------------------------------------------------------------
+
+{- How we designed the tests.
+
+We use hedgehog to test properties that are axioms that fully define the
+behavior of sets. There is typically one axiom per each combination of
+accessor and constructor/mutator. So one defintion for accessor @f@, and
+constructor/mutator @g@, we have one axiom of the form @f (g (...)) = ...@.
+
+If however, this is cumbersome, we can often just test against an existing
+implementation. This is like a homomorphism test (but not an exact
+homomorphism). For unions, this is like saying if we have two lists A and B,
+and we take their union as lists, then sort and nub (remove duplicates)
+this is the same as using @Set.fromList@ to make them into sets, taking
+the union as sets, converting back with @Set.toList@ and then sorting
+the output list. Note that this can replace an axiom (though seeing this is
+not trivial).
+
+See https://softwarefoundations.cis.upenn.edu/vfa-current/ADT.html
+for more about how ADT axioms work.
+-}
+
 
 mutSetTests :: TestTree
 mutSetTests = testGroup "Mutable set tests" group
@@ -38,6 +60,13 @@ group =
   , testProperty "∀ s, x \\notin s. size (insert s x) = size s + 1" sizeInsert2
   , testProperty "∀ s, x \\in s. size (delete s x) = size s - 1" sizeDelete1
   , testProperty "∀ s, x \\notin s. size (delete s x) = size s" sizeDelete2
+  , testProperty "sort . nub = sort . toList . fromList" toListFromList
+  , testProperty
+      "sort . nub (l ∪ m) = sort . toList (fromList l ∪ fromList m)"
+      unionHomomorphism
+  , testProperty
+      "sort . nub (l ∩ m) = sort . toList (fromList l ∩ fromList m)"
+      intersectHomomorphism
   ]
 
 -- # Internal Library
@@ -46,8 +75,8 @@ group =
 type SetTester = Set.Set Int %1-> Ur (TestT IO ())
 
 -- | A random list
-nonemptyList :: Gen [Int]
-nonemptyList = do
+list :: Gen [Int]
+list = do
   size <- Gen.int $ Range.linearFrom 0 0 1000
   let size' = Range.singleton size
   Gen.list size' $ Gen.int $ Range.linearFrom 0 (-100) 100
@@ -72,7 +101,7 @@ getFst (a, b) = lseq b a
 memberInsert1 :: Property
 memberInsert1 = property $ do
   val <- forAll value
-  l <- forAll nonemptyList
+  l <- forAll list
   let tester = memberInsert1Test val
   test $ unur Linear.$ Set.fromList l tester
 
@@ -86,7 +115,7 @@ memberInsert2 :: Property
 memberInsert2 = property $ do
   val1 <- forAll value
   val2 <- forAll $ Gen.filter (/= val1) value
-  l <- forAll nonemptyList
+  l <- forAll list
   let tester = memberInsert2Test val1 val2
   test $ unur Linear.$ Set.fromList l tester
 
@@ -102,7 +131,7 @@ memberInsert2Test val1 val2 set = fromRead (Set.member val2 set)
 memberDelete1 :: Property
 memberDelete1 = property $ do
   val <- forAll value
-  l <- forAll nonemptyList
+  l <- forAll list
   let tester = memberDelete1Test val
   test $ unur Linear.$ Set.fromList l tester
 
@@ -116,7 +145,7 @@ memberDelete2 :: Property
 memberDelete2 = property $ do
   val1 <- forAll value
   val2 <- forAll $ Gen.filter (/= val1) value
-  l <- forAll nonemptyList
+  l <- forAll list
   let tester = memberDelete2Test val1 val2
   test $ unur Linear.$ Set.fromList l tester
 
@@ -131,7 +160,7 @@ memberDelete2Test val1 val2 set = fromRead (Set.member val2 set)
 
 sizeInsert1 :: Property
 sizeInsert1 = property $ do
-  l <- forAll nonemptyList
+  l <- forAll list
   val <- forAll $ Gen.filter (`elem` l) value
   let tester = sizeInsert1Test val
   test $ unur Linear.$ Set.fromList l tester
@@ -147,7 +176,7 @@ sizeInsert1Test val set = fromRead (Set.size set)
 
 sizeInsert2 :: Property
 sizeInsert2 = property $ do
-  l <- forAll nonemptyList
+  l <- forAll list
   val <- forAll $ Gen.filter (not . (`elem` l)) value
   let tester = sizeInsert2Test val
   test $ unur Linear.$ Set.fromList l tester
@@ -163,7 +192,7 @@ sizeInsert2Test val set = fromRead (Set.size set)
 
 sizeDelete1 :: Property
 sizeDelete1 = property $ do
-  l <- forAll nonemptyList
+  l <- forAll list
   val <- forAll $ Gen.filter (`elem` l) value
   let tester = sizeDelete1Test val
   test $ unur Linear.$ Set.fromList l tester
@@ -179,7 +208,7 @@ sizeDelete1Test val set = fromRead (Set.size set)
 
 sizeDelete2 :: Property
 sizeDelete2 = property $ do
-  l <- forAll nonemptyList
+  l <- forAll list
   val <- forAll $ Gen.filter (not . (`elem` l)) value
   let tester = sizeDelete2Test val
   test $ unur Linear.$ Set.fromList l tester
@@ -192,3 +221,38 @@ sizeDelete2Test val set = fromRead (Set.size set)
       testEqual
         sizeOriginal
         (getFst Linear.$ (Set.size (Set.delete val set)))
+
+toListFromList :: Property
+toListFromList = property $ do
+  l <- forAll list
+  let outsideSet = List.nub . List.sort $ l
+  List.sort (unur (Set.fromList l Set.toList)) === outsideSet
+
+unionHomomorphism :: Property
+unionHomomorphism = property $ do
+  l <- forAll list
+  l' <- forAll list
+  let listUnion = List.nub $ List.sort $ List.union l l'
+  let setUnion = List.sort $ unur (fromLists l l' doUnion)
+  setUnion === listUnion
+  where
+    fromLists :: [Int] -> [Int] -> (Set Int %1-> Set Int %1-> Ur b) %1-> Ur b
+    fromLists l l' f = Set.fromList l (\s -> Set.fromList l' (\s' -> f s s'))
+
+    doUnion :: Set Int %1-> Set Int %1-> Ur [Int]
+    doUnion s s' = Set.toList (Set.union s s')
+
+intersectHomomorphism :: Property
+intersectHomomorphism = property $ do
+  l <- forAll list
+  l' <- forAll list
+  let listIntersect = List.nub $ List.sort $ List.intersect l l'
+  let setIntersect = List.sort $ unur (fromLists l l' doIntersect)
+  setIntersect === listIntersect
+  where
+    fromLists :: [Int] -> [Int] -> (Set Int %1-> Set Int %1-> Ur b) %1-> Ur b
+    fromLists l l' f = Set.fromList l (\s -> Set.fromList l' (\s' -> f s s'))
+
+    doIntersect :: Set Int %1-> Set Int %1-> Ur [Int]
+    doIntersect s s' = Set.toList (Set.intersection s s')
+


### PR DESCRIPTION
Working towards closing #93 I've added tests for intersections and unions for sets.

[Remark: We should probably add tests for `empty` and maybe I should just do that in the PR but it looks obviously correct to me. (Saying this, I feel like I'm going to end up having to add it.)]

Issue #93 explains that the mutable data test suite is meant to provide properties which serve as axioms that define the behavior of how to interact with the data structure. That is, if all the properties hold, the behavior of the data structure is mathematically specified. For each accessor function `f` and each modifier or constructor `g` we have one axiom to specify the behavior of `f (g (...)) = ...`. See for instance [this](https://softwarefoundations.cis.upenn.edu/vfa-current/ADT.html) link. 

In this PR, since we added two modifiers (intersection and union) and have two basic accessors (member and size), we need 2 X 2 = 4 axioms, which are precisely the 4 tests I've added.