### PR TITLE
Add a Github action ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,37 @@
+name: Continuous integration
+on: [push]
+env:
+  # Bump this number to invalidate the Github-actions cache
+  cache-invalidation-key: 0
+jobs:
+  tests:
+    name: Build & Test
+    env:
+      NIXSHELL: nix-shell --pure
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.3.4
+    - uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - name: Build Nix dependencies
+      run: $NIXSHELL --run "echo '=== Installed ==='"
+    - name: Cache Cabal dependencies
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cabal/packages
+          ~/.cabal/store
+          dist-newstyle
+        key: cache-${{ runner.os }}-${{ hashFiles('nixpkgs.nix') }}-v${{ env.cache-invalidation-key }}-${{ hashFiles('linear-base.cabal') }}-${{ github.sha }}
+        restore-keys: cache-${{ runner.os }}-${{ hashFiles('nixpkgs.nix') }}-v${{ env.cache-invalidation-key }}-${{ hashFiles('linear-base.cabal') }}-
+    - name: Update Cabal's database
+      run: $NIXSHELL --run "cabal update"
+    - name: Build Cabal's dependencies
+      run:  $NIXSHELL --run "cabal build --enable-tests --enable-benchmarks --dependencies-only"
+    - name: Build
+      run: $NIXSHELL --run "cabal build"
+    - name: Test
+      run: $NIXSHELL --run "cabal test"
+    - name: Haddock
+      run: $NIXSHELL --run "cabal haddock"


### PR DESCRIPTION
Now that we don't need to build GHC ourselves for the sake of
linear-base to work, we don't need to lock a super beefy runner for 1h
from time to time.

On the other hand, the buildkite runner didn't run ci for
contributions outside of Tweag. Having a Github-action based ci will
be better for contributors.

I'll remove the Buildkite ci in a separate PR.