### PR TITLE
Reenable doctests

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -17,9 +17,3 @@ source-repository-package
   location: https://github.com/utdemir/haskell-hedgehog.git
   tag: c98aa9e33bf6871098d6f4ac94eeaac10383d696
   subdir: hedgehog
-
-source-repository-package
-  -- https://github.com/sol/doctest/pull/272
-  type: git
-  location: https://github.com/utdemir/doctest.git
-  tag: 090cccaf12c5643ca80f8c2afe693a488277d365

--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -8,7 +8,7 @@ author: Tweag
 maintainer: arnaud.spiwack@tweag.io
 copyright: (c) Tweag Holding and affiliates
 category: Prelude
-build-type: Simple
+build-type: Custom
 synopsis: Standard library for linear types.
 description: Please see README.md.
 
@@ -175,38 +175,21 @@ benchmark mutable-data
   ghc-options: -rtsopts=ignore
   default-language: Haskell2010
 
--- TODO: Uncomment below block and set 'build-type' to 'Custom' to enable
--- doctests once cabal-install 3.4 is released.
---
--- Longer story:
---
--- cabal-install has a piece of code[1] which injects a Cabal upper bound to
--- packages with custom Setup.hs's. And this happens after the overrides,
--- so the usual mechanisms of overriding upper bounds does not work.
---
--- GHC 9 comes with Cabal 3.4, which is above that bound. So, when using
--- GHC 9 with cabal-install 3.2; `build-type: Custom` causes another Cabal
--- library to be built, and that causes a strange type error ("expecting IO,
--- but got IO"), which I suspect because it conflicts with the existing boot
--- packages.
---
--- [1]: https://github.com/haskell/cabal/blob/d28c80acc69b9e7fa992a0b2b7fced937734b238/cabal-install/src/Distribution/Client/ProjectPlanning.hs#L1132-L1149
+custom-setup
+ setup-depends:
+   base >= 4 && <5,
+   Cabal,
+   cabal-doctest
 
--- custom-setup
---  setup-depends:
---    base >= 4 && <5,
---    Cabal,
---    cabal-doctest
---
--- test-suite doctests
---   type:                 exitcode-stdio-1.0
---   hs-source-dirs:       test/
---   main-is:              Doctest.hs
---   build-depends:        base
---                       , doctest
---                       , linear-base
---   ghc-options:          -Wall -threaded
---   default-language:     Haskell2010
+test-suite doctests
+  type:                 exitcode-stdio-1.0
+  hs-source-dirs:       test/
+  main-is:              Doctest.hs
+  build-depends:        base
+                      , doctest
+                      , linear-base
+  ghc-options:          -Wall -threaded
+  default-language:     Haskell2010
 
 source-repository head
   type: git

--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -178,7 +178,7 @@ benchmark mutable-data
 custom-setup
  setup-depends:
    base >= 4 && <5,
-   Cabal >= 3.4.0.0,
+   Cabal,
    cabal-doctest
 
 test-suite doctests

--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -178,7 +178,7 @@ benchmark mutable-data
 custom-setup
  setup-depends:
    base >= 4 && <5,
-   Cabal,
+   Cabal >= 3.4.0.0,
    cabal-doctest
 
 test-suite doctests

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,6 +1,6 @@
 let
-  rev = "f9b3e78132eabde9d01c27b82c6102c87a2ea5a1";
-  sha256 = "00dkynb7p9vy511h9g8b6a4r8j26iwsrn0s3433nhcr4v93q17z1";
+  rev = "e495e2fa72110eaccbbb600fc77bda6e47b906c5";
+  sha256 = "1kq5kh4cqchlwgn07277kw9yl95fjcwqqc45kz2x2kf14md56wn4";
 in
 import (fetchTarball {
   inherit sha256;

--- a/src/Data/Vector/Mutable/Linear.hs
+++ b/src/Data/Vector/Mutable/Linear.hs
@@ -12,6 +12,7 @@
 -- == Example
 --
 -- >>> :set -XLinearTypes
+-- >>> :set -XNoImplicitPrelude
 -- >>> import Prelude.Linear
 -- >>> import qualified Data.Vector.Mutable.Linear as Vector
 -- >>> :{

--- a/src/Foreign/Marshal/Pure.hs
+++ b/src/Foreign/Marshal/Pure.hs
@@ -24,7 +24,7 @@
 -- >>> import Data.Unrestricted.Linear
 -- >>> import qualified Foreign.Marshal.Pure as Manual
 -- >>> :{
---   nothingWith3 :: Pool %1-> Ur Int
+--   nothingWith3 :: Manual.Pool %1-> Ur Int
 --   nothingWith3 pool = move (Manual.deconstruct (Manual.alloc 3 pool))
 -- :}
 --

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,9 +18,6 @@ extra-deps:
   commit: c98aa9e33bf6871098d6f4ac94eeaac10383d696
   subdirs:
     - hedgehog
-# https://github.com/sol/doctest/pull/272
-- git: https://github.com/utdemir/doctest.git
-  commit: 090cccaf12c5643ca80f8c2afe693a488277d365
 
 nix:
   enable: true


### PR DESCRIPTION
Cabal 3.4.0.0 is out now, so I reenabled the doctest.

But most the doctests are failing with an error like:

```
attempting to use module ‘main:Foreign.Marshal.Pure’ (...) which is not loaded
```

@utdemir Do you know what might cause this?