### PR TITLE
Instances module for Data.V.Linear

### DIFF
--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -65,6 +65,7 @@ library
     Data.Unrestricted.Linear
     Data.V.Linear
     Data.V.Linear.Internal.V
+    Data.V.Linear.Internal.Instances
     Data.Vector.Mutable.Linear
     Debug.Trace.Linear
     Foreign.Marshal.Pure

--- a/src/Data/V/Linear.hs
+++ b/src/Data/V/Linear.hs
@@ -1,10 +1,5 @@
-{-# OPTIONS -Wno-orphans #-}
-{-# LANGUAGE FlexibleInstances #-}
+{-# OPTIONS_GHC -Wno-dodgy-exports #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
-
 -- | This module defines vectors of known length which can hold linear values.
 --
 -- Having a known length matters with linear types, because many common vector
@@ -46,16 +41,11 @@ module Data.V.Linear
   , iterate
   -- * Type-level utilities
   , caseNat
+  , module Data.V.Linear.Internal.Instances
   ) where
 
 import Data.V.Linear.Internal.V
-import Prelude.Linear.Internal
-import qualified Unsafe.Linear as Unsafe
-import qualified Data.Functor.Linear.Internal.Functor as Data
-import qualified Data.Functor.Linear.Internal.Applicative as Data
-import qualified Data.Functor.Linear.Internal.Traversable as Data
-import GHC.TypeLits
-import qualified Data.Vector as Vector
+import Data.V.Linear.Internal.Instances ()
 
 {- Developers Note
 
@@ -71,21 +61,4 @@ of the instances.
 Remark: ideally the instances below would be in an internal `Instances`
 module. But we haven't got around to it yet.
 -}
-
-
--- # Instances of V
--------------------------------------------------------------------------------
-
-instance Data.Functor (V n) where
-  fmap f (V xs) = V $ Unsafe.toLinear (Vector.map (\x -> f x)) xs
-
-instance KnownNat n => Data.Applicative (V n) where
-  pure a = V $ Vector.replicate (theLength @n) a
-  (V fs) <*> (V xs) = V $
-    Unsafe.toLinear2 (Vector.zipWith (\f x -> f $ x)) fs xs
-
-instance KnownNat n => Data.Traversable (V n) where
-  traverse f (V xs) =
-    (V . Unsafe.toLinear (Vector.fromListN (theLength @n))) Data.<$>
-    Data.traverse f (Unsafe.toLinear Vector.toList xs)
 

--- a/src/Data/V/Linear/Internal/Instances.hs
+++ b/src/Data/V/Linear/Internal/Instances.hs
@@ -1,0 +1,37 @@
+{-# OPTIONS -Wno-orphans #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | This module contains all instances for V
+--
+module Data.V.Linear.Internal.Instances where
+
+import Data.V.Linear.Internal.V
+import Prelude.Linear.Internal
+import qualified Unsafe.Linear as Unsafe
+import qualified Data.Functor.Linear.Internal.Functor as Data
+import qualified Data.Functor.Linear.Internal.Applicative as Data
+import qualified Data.Functor.Linear.Internal.Traversable as Data
+import GHC.TypeLits
+import qualified Data.Vector as Vector
+
+
+-- # Instances of V
+-------------------------------------------------------------------------------
+
+instance Data.Functor (V n) where
+  fmap f (V xs) = V $ Unsafe.toLinear (Vector.map (\x -> f x)) xs
+
+instance KnownNat n => Data.Applicative (V n) where
+  pure a = V $ Vector.replicate (theLength @n) a
+  (V fs) <*> (V xs) = V $
+    Unsafe.toLinear2 (Vector.zipWith (\f x -> f $ x)) fs xs
+
+instance KnownNat n => Data.Traversable (V n) where
+  traverse f (V xs) =
+    (V . Unsafe.toLinear (Vector.fromListN (theLength @n))) Data.<$>
+    Data.traverse f (Unsafe.toLinear Vector.toList xs)
+


### PR DESCRIPTION
We weren't able to create a `Instances` module for `Data.V.Linear` as we did for `Data.Functor.Linear` but this PR fixes that.

The issue: to be able to export a module, GHC requires that module to have something to export. 

Our other `Instances` modules exported something.

To get this to work I had `Data.V.Linear.Internal.Instances` re-export `Data.fmap` which is harmless since we have Data.Functor instances in it. [To be more precise, by "harmless", I mean for any use of `Data.V.Linear`, it will be indistinguishable from if the `Instances` module did not export anything.]