### PR TITLE
No cabal-doctest in Setup.hs

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,6 +1,2 @@
-module Main where
-
-import Distribution.Extra.Doctest (defaultMainWithDoctests)
-
-main :: IO ()
-main = defaultMainWithDoctests "doctests"
+import Distribution.Simple
+main = defaultMain


### PR DESCRIPTION
This allows projects to depend on linear-types without depending on cabal-doctest