### PR TITLE
Add linear mutable array benchmarks

### DIFF
--- a/bench/Data/Mutable/Array.hs
+++ b/bench/Data/Mutable/Array.hs
@@ -1,0 +1,98 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE NumericUnderscores #-}
+
+module Data.Mutable.Array (benchmarks) where
+
+import Gauge
+import Data.Function ((&))
+import qualified Data.Unrestricted.Linear as Linear
+import Data.List (foldl')
+import qualified Prelude.Linear as Linear
+
+import qualified Data.Array.Mutable.Linear as Array.Linear
+import qualified Data.Vector
+
+
+arr_size :: Int
+arr_size = 10_000_000
+
+benchmarks :: Benchmark
+benchmarks = bgroup "arrays"
+  [ runImpls "map" bMap arr_size
+  , runImpls "reads" bReads arr_size
+  ]
+
+--------------------------------------------------------------------------------
+
+data Impls =
+  Impls
+    (Array.Linear.Array Int %1-> ())
+    (Data.Vector.Vector Int -> ())
+
+runImpls :: String -> Impls -> Int -> Benchmark
+runImpls name impls size =
+  let Impls linear dataVector = impls
+  in bgroup name
+       [ bench "Data.Array.Mutable.Linear" $ whnf (runLinear linear) size
+       , bench "Data.Vector" $ whnf (runDataVector dataVector) size
+       ]
+ where
+  runLinear :: (Array.Linear.Array Int %1-> ()) -> Int -> ()
+  runLinear cb sz = Linear.unur (Array.Linear.alloc sz 0 (\a -> Linear.move (cb a)))
+
+  runDataVector :: (Data.Vector.Vector Int -> ()) -> Int -> ()
+  runDataVector cb sz = cb (Data.Vector.replicate sz 0)
+
+--------------------------------------------------------------------------------
+
+bMap :: Impls
+bMap = Impls linear dataVector
+  where
+   linear :: Array.Linear.Array Int %1-> ()
+   linear hm =
+     hm
+       Linear.& Array.Linear.map (+1)
+       Linear.& Array.Linear.toList
+       Linear.& Linear.lift (foldl' (+) 0)
+       Linear.& Linear.unur
+       Linear.& (`Linear.lseq` ())
+
+   dataVector :: Data.Vector.Vector Int -> ()
+   dataVector hm =
+     hm
+       & Data.Vector.map (+1)
+       & Data.Vector.toList
+       & foldl' (+) 0
+       & (`seq` ())
+{-# NOINLINE bMap #-}
+
+bReads :: Impls
+bReads = Impls linear dataVector
+  where
+   linear :: Array.Linear.Array Int %1-> ()
+   linear hm =
+     hm
+       Linear.& Array.Linear.size
+       Linear.& \(Linear.Ur sz, arr) -> arr
+       Linear.& go 0 sz
+    where
+     go :: Int -> Int -> Array.Linear.Array Int %1-> ()
+     go start end arr
+       | start < end =
+           Array.Linear.unsafeGet start arr
+             Linear.& \(Linear.Ur i, arr') -> i `Linear.seq` go (start + 1) end arr'
+       | otherwise = arr `Linear.lseq` ()
+
+   dataVector :: Data.Vector.Vector Int -> ()
+   dataVector v =
+     let sz = Data.Vector.length v
+      in go 0 sz
+    where
+     go :: Int -> Int -> ()
+     go start end
+       | start < end =
+           (v Data.Vector.! start) `seq`  go (start + 1) end
+       | otherwise = ()
+{-# NOINLINE bReads #-}

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -2,11 +2,13 @@ module Main where
 
 import Gauge
 import Data.Mutable.HashMap (hmbench, getHMInput)
+import qualified Data.Mutable.Array as Array
 
 main :: IO ()
 main = do
   hmInput <- getHMInput
   defaultMain
     [ hmbench hmInput
+    , Array.benchmarks
     ]
 

--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -107,6 +107,7 @@ library
     transformers,
     vector >= 0.12.2,
     primitive
+  ghc-options: -O
   default-language: Haskell2010
 
 test-suite test
@@ -163,8 +164,10 @@ benchmark mutable-data
   main-is: Main.hs
   other-modules:
     Data.Mutable.HashMap
+    Data.Mutable.Array
   build-depends:
     base,
+    vector,
     deepseq,
     gauge,
     hashtables,
@@ -173,7 +176,7 @@ benchmark mutable-data
     random,
     random-shuffle,
     unordered-containers
-  ghc-options: -rtsopts=ignore
+  ghc-options: -O
   default-language: Haskell2010
 
 -- TODO: Uncomment below block and set 'build-type' to 'Custom' to enable


### PR DESCRIPTION
Slightly more details on issue #328.

I only spent time on `reads` benchmark, which creates an array
and iterates on it. On a recent GHC HEAD (`378c0bba7d`), here're
the current results:

```
$ cabal bench --benchmark-options 'arrays/reads'
...
benchmarked arrays/reads/Data.Array.Mutable.Linear
time                 191.7 ms   (185.3 ms .. 195.9 ms)
                     0.999 R²   (0.997 R² .. 1.000 R²)
mean                 213.9 ms   (206.2 ms .. 226.2 ms)
std dev              16.61 ms   (9.796 ms .. 25.32 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarked arrays/reads/Data.Vector
time                 58.77 ms   (58.64 ms .. 58.88 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 67.59 ms   (64.36 ms .. 75.56 ms)
std dev              8.991 ms   (3.925 ms .. 14.61 ms)
variance introduced by outliers: 48% (moderately inflated)
```

The benchmark methodology is not ideal, since all benchmarks include
creation of the underlying array/vector. The reason is that the `gauge`
library we are using for benchmarks is not implemented with linear
arrows so we can not use its API easily to pass a linear value to a
benchmark. There might be a way to work around this implementation using
`gauge` (or another benchmarking library), but I didn't spend too much
time on it.