### PR TITLE
Add default instances for the Data.Unrestricted classes based on the Generic framework 

### DIFF
--- a/src/Data/Unrestricted/Internal/Consumable.hs
+++ b/src/Data/Unrestricted/Internal/Consumable.hs
@@ -1,5 +1,7 @@
 {-# OPTIONS_HADDOCK hide #-}
 {-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 module Data.Unrestricted.Internal.Consumable
   (
@@ -7,11 +9,17 @@ module Data.Unrestricted.Internal.Consumable
     Consumable(..)
   , lseq
   , seqUnit
+  , GConsumable(..)
   )
   where
 
+import GHC.Generics
+import qualified Unsafe.Linear as Unsafe
+
 class Consumable a where
   consume :: a %1-> ()
+  default consume :: (Generic a, GConsumable (Rep a)) => a %1-> ()
+  consume a = gconsume (Unsafe.toLinear from a)
 
 -- | Consume the unit and return the second argument.
 -- This is like 'seq' but since the first argument is restricted to be of type
@@ -24,3 +32,5 @@ seqUnit () b = b
 lseq :: Consumable a => a %1-> b %1-> b
 lseq a b = seqUnit (consume a) b
 
+class GConsumable f where
+  gconsume :: f x %1-> ()

--- a/src/Data/Unrestricted/Internal/Movable.hs
+++ b/src/Data/Unrestricted/Internal/Movable.hs
@@ -1,12 +1,21 @@
 {-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleContexts #-}
+
 module Data.Unrestricted.Internal.Movable
   (
   -- * Movable
     Movable(..)
+  , GMovable(..)
   ) where
 
+import GHC.Generics
 import Data.Unrestricted.Internal.Ur
 import Data.Unrestricted.Internal.Dupable
+import qualified Unsafe.Linear as Unsafe
+import Prelude.Linear.Internal ((&))
+
 
 -- | Use @'Movable' a@ to represent a type which can be used many times even
 -- when given linearly. Simple data types such as 'Bool' or @[]@ are 'Movable'.
@@ -25,4 +34,8 @@ import Data.Unrestricted.Internal.Dupable
 -- * @case move x of {Ur x -> (x, x)} = dup2 x@
 class Dupable a => Movable a where
   move :: a %1-> Ur a
+  default move :: (Generic a, GMovable (Rep a)) => a %1-> Ur a
+  move a = gmove (Unsafe.toLinear from a) & \case (Ur fx) -> Ur (to fx)
 
+class GMovable f where
+  gmove :: f x %1-> Ur (f x)

--- a/src/Foreign/Marshal/Pure/Internal.hs
+++ b/src/Foreign/Marshal/Pure/Internal.hs
@@ -296,6 +296,7 @@ instance Consumable Pool where
 
 instance Dupable Pool where
   dupV (Pool l) = Data.pure (Pool l)
+  dup2 (Pool l) = (Pool l, Pool l)
 
 -- | 'Box a' is the abstract type of manually managed data. It can be used as
 -- part of data type definitions in order to store linked data structure off


### PR DESCRIPTION
Just trying to understand the combination of Generics and linearity. Would using `Unsafe.toLinear` on `from` and `to` be the way to go for now?