### PR TITLE
Various HashMap optimisations

### DIFF
--- a/src/Data/HashMap/Mutable/Linear/Internal.hs
+++ b/src/Data/HashMap/Mutable/Linear/Internal.hs
@@ -87,7 +87,7 @@ type RobinArr k v = Array (Maybe (RobinVal k v))
 
 -- | Robin values are triples of the key, value and PSL
 -- (the probe sequence length).
-data RobinVal k v = RobinVal {-# UNPACK #-} !PSL k v
+data RobinVal k v = RobinVal !PSL !k v
   deriving (Show)
 
 incRobinValPSL :: RobinVal k v -> RobinVal k v

--- a/src/Data/HashMap/Mutable/Linear/Internal.hs
+++ b/src/Data/HashMap/Mutable/Linear/Internal.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE LinearTypes #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StrictData #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UnliftedNewtypes #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
@@ -75,9 +74,9 @@ data HashMap k v where
   -- - array is non-empty
   -- - (count / capacity) <= constMaxLoadFactor.
   HashMap
-    :: Int -- ^ The number of stored (key, value) pairs.
-    -> RobinArr k v -- ^ Underlying array.
+    :: !Int -- ^ The number of stored (key, value) pairs.
     -> !Int -- ^ Capacity of the underlying array (cached here)
+    -> !(RobinArr k v) -- ^ Underlying array.
     %1-> HashMap k v
 
 -- | An array of Robin values

--- a/src/Data/HashMap/Mutable/Linear/Internal.hs
+++ b/src/Data/HashMap/Mutable/Linear/Internal.hs
@@ -202,6 +202,7 @@ alterF f key hm =
               ((ix + 1) `mod` cap)
               (incRobinValPSL evicted)
              & growMapIfNecessary
+{-# INLINE alterF #-}
 
 -- aspiwack: I'm implementing `alter` in terms of `alterF`, because, at this
 -- point, we may have some bug fixes and so on and so forth. And maintaining two
@@ -217,6 +218,7 @@ alter f key hm = runIdentity $ alterF (\v -> Identity (Ur (f v))) key hm
   where
     runIdentity :: Identity a %1-> a
     runIdentity (Identity x) = x
+{-# INLINE alter #-}
 
 -- | Insert a key value pair to a 'HashMap'. It overwrites the previous
 -- value if it exists.


### PR DESCRIPTION
Just some minor optimisations for our HashMap implementation. It contains
a few unrelated small changes, so reviewing each individual commit might
be easier.

When I compare this against `Data.HashMap.Strict`, the results change based
on the input (likely based on the hash distribution of the key). I need to investigate
this more. Just as reference, here're the functions I am comparing (`Key` is just a
newtype wrapper around `Int`):

```
   linear :: [Key] -> HashMap.Linear.HashMap Key () %1-> ()
   linear inp hm = go inp hm `Linear.lseq` ()
    where
     go :: [Key] -> HashMap.Linear.HashMap Key () %1-> HashMap.Linear.HashMap Key ()
     go [] h = h
     go (x:xs) h = go xs Linear.$! HashMap.Linear.insert x () h

   dataHashMap :: [Key] -> Data.HashMap.Strict.HashMap Key () -> ()
   dataHashMap inp hm = go inp hm `seq` ()
    where
     go :: [Key] -> Data.HashMap.Strict.HashMap Key () -> Data.HashMap.Strict.HashMap Key ()
     go [] h = h
     go (x:xs) h = go xs $! Data.HashMap.Strict.insert x () h
```

I did not include the benchmark on this PR, since it looks a bit different
than our existing HashMap benchmarks. I have to combine them together at
one point.