### PR TITLE
More generic push arrays 1/2

### DIFF
--- a/src/Data/Array/Destination.hs
+++ b/src/Data/Array/Destination.hs
@@ -123,6 +123,7 @@ module Data.Array.Destination
   , mirror
   , fromFunction
   , fill
+  , dropEmpty
   )
   where
 
@@ -178,6 +179,14 @@ fill = Unsafe.toLinear2 unsafeFill
         error "Destination.fill: requires a destination of size 1"
       else
         unsafeDupablePerformIO Prelude.$ MVector.write ds 0 a
+
+-- | @dropEmpty dest@ consumes and empty array and fails otherwise.
+dropEmpty :: HasCallStack => DArray a %1-> ()
+dropEmpty = Unsafe.toLinear unsafeDrop where
+  unsafeDrop :: DArray a -> ()
+  unsafeDrop (DArray ds)
+    | MVector.length ds > 0 = error "Destination.dropEmpty on non-empty array."
+    | otherwise = ()
 
 -- | @'split' n dest = (destl, destr)@ such as @destl@ has length @n@.
 --

--- a/src/Data/Array/Destination.hs
+++ b/src/Data/Array/Destination.hs
@@ -186,7 +186,7 @@ dropEmpty = Unsafe.toLinear unsafeDrop where
   unsafeDrop :: DArray a -> ()
   unsafeDrop (DArray ds)
     | MVector.length ds > 0 = error "Destination.dropEmpty on non-empty array."
-    | otherwise = ()
+    | otherwise = ds `seq` ()
 
 -- | @'split' n dest = (destl, destr)@ such as @destl@ has length @n@.
 --

--- a/src/Data/Array/Polarized.hs
+++ b/src/Data/Array/Polarized.hs
@@ -102,8 +102,8 @@ module Data.Array.Polarized
 import qualified Data.Array.Polarized.Pull.Internal as Pull
 import qualified Data.Array.Polarized.Pull as Pull
 import qualified Data.Array.Polarized.Push as Push
+import qualified Data.Foldable as NonLinear
 import Prelude.Linear
-import qualified Prelude
 import Data.Vector (Vector)
 
 -- DEVELOPER NOTE:
@@ -130,8 +130,7 @@ import Data.Vector (Vector)
 -- NOTE: this does NOT require allocation and can be in-lined.
 transfer :: Pull.Array a %1-> Push.Array a
 transfer (Pull.Array f n) =
-  Push.Array
-    (\k -> Prelude.foldl (\m i -> m <> (k (f i))) mempty [0..(n-1)])
+  Push.Array (\k -> NonLinear.foldMap' (\x -> k (f x)) [0..(n-1)])
 
 -- | This is a shortcut convenience function
 -- for @transfer . Pull.fromVector@.

--- a/src/Data/Array/Polarized.hs
+++ b/src/Data/Array/Polarized.hs
@@ -99,11 +99,11 @@ module Data.Array.Polarized
   )
   where
 
-import qualified Data.Array.Destination as DArray
 import qualified Data.Array.Polarized.Pull.Internal as Pull
 import qualified Data.Array.Polarized.Pull as Pull
 import qualified Data.Array.Polarized.Push as Push
 import Prelude.Linear
+import qualified Prelude
 import Data.Vector (Vector)
 
 -- DEVELOPER NOTE:
@@ -129,7 +129,9 @@ import Data.Vector (Vector)
 -- | Convert a pull array into a push array.
 -- NOTE: this does NOT require allocation and can be in-lined.
 transfer :: Pull.Array a %1-> Push.Array a
-transfer (Pull.Array f n) = Push.Array (\g -> DArray.fromFunction (\i -> g (f i))) n
+transfer (Pull.Array f n) =
+  Push.Array
+    (\k -> Prelude.foldl (\m i -> m <> (k (f i))) mempty [0..(n-1)])
 
 -- | This is a shortcut convenience function
 -- for @transfer . Pull.fromVector@.

--- a/src/Data/Array/Polarized/Push.hs
+++ b/src/Data/Array/Polarized/Push.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_GHC -fno-warn-partial-type-signatures #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LinearTypes #-}
@@ -11,55 +10,113 @@
 -- allocated for an array. See @Data.Array.Polarized@.
 --
 -- This module is designed to be imported qualified as @Push@.
-module Data.Array.Polarized.Push where
+module Data.Array.Polarized.Push
+  ( Array(..)
+  , alloc
+  , make
+  )
+where
 
--- XXX: it might be better to hide the data constructor, in case we wish to
--- change the implementation.
-
-import Data.Array.Destination (DArray)
-import qualified Data.Array.Destination as DArray
 import qualified Data.Functor.Linear as Data
+import qualified Data.Array.Destination as DArray
+import Data.Array.Destination (DArray)
 import Data.Vector (Vector)
-import Prelude.Linear
 import qualified Prelude
+import qualified Unsafe.Linear as Unsafe
+import Prelude.Linear
+import GHC.Stack
 
--- TODO: the below isn't really true yet since no friendly way of constructing
--- a PushArray directly is given yet (see issue #62), but the spirit holds.
--- TODO: There's also a slight lie in that one might want to consume a
--- PushArray into a commutative monoid, for instance summing all the elements,
--- and this is not yet possible, although it should be.
+
+-- The Types
+-------------------------------------------------------------------------------
 
 -- | Push arrays are un-allocated finished arrays. These are finished
 -- computations passed along or enlarged until we are ready to allocate.
 data Array a where
+  Array :: (forall m. Monoid m => (a -> m) -> m) %1-> Array a
+  -- Developer notes:
+  --
+  -- Think of @(a -> m)@ as something that writes an @a@ and think of
+  -- @((a -> m) -> m)@ as something that takes a way to write a single element
+  -- and writes and concatenates all elements.
+  --
+  -- Also, note that in this formulation we don't know the length beforehand.
+
+data ArrayWriter a where
+  ArrayWriter :: (DArray a %1-> ()) %1-> !Int -> ArrayWriter a
   -- The second parameter is the length of the @DArray@
-  Array :: (forall b. (a %1-> b) -> DArray b %1-> ()) %1-> Int -> Array a
-  deriving Prelude.Semigroup via NonLinear (Array a)
+
+
+-- API
+-------------------------------------------------------------------------------
+
+-- | Convert a push array into a vector by allocating. This would be a common
+-- end to a computation using push and pull arrays.
+alloc :: Array a %1-> Vector a
+alloc (Array k) = allocArrayWriter $ k singletonWriter where
+  singletonWriter :: a -> ArrayWriter a
+  singletonWriter a = ArrayWriter (DArray.fill a) 1
+
+  allocArrayWriter :: ArrayWriter a %1-> Vector a
+  allocArrayWriter (ArrayWriter writer len) = DArray.alloc len writer
+
+-- | @`make` x n@ creates a constant push array of length @n@ in which every
+-- element is @x@.
+make :: HasCallStack => a -> Int -> Array a
+make x n
+  | n < 0 = error "Making negative length push array"
+  | otherwise = Array (\makeA -> mconcat $ Prelude.replicate n (makeA x))
+
+
+-- # Instances
+-------------------------------------------------------------------------------
 
 instance Data.Functor Array where
-  fmap f (Array k n) = Array (\g dest -> k (g . f) dest) n
+  fmap f (Array k) = Array (\g -> k (\x -> (g (f x))))
+
+instance Prelude.Semigroup (Array a) where
+  (<>) x y = append x y
 
 instance Semigroup (Array a) where
   (<>) = append
 
--- XXX: the use of Vector in the type of alloc is temporary (see also
--- "Data.Array.Destination")
--- | Convert a push array into a vector by allocating. This would be a common
--- end to a computation using push and pull arrays.
-alloc :: Array a %1-> Vector a
-alloc (Array k n) = DArray.alloc n (k id)
+instance Prelude.Monoid (Array a) where
+  mempty = empty
 
--- | @`make` x n@ creates a constant push array of length @n@ in which every
--- element is @x@.
-make :: a -> Int -> Array a
-make x n = Array (\k -> DArray.replicate (k x)) n
+instance Monoid (Array a) where
+  mempty = empty
 
--- | Concatenate two push arrays.
+empty :: Array a
+empty = Array (\_ -> mempty)
+
 append :: Array a %1-> Array a %1-> Array a
-append (Array kl nl) (Array kr nr) =
-    Array
-      (\f dest -> parallelApply f kl kr (DArray.split nl dest))
-      (nl+nr)
-  where
-    parallelApply :: (a %1-> b) -> ((a %1-> b) -> DArray b %1-> ()) %1-> ((a %1-> b) -> DArray b %1-> ()) %1-> (DArray b, DArray b) %1-> ()
-    parallelApply f' kl' kr' (dl, dr) = kl' f' dl <> kr' f' dr
+append (Array k1) (Array k2) = Array (\writeA -> k1 writeA <> k2 writeA)
+
+instance Prelude.Semigroup (ArrayWriter a) where
+  (<>) x y = addWriters x y
+
+instance Prelude.Monoid (ArrayWriter a) where
+  mempty = emptyWriter
+
+instance Semigroup (ArrayWriter a) where
+  (<>) = addWriters
+
+instance Monoid (ArrayWriter a) where
+  mempty = emptyWriter
+
+addWriters :: ArrayWriter a %1-> ArrayWriter a %1-> ArrayWriter a
+addWriters (ArrayWriter k1 l1) (ArrayWriter k2 l2) =
+  ArrayWriter
+    (\darr ->
+      (DArray.split l1 darr) & \(darr1,darr2) -> consume (k1 darr1, k2 darr2))
+    (l1+l2)
+-- Remark. In order for the function above to work, consume must forcibly
+-- evaluate both tuples. If it was lazy, then we might not actually perform
+-- @k1@ or @k2@ and the unsafe IO won't get done. In general, this makes me
+-- think we haven't spelled out the careful rules of what consuming functions
+-- must follow so that we can release a safe API.
+
+emptyWriter :: ArrayWriter a
+emptyWriter = ArrayWriter (Unsafe.toLinear (const ())) 0
+-- Remark. @emptyWriter@ assumes we can split a destination array at 0.
+


### PR DESCRIPTION
This PR flushes out the design laid out in the `better-push-array` branch. [In an effort to avoid plagiarism: note that all of these are @aspiwack's ideas.] We represent push arrays with this clever little rank-2 thing:

```haskell
data Array a where
  Array :: (forall m. Monoid m => (a -> m) -> m) %1-> Array a
```
that takes a polymorphic conversion to a monoid for some element, and creates a monoid. This way it represents the monoidal concatenation of a certain natural (including zero) number of `a`s, in some unknown order.

We instantiate this with a function that takes an `a` and makes it an `ArrayWriter a`:

```haskell
data ArrayWriter a where
  ArrayWriter :: (DArray a %1-> ()) %1-> !Int -> ArrayWriter a
```

which holds the ingredients needed to write some number of elements, without holding the space to do so.

This is part 1/2 because I still have to add the fold functions.
