### PR TITLE
Simplify 'seq' for performance

### DIFF
--- a/src/Prelude/Linear/Internal.hs
+++ b/src/Prelude/Linear/Internal.hs
@@ -1,5 +1,5 @@
 -- | This is a very very simple prelude, which doesn't depend on anything else
--- in the linear-base library (except possibly "Unsafe.Linear").
+-- in the linear-base library.
 
 {-# OPTIONS_HADDOCK hide #-}
 {-# LANGUAGE LambdaCase #-}
@@ -9,8 +9,6 @@
 
 module Prelude.Linear.Internal where
 
-import qualified Prelude as Prelude
-import qualified Unsafe.Linear as Unsafe
 import Data.Functor.Identity
 
 -- A note on implementation: to avoid silly mistakes, very easy functions are
@@ -41,7 +39,7 @@ asTypeOf = const
 -- to consume @x@ when the resulting computation is consumed. Therefore, @seq@
 -- cannot be linear in it's first argument.
 seq :: a -> b %q-> b
-seq x y = Unsafe.toLinear (Prelude.seq x) y
+seq !_ y = y
 
 ($!) :: (a %p-> b) %q-> a %p-> b
 ($!) f !a = f a


### PR DESCRIPTION
This simple change both looks nicer, and also speeds up
one of my (yet unpublished) local benchmarks considerably.

I think calling `toLinear` is very costly, since the `coerce`
does not inline and the parameter to it ends up being an allocation.
Surely my terminology here is not quite right, and I would love to
know more about how the `coerce` is handled on the simplifier and
core prep, so please do correct me.