### PR TITLE
Update dependencies and remove overrides

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,4 @@
 packages: *.cabal
-allow-newer: all
 
 package linear-base
   ghc-options: -Wall -Werror

--- a/cabal.project
+++ b/cabal.project
@@ -3,23 +3,3 @@ allow-newer: all
 
 package linear-base
   ghc-options: -Wall -Werror
-
--- If you update below, make sure to also update stack.yaml too
-source-repository-package
-  type: git
-  location: https://github.com/Divesh-Otwani/foundation.git
-  subdir: basement
-  tag: ad709f41a8c4671f2f96fdf9c93cd62d3e7bca9f
-
-source-repository-package
-  -- https://github.com/hedgehogqa/haskell-hedgehog/pull/392
-  type: git
-  location: https://github.com/utdemir/haskell-hedgehog.git
-  tag: c98aa9e33bf6871098d6f4ac94eeaac10383d696
-  subdir: hedgehog
-
-source-repository-package
-  -- https://github.com/sol/doctest/pull/272
-  type: git
-  location: https://github.com/utdemir/doctest.git
-  tag: 090cccaf12c5643ca80f8c2afe693a488277d365

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,6 +1,6 @@
 let
-  rev = "f9b3e78132eabde9d01c27b82c6102c87a2ea5a1";
-  sha256 = "00dkynb7p9vy511h9g8b6a4r8j26iwsrn0s3433nhcr4v93q17z1";
+  rev = "acd49fab8ece11a89ef8ee49903e1cd7bb50f4b7";
+  sha256 = "1zbwifjak4ni71by4xdfp41byz152ll689hqy12pkdwnlspz3g8i";
 in
 import (fetchTarball {
   inherit sha256;

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-17.1
+resolver: lts-17.11
 compiler: ghc-9.0.1
 allow-newer: true
 system-ghc: true
@@ -6,21 +6,8 @@ system-ghc: true
 packages:
 - '.'
 
-# If you update the extra-deps, make sure to also update cabal.project
 extra-deps:
-# To get the library gauge for benchmarks working:
-- git: https://github.com/Divesh-Otwani/foundation.git
-  commit: ad709f41a8c4671f2f96fdf9c93cd62d3e7bca9f
-  subdirs:
-    - basement
-# https://github.com/hedgehogqa/haskell-hedgehog/pull/392
-- git: https://github.com/utdemir/haskell-hedgehog.git
-  commit: c98aa9e33bf6871098d6f4ac94eeaac10383d696
-  subdirs:
-    - hedgehog
-# https://github.com/sol/doctest/pull/272
-- git: https://github.com/utdemir/doctest.git
-  commit: 090cccaf12c5643ca80f8c2afe693a488277d365
+- doctest-0.18.1
 
 nix:
   enable: true

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,5 @@
 resolver: lts-17.11
 compiler: ghc-9.0.1
-allow-newer: true
 system-ghc: true
 
 packages:


### PR DESCRIPTION
Our dependencies has catched up to GHC 9, and we do need any of our forks now.

This PR updates stackage resolver and removes the overrides on cabal.project and stack.yaml.
