### PR TITLE
Fix builds on MacOS

### DIFF
--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,9 +1,10 @@
 let
-  # https://github.com/tweag/nixpkgs/tree/update-ghchead-20201001
-  rev = "60a06c5a2ec88392c1eb5e252367dde4e0ead16c";
-  sha256 = "0952kxb7zlw81vwk72dm4cxs01ygqgbxsy0ibqsj7khr7xp115jh";
+  # https://github.com/tweag/nixpkgs/tree/ud/update-ghchead-20201001
+  rev = "78d9696f5d1524fcf2fd947f012ffc08fcba4dd1";
+  sha256 = "146rahqm2rkbz2hl689rqc04wcfdrghbjzxzynbzsc3xi5if59bh";
 in
 import (fetchTarball {
   inherit sha256;
-  url = "https://github.com/utdemir/nixpkgs/archive/${rev}.tar.gz";
+  url = "https://github.com/tweag/nixpkgs/archive/${rev}.tar.gz";
 })
+

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,6 @@
-with import ./nixpkgs.nix {};
+{ system ? builtins.currentSystem }:
+
+with import ./nixpkgs.nix { inherit system; };
 
 mkShell {
   # Set UTF-8 local so that run-tests can parse GHC's unicode output.


### PR DESCRIPTION
Closes https://github.com/tweag/linear-base/issues/268.

I applied the fix mentioned at #268 to our fork of nixpkgs, rebased it to the current nixpkgs master (appearently it contains another fix for darwin builds), and pushed the branch to tweag's nixpkgs instead of my own. See the last two commits on https://github.com/tweag/nixpkgs/tree/78d9696f5d1524fcf2fd947f012ffc08fcba4dd1 for the nixpkgs changes.

I also added a parameter to `shell.nix` which allows passing `system` as a parameter (so I could test this change on a LInux machine with a darwin build machine.).

I tested that the `shell.nix` builds on both Linux and MacOS Mojave