### PR TITLE
Bench/hashmap

### DIFF
--- a/bench/Data/Mutable/HashMap.hs
+++ b/bench/Data/Mutable/HashMap.hs
@@ -1,0 +1,15 @@
+module Data.Mutable.HashMap (hmbench) where
+
+import Gauge
+
+hmbench :: Benchmark
+hmbench = bgroup "Comparing hashmaps"
+  [ bgroup "linear-base: Data.HashMap.Mutable.Linear" [linearbench]
+  , bgroup "base: Data.Map.Strict" [purestrictbench]
+  ]
+
+linearbench :: Benchmark
+linearbench = bench "" $ nf id ()
+
+purestrictbench :: Benchmark
+purestrictbench = bench "" $ nf id ()

--- a/bench/Data/Mutable/HashMap.hs
+++ b/bench/Data/Mutable/HashMap.hs
@@ -1,15 +1,328 @@
-module Data.Mutable.HashMap (hmbench) where
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+module Data.Mutable.HashMap (hmbench, getHMInput) where
 
 import Gauge
+import qualified System.Random as Random
+import qualified System.Random.Shuffle as Random
+import Control.DeepSeq (deepseq, force, NFData(..))
+import Data.Hashable (Hashable(..), hashWithSalt)
+import GHC.Generics (Generic)
+import qualified Data.Unrestricted.Linear as Linear
+import Data.List (foldl')
+import qualified Prelude.Linear as Linear
+import Control.Monad.ST (runST, ST)
 
-hmbench :: Benchmark
-hmbench = bgroup "Comparing hashmaps"
-  [ bgroup "linear-base: Data.HashMap.Mutable.Linear" [linearbench]
-  , bgroup "base: Data.Map.Strict" [purestrictbench]
+import qualified Data.HashMap.Mutable.Linear as LMap
+import qualified Data.HashMap.Strict as Map
+import qualified Data.HashTable.ST.Basic as BasicST
+import qualified Data.HashTable.ST.Cuckoo as CuckooST
+
+
+-- # Exported benchmarks
+-------------------------------------------------------------------------------
+
+newtype Key = Key Int
+
+deriving instance Eq Key
+deriving instance Ord Key
+deriving instance Generic Key
+deriving instance NFData Key
+instance Hashable Key where
+    hash (Key x) =
+      x  `hashWithSalt` (154669 :: Int)
+    -- Note: salt with a prime
+
+data BenchInput where
+  BenchInput ::
+    { pairs :: ![(Key, Int)] -- Keys paired with values
+    , shuffle1 :: ![Key]
+    , shuffle2 :: ![Key]
+    , shuffle3 :: ![Key]
+    } -> BenchInput
+
+hmbench :: BenchInput -> Benchmark
+hmbench inp = bgroup "Comparing Linear Hashmaps"
+  [ bgroup "linear-base:Data.HashMap.Mutable.Linear" $
+      linear_hashmap inp
+  , bgroup "unordered-containers:Data.HashMap.Strict" $
+      vanilla_hashmap_strict inp
+  , bgroup "hashtables:Data.HashTable.ST.Basic" $
+      st_basic inp
+  , bgroup "hashtables:Data.HashTable.ST.Cuckoo" $
+      st_cuckoo inp
   ]
 
-linearbench :: Benchmark
-linearbench = bench "" $ nf id ()
+descriptions :: [String]
+descriptions =
+  -- By "shuffle" we mean we vary the order we access keys
+  [ "Insert x, delete x, repeat for whole range"
+  , "Insert all, shuffle, modify all"
+  , "Insert all, shuffle, lookup all"
+  , "Insert all, shuffle, modify all, shuffle, lookup all"
+  , "Insert all, shuffle, modify all, shuffle, modify all, shuffle, lookup all"
+  ]
 
-purestrictbench :: Benchmark
-purestrictbench = bench "" $ nf id ()
+
+-- # Config
+-------------------------------------------------------------------------------
+
+num_keys :: Int
+num_keys = 100_000
+
+getHMInput :: IO BenchInput
+getHMInput = do
+  let keys = map Key $ enumFromTo 1 num_keys
+  g0 <- Random.getStdGen
+  let (gx,gc) = Random.split g0
+  let (ga,gb) = Random.split gx
+  let shuff1 = force $ Random.shuffle' keys num_keys ga
+  let shuff2 = force $ Random.shuffle' shuff1 num_keys gb
+  let shuff3 = force $ Random.shuffle' shuff2 num_keys gc
+  g1 <- Random.getStdGen
+  let (vals :: [Int]) = Random.randomRs (0,num_keys) g1
+  let kv_pairs = force (zip keys vals)
+  return $ BenchInput kv_pairs shuff1 shuff2 shuff3
+
+modVal :: Maybe Int -> Maybe Int
+modVal Nothing = Nothing
+modVal (Just !k)
+  | even k = Nothing
+  | otherwise = Just $ floor (sqrt (fromIntegral k) :: Float) + (2*k) + 1
+
+
+-- # Linear Hashmaps
+-------------------------------------------------------------------------------
+
+linear_hashmap :: BenchInput -> [Benchmark]
+linear_hashmap inp@(BenchInput {pairs=kvs}) =
+  [bench1, bench2, bench3, bench4, bench5]
+  where
+    mkBench ::
+      Int ->
+      ([(Key,Int)] -> LMap.HashMap Key Int %1-> LMap.HashMap Key Int) ->
+      Benchmark
+    mkBench n f = bench (descriptions!!n) $ nf
+      (\xs -> unur $ LMap.empty num_keys Linear.$ kill Linear.. f xs) kvs
+
+    kill :: LMap.HashMap k v %1-> Linear.Ur ()
+    kill hmap = Linear.lseq hmap (Linear.Ur ())
+
+    unur :: Linear.Ur a -> a
+    unur (Linear.Ur a) = a
+
+    foldlx :: (b %1-> a -> b) -> [a] -> b %1-> b
+    foldlx _ [] !b = b
+    foldlx f (a:as) !b = foldlx f as (f b a)
+
+    look :: LMap.HashMap Key Int %1-> Key -> LMap.HashMap Key Int
+    look hmap k = LMap.lookup k hmap Linear.& \case
+      (Linear.Ur Nothing, hmap0) -> hmap0
+      (Linear.Ur (Just v), hmap0) -> Linear.seq (force v) hmap0
+
+    insertDelete ::
+      LMap.HashMap Key Int %1-> (Key,Int) -> LMap.HashMap Key Int
+    insertDelete hmap (c,v) = LMap.delete c (LMap.insert c v hmap)
+
+    bench1 :: Benchmark
+    bench1 = mkBench 0 bench1_
+
+    bench1_ :: [(Key,Int)] -> LMap.HashMap Key Int %1-> LMap.HashMap Key Int
+    bench1_ xs = foldlx insertDelete xs
+
+    bench2 :: Benchmark
+    bench2 = mkBench 1 bench2_
+
+    bench2_ :: [(Key,Int)] -> LMap.HashMap Key Int %1-> LMap.HashMap Key Int
+    bench2_ xs =
+        foldlx (Linear.flip (LMap.alter modVal)) (shuffle1 inp) Linear..
+        LMap.insertAll xs
+
+    bench3 :: Benchmark
+    bench3 = mkBench 2 bench3_
+
+    bench3_ :: [(Key,Int)] -> LMap.HashMap Key Int %1-> LMap.HashMap Key Int
+    bench3_ xs =
+      foldlx look (shuffle1 inp) Linear..
+      LMap.insertAll xs
+
+    bench4 :: Benchmark
+    bench4 = mkBench 3 bench4_
+
+    bench4_ :: [(Key,Int)] -> LMap.HashMap Key Int %1-> LMap.HashMap Key Int
+    bench4_ xs =
+      foldlx look (shuffle2 inp) Linear..
+      foldlx (Linear.flip (LMap.alter modVal)) (shuffle1 inp) Linear..
+      LMap.insertAll xs
+
+    bench5 :: Benchmark
+    bench5 = mkBench 4 bench5_
+
+    bench5_ :: [(Key,Int)] -> LMap.HashMap Key Int %1-> LMap.HashMap Key Int
+    bench5_ xs =
+      foldlx look (shuffle3 inp) Linear..
+      foldlx (Linear.flip (LMap.alter modVal)) (shuffle2 inp) Linear..
+      foldlx (Linear.flip (LMap.alter modVal)) (shuffle1 inp) Linear..
+      LMap.insertAll xs
+
+
+-- # Vanilla Hashmaps
+-------------------------------------------------------------------------------
+
+vanilla_hashmap_strict :: BenchInput -> [Benchmark]
+vanilla_hashmap_strict inp@(BenchInput {pairs=kvs}) =
+  [bench1, bench2, bench3, bench4, bench5]
+  where
+    mkBench ::
+      Int ->
+      ([(Key,Int)] -> Map.HashMap Key Int -> Map.HashMap Key Int) ->
+      Benchmark
+    mkBench n f =
+      bench (descriptions!!n) $ nf (\xs -> rnf $ f xs Map.empty) kvs
+
+    foldlx :: (b -> a -> b) -> [a] -> b -> b
+    foldlx f xs b = foldl' f b xs
+
+    look :: Map.HashMap Key Int -> Key -> Map.HashMap Key Int
+    look m k = case m Map.!? k of
+      Nothing -> m
+      Just v -> deepseq v m
+
+    bench1 :: Benchmark
+    bench1 = mkBench 0 $
+      \xs hm -> foldl' (\m (k,v) -> Map.delete k (Map.insert k v m)) hm xs
+
+    bench2 :: Benchmark
+    bench2 = mkBench 1 $
+      \xs ->
+        foldlx (flip $ Map.alter modVal) (shuffle1 inp) .
+        foldlx (flip $ uncurry Map.insert) xs
+
+    bench3 :: Benchmark
+    bench3 = mkBench 2 $
+      \xs ->
+        foldlx look (shuffle1 inp) .
+        foldlx (flip $ uncurry Map.insert) xs
+
+    bench4 :: Benchmark
+    bench4 = mkBench 3 $
+      \xs ->
+        foldlx look (shuffle2 inp) .
+        foldlx (flip $ Map.alter modVal) (shuffle1 inp) .
+        foldlx (flip $ uncurry Map.insert) xs
+
+    bench5 :: Benchmark
+    bench5 = mkBench 4 $
+      \xs ->
+        foldlx look (shuffle3 inp) .
+        foldlx (flip $ Map.alter modVal) (shuffle2 inp) .
+        foldlx (flip $ Map.alter modVal) (shuffle1 inp) .
+        foldlx (flip $ uncurry Map.insert) xs
+
+
+-- # ST Basic
+-------------------------------------------------------------------------------
+
+st_basic ::  BenchInput -> [Benchmark]
+st_basic inp@(BenchInput {pairs=kvs}) =
+  [bench1, bench2, bench3, bench4, bench5]
+  where
+    mkBench ::
+      Int ->
+      (forall s. [(Key,Int)] -> BasicST.HashTable s Key Int -> ST s ()) ->
+      Benchmark
+    mkBench n f = bench (descriptions!!n) $ nf
+      (\xs -> runST (BasicST.newSized num_keys >>= f xs)) kvs
+
+    look :: BasicST.HashTable s Key Int -> Key -> ST s ()
+    look m k = do
+      maybeV <- fmap force $ BasicST.lookup m k
+      case maybeV of
+        Nothing -> return ()
+        Just v -> deepseq v (return ())
+
+    bench1 :: Benchmark
+    bench1 = mkBench 0 $ \xs hm ->
+      mapM_ (\(k,v) -> BasicST.insert hm k v >> BasicST.delete hm k) xs
+
+    bench2 :: Benchmark
+    bench2 = mkBench 1 $ \xs hm -> do
+      mapM_ (\(k,v) -> BasicST.insert hm k v) xs
+      mapM_ (\k -> BasicST.mutate hm k ((,()) . modVal)) (shuffle1 inp)
+
+    bench3 :: Benchmark
+    bench3 = mkBench 2 $ \xs hm -> do
+      mapM_ (\(k,v) -> BasicST.insert hm k v) xs
+      mapM_ (look hm) (shuffle1 inp)
+
+    bench4 :: Benchmark
+    bench4 = mkBench 3 $ \xs hm -> do
+      mapM_ (\(k,v) -> BasicST.insert hm k v) xs
+      mapM_ (\k -> BasicST.mutate hm k ((,()) . modVal)) (shuffle1 inp)
+      mapM_ (look hm) (shuffle2 inp)
+
+    bench5 :: Benchmark
+    bench5 = mkBench 4 $ \xs hm -> do
+      mapM_ (\(k,v) -> BasicST.insert hm k v) xs
+      mapM_ (\k -> BasicST.mutate hm k ((,()) . modVal)) (shuffle1 inp)
+      mapM_ (\k -> BasicST.mutate hm k ((,()) . modVal)) (shuffle2 inp)
+      mapM_ (look hm) (shuffle3 inp)
+
+
+-- # ST Cuckoo
+-------------------------------------------------------------------------------
+
+st_cuckoo ::  BenchInput -> [Benchmark]
+st_cuckoo inp@(BenchInput {pairs=kvs}) =
+  [bench1, bench2, bench3, bench4, bench5]
+  where
+    mkBench ::
+      Int ->
+      (forall s. [(Key,Int)] -> CuckooST.HashTable s Key Int -> ST s ()) ->
+      Benchmark
+    mkBench n f = bench (descriptions!!n) $ nf
+      (\xs -> runST (CuckooST.newSized num_keys >>= f xs)) kvs
+
+    look :: CuckooST.HashTable s Key Int -> Key -> ST s ()
+    look m k = do
+      maybeV <- fmap force $ CuckooST.lookup m k
+      case maybeV of
+        Nothing -> return ()
+        Just v -> deepseq v (return ())
+
+    bench1 :: Benchmark
+    bench1 = mkBench 0 $ \xs hm ->
+      mapM_ (\(k,v) -> CuckooST.insert hm k v >> CuckooST.delete hm k) xs
+
+    bench2 :: Benchmark
+    bench2 = mkBench 1 $ \xs hm -> do
+      mapM_ (\(k,v) -> CuckooST.insert hm k v) xs
+      mapM_ (\k -> CuckooST.mutate hm k ((,()) . modVal)) (shuffle1 inp)
+
+    bench3 :: Benchmark
+    bench3 = mkBench 2 $ \xs hm -> do
+      mapM_ (\(k,v) -> CuckooST.insert hm k v) xs
+      mapM_ (look hm) (shuffle1 inp)
+
+    bench4 :: Benchmark
+    bench4 = mkBench 3 $ \xs hm -> do
+      mapM_ (\(k,v) -> CuckooST.insert hm k v) xs
+      mapM_ (\k -> CuckooST.mutate hm k ((,()) . modVal)) (shuffle1 inp)
+      mapM_ (look hm) (shuffle2 inp)
+
+    bench5 :: Benchmark
+    bench5 = mkBench 4 $ \xs hm -> do
+      mapM_ (\(k,v) -> CuckooST.insert hm k v) xs
+      mapM_ (\k -> CuckooST.mutate hm k ((,()) . modVal)) (shuffle1 inp)
+      mapM_ (\k -> CuckooST.mutate hm k ((,()) . modVal)) (shuffle2 inp)
+      mapM_ (look hm) (shuffle3 inp)
+

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -1,8 +1,12 @@
 module Main where
 
 import Gauge
-import Data.Mutable.HashMap (hmbench)
+import Data.Mutable.HashMap (hmbench, getHMInput)
 
 main :: IO ()
-main = defaultMain [hmbench]
+main = do
+  hmInput <- getHMInput
+  defaultMain
+    [ hmbench hmInput
+    ]
 

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -1,0 +1,8 @@
+module Main where
+
+import Gauge
+import Data.Mutable.HashMap (hmbench)
+
+main :: IO ()
+main = defaultMain [hmbench]
+

--- a/cabal.project
+++ b/cabal.project
@@ -1,11 +1,15 @@
 packages: *.cabal
-
 allow-newer: all
 
 package linear-base
   ghc-options: -Wall -Werror
 
 -- If you update below, make sure to also update stack.yaml too
+source-repository-package
+  type: git
+  location: https://github.com/Divesh-Otwani/foundation.git
+  subdir: basement
+  tag: ad709f41a8c4671f2f96fdf9c93cd62d3e7bca9f
 
 source-repository-package
   -- https://github.com/nick8325/quickcheck/pull/314

--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -144,6 +144,19 @@ test-suite examples
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   default-language: Haskell2010
 
+benchmark mutable-data
+  type: exitcode-stdio-1.0
+  hs-source-dirs: bench
+  main-is: Main.hs
+  other-modules:
+    Data.Mutable.HashMap
+  build-depends:
+    base,
+    gauge,
+    linear-base
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  default-language: Haskell2010
+
 -- TODO: Uncomment below block and set 'build-type' to 'Custom' to enable
 -- doctests once cabal-install 3.4 is released.
 --

--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -152,9 +152,15 @@ benchmark mutable-data
     Data.Mutable.HashMap
   build-depends:
     base,
+    deepseq,
     gauge,
-    linear-base
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+    hashtables,
+    hashable,
+    linear-base,
+    random,
+    random-shuffle,
+    unordered-containers
+  ghc-options: -rtsopts=ignore
   default-language: Haskell2010
 
 -- TODO: Uncomment below block and set 'build-type' to 'Custom' to enable

--- a/src/Data/HashMap/Mutable/Linear.hs
+++ b/src/Data/HashMap/Mutable/Linear.hs
@@ -135,7 +135,7 @@ newtype PSL = PSL Int
 
 -- | At minimum, we need to store hashable
 -- and identifiable keys
-type Keyed k = (Eq k, Hashable k)
+type Keyed k = (Prelude.Eq k, Hashable k)
 
 -- | The results of searching for where to insert a key.
 --
@@ -496,7 +496,7 @@ probeFrom (k, p) ix (HashMap ct arr) = Array.read arr ix & \case
   (Ur Nothing, arr') ->
     (HashMap ct arr', IndexToInsert p ix)
   (Ur (Just robinVal'@(RobinVal psl k' v')), arr') ->
-    case k == k' of
+    case k Prelude.== k' of
       -- Note: in the True case, we must have p == psl
       True -> (HashMap ct arr', IndexToUpdate v' psl ix)
       False -> case psl Prelude.< p of

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,6 +9,11 @@ packages:
 
 # If you update the extra-deps, make sure to also update cabal.project
 extra-deps:
+# To get the library gauge for benchmarks working:
+- git: https://github.com/Divesh-Otwani/foundation.git
+  commit: ad709f41a8c4671f2f96fdf9c93cd62d3e7bca9f
+  subdirs:
+    - basement
 # https://github.com/nick8325/quickcheck/pull/314
 - git: https://github.com/buggymcbugfix/quickcheck.git
   commit: f24fbd0d0f7a03da76c46b31d6fba9678ff5e71c


### PR DESCRIPTION
A first iteration of hashmap benchmarks. I expect these to have several red herrings and complications but more or less be useful.

We test 4 hashmaps:

1. Data.HashMap.Mutable.Linear
2. unordered-containers:Data.HashMap.Strict
3. hashtables:Data.HashTable.ST.Basic
4. hashtables:Data.HashTable.ST.Cuckoo

on 5 tests initialized with a random set of key-value pairs where the keys are salted ints and the values are ints.
Let kvs be the set of given pairs to insert, then we test:

1. Insert a kv pair, delete that key, for each pair in kvs
2. Insert all of kvs, modify the values in random key access (with modification deleting half)
3. Insert all of kvs, lookup each key in a random order
4. Insert all of kvs, modify as in (3) in a random order, then lookup in another random order
5. Insert all, modify as in (3) in a random order, modify again in another random order, lookup in another random order

The basic results seem to indicate we're slower than literally everything. 
# :rofl: :rofl: :rofl: :rofl: :rofl: 

A basic run on my laptop gave:

| Name  | Bench 1 | Bench 2 | Bench 3 | Bench 4 | Bench 5 |
| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
| Linear | 51ms | 345 ms | 228 ms | 392 ms | 479 ms |
| Strict | 3.7 ms | 195 ms | 96 ms | 209 ms | 257 ms |
| ST Basic | 35 ms | 75 ms | 46 ms | 93 ms | 129 ms |
| ST Cuckoo | 36 ms | 50 ms | 44 ms | 79 ms | 94 ms |

The standard deviations were low enough for the differences in the table above to be roughly accurate.



