### PR TITLE
Use safer Vector.fromArray

### DIFF
--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -104,7 +104,7 @@ library
     storable-tuple,
     text,
     transformers,
-    vector,
+    vector >= 0.12.2,
     primitive
   default-language: Haskell2010
 

--- a/src/Data/Array/Mutable/Linear/Internal.hs
+++ b/src/Data/Array/Mutable/Linear/Internal.hs
@@ -43,10 +43,8 @@ import Data.Array.Mutable.Unlifted.Linear (Array#)
 import qualified Data.Array.Mutable.Unlifted.Linear as Unlifted
 import qualified Data.Functor.Linear as Data
 import qualified Data.Vector as Vector
-import qualified Data.Vector.Mutable as MVector
 import Prelude.Linear ((&), forget)
 import qualified Data.Primitive.Array as Prim
-import System.IO.Unsafe (unsafeDupablePerformIO)
 import Prelude hiding (read, map)
 
 -- # Data types
@@ -202,15 +200,7 @@ slice from targetSize arr =
 -- 'vector' package).
 freeze :: Array a %1-> Ur (Vector.Vector a)
 freeze (Array arr) =
-  Unlifted.freeze go arr
- where
-   go arr = unsafeDupablePerformIO $ do
-     mut <- Prim.unsafeThawArray (Prim.Array arr)
-     let mv = MVector.MVector 0 (Prim.sizeofMutableArray mut) mut
-     Vector.unsafeFreeze mv
-   -- We only need to do above because 'Vector' constructor is hidden.
-   -- Once it is exposed, we should be able to replace it with something
-   -- safer like: `go arr = Vector 0 (sizeof arr) arr`
+  Unlifted.freeze (\a -> Vector.fromArray (Prim.Array a)) arr
 
 map :: (a -> b) -> Array a %1-> Array b
 map f (Array arr) = Array (Unlifted.map f arr)


### PR DESCRIPTION
Closes #214.

Turns out there is [a recent addition](https://hackage.haskell.org/package/vector-0.12.3.0/docs/Data-Vector.html#v:fromArray) to `vector` library since version `0.12.2.0`:

```
fromArray :: Data.Primitive.Array a -> Vector a
```

This is very close to what we were looking for, so this PR uses that to simplify our `Data.Array.Mutable.Linear.freeze` function.

I also added a lower bound to `vector` package to ensure that we don't get an old one.