### PR TITLE
Rename module Control.Monad.Linear to Control.Functor.Linear in examples

### DIFF
--- a/src/Control/Optics/Linear.hs
+++ b/src/Control/Optics/Linear.hs
@@ -90,7 +90,7 @@
 --
 -- > type Kleisli f a b = a #-> f b
 --
--- /Note: We abbreviate Control for Control.Monad.Linear./
+-- /Note: We abbreviate Control for Control.Functor.Linear./
 --
 -- +-----------------+------------+---------------+--------------------+-----------+
 -- |                 | Profunctor | Strong (,) () | Strong Either Void | Wandering |

--- a/src/Control/Optics/Linear/Traversal.hs
+++ b/src/Control/Optics/Linear/Traversal.hs
@@ -17,8 +17,8 @@
 -- {-# LANGUAGE GADTs #-}
 --
 -- import Control.Optics.Linear.Internal
--- import qualified Control.Monad.Linear as Control
--- import Control.Monad.Linear ((<$>), (<*>), pure)
+-- import qualified Control.Functor.Linear as Control
+-- import Control.Functor.Linear ((<$>), (<*>), pure)
 -- import Prelude.Linear
 --
 -- -- We can use a traversal to append a string only to the

--- a/src/System/IO/Resource.hs
+++ b/src/System/IO/Resource.hs
@@ -24,7 +24,7 @@
 -- >>> :set -XQualifiedDo
 -- >>> :set -XNoImplicitPrelude
 -- >>> import qualified System.IO.Resource as Linear
--- >>> import qualified Control.Monad.Linear as Control
+-- >>> import qualified Control.Functor.Linear as Control
 -- >>> import qualified Data.Text as Text
 -- >>> import Prelude.Linear
 -- >>> import qualified Prelude


### PR DESCRIPTION
Hi 👋! I was trying out this library and noticed that the examples refer to `Control.Monad.Linear` instead of `Control.Functor.Linear`. This PR fixes them. 