### PR TITLE
Add missing Monoid instances

### DIFF
--- a/src/Data/Monoid/Linear/Internal/Monoid.hs
+++ b/src/Data/Monoid/Linear/Internal/Monoid.hs
@@ -46,9 +46,15 @@ instance Prelude.Monoid (Endo a) where
   mempty = Endo id
 instance Monoid (Endo a)
 
+instance Monoid ()
+
 instance (Monoid a, Monoid b) => Monoid (a,b)
 
 instance Monoid a => Monoid (Dual a)
+
+instance Monoid All
+
+instance Monoid Any
 
 instance Monoid Ordering where
     mempty = EQ


### PR DESCRIPTION
I need the `Monoid ()` instance for deriving `Consumable` instances with a linear `foldMap`.