### PR TITLE
Update dependencies and remove obsolete overrides

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -12,23 +12,11 @@ source-repository-package
   tag: ad709f41a8c4671f2f96fdf9c93cd62d3e7bca9f
 
 source-repository-package
-  -- https://github.com/nick8325/quickcheck/pull/314
-  type: git
-  location: https://github.com/buggymcbugfix/quickcheck.git
-  tag: f24fbd0d0f7a03da76c46b31d6fba9678ff5e71c
-
-source-repository-package
   -- https://github.com/hedgehogqa/haskell-hedgehog/pull/392
   type: git
   location: https://github.com/utdemir/haskell-hedgehog.git
   tag: c98aa9e33bf6871098d6f4ac94eeaac10383d696
   subdir: hedgehog
-
-source-repository-package
-  -- https://github.com/dreixel/syb/pull/25
-  type: git
-  location: https://github.com/utdemir/syb.git
-  tag: a072e20d7a5806779486646418fa20c5ffd99a4f
 
 source-repository-package
   -- https://github.com/sol/doctest/pull/272

--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -85,7 +85,7 @@ library
     System.IO.Resource
     Unsafe.Linear
   build-depends:
-    base >= 4.7 && < 5,
+    base >= 4.15 && < 5,
     containers,
     ghc-prim,
     hashable,

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,7 +1,7 @@
 let
-  # https://github.com/tweag/nixpkgs/tree/ud/update-ghchead-20201001
-  rev = "78d9696f5d1524fcf2fd947f012ffc08fcba4dd1";
-  sha256 = "146rahqm2rkbz2hl689rqc04wcfdrghbjzxzynbzsc3xi5if59bh";
+  # https://github.com/tweag/nixpkgs/tree/ud/ghc9
+  rev = "17a21c9466ef77471f5181bc075d7fc2265bcc72";
+  sha256 = "12g4jn74az3plzlc8klhbgfjlg2kbxs1238aqymksbxzf2z2n1j3";
 in
 import (fetchTarball {
   inherit sha256;

--- a/shell-stack.nix
+++ b/shell-stack.nix
@@ -1,5 +1,4 @@
 { pkgs ?  import ./nixpkgs.nix {}
-, ghc ? pkgs.haskell.compiler.ghcHEAD
 }:
 
 with pkgs;
@@ -7,6 +6,6 @@ with pkgs;
 haskell.lib.buildStackProject {
   name = "linear-base";
   buildInputs = [ git zlib ];
-  ghc = pkgs.haskell.compiler.ghcHEAD;
+  ghc = pkgs.haskell.compiler.ghc901;
   LANG = "en_US.utf8";
 }

--- a/shell.nix
+++ b/shell.nix
@@ -7,7 +7,7 @@ mkShell {
   LANG="C.UTF-8";
 
   buildInputs = [
-    haskell.compiler.ghcHEAD
+    haskell.compiler.ghc901
     cabal-install
     git
     nix

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,5 @@
-# See https://hub.docker.com/r/tweag/linear-types/
-resolver: lts-16.15
-compiler: ghc-9.1
+resolver: lts-17.1
+compiler: ghc-9.0.1
 allow-newer: true
 system-ghc: true
 
@@ -14,23 +13,14 @@ extra-deps:
   commit: ad709f41a8c4671f2f96fdf9c93cd62d3e7bca9f
   subdirs:
     - basement
-# https://github.com/nick8325/quickcheck/pull/314
-- git: https://github.com/buggymcbugfix/quickcheck.git
-  commit: f24fbd0d0f7a03da76c46b31d6fba9678ff5e71c
 # https://github.com/hedgehogqa/haskell-hedgehog/pull/392
 - git: https://github.com/utdemir/haskell-hedgehog.git
   commit: c98aa9e33bf6871098d6f4ac94eeaac10383d696
   subdirs:
     - hedgehog
-# https://github.com/dreixel/syb/pull/25
-- git: https://github.com/utdemir/syb.git
-  commit: a072e20d7a5806779486646418fa20c5ffd99a4f
 # https://github.com/sol/doctest/pull/272
 - git: https://github.com/utdemir/doctest.git
   commit: 090cccaf12c5643ca80f8c2afe693a488277d365
-# below is required for getting quickcheck compile
-- random-1.2.0
-- splitmix-0.1.0.1
 
 nix:
   enable: true


### PR DESCRIPTION
I did some housekeeping before the release.

* I switched using `ghc901` instead of `ghcHEAD`, and updated our `nixpkgs` fork to use the released binaries.
* I removed `quickcheck` and `syb` overrides since the required updates are merged & released.
* I increased the base lower bound to the one released with GHC 9, so the install plan will fail with olde GHC's.
* I updated the stackage resolver to get up-to-date packages (includes the released fixes I mentioned above).

However, I couldn't enable doctests. I think `cabal-install` coming from our nix expressions need to be updated before that.

(CI might take a while to complete since it has to compile a new GHC.)