### PR TITLE
Force resolving test dependencies on cabal

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,6 @@
 packages: *.cabal
 
+tests: true
+
 package linear-base
   ghc-options: -Wall -Werror


### PR DESCRIPTION
For some reason [we started getting](https://github.com/tweag/linear-base/runs/3372126892):

```
cabal: Cannot test the package linear-base-0.1.1 because none of the
components are available to build: the test suite 'test' and the test suite
'examples' are not available because the solver did not find a plan that
included the test suites. Force the solver to enable this for all packages by
adding the line 'tests: True' to the 'cabal.project.local' file.
```

On the CI, even on our branches without any build system related changes. It's not clear to my why is this happening, but the only mutable thing I can think of is the Hackage index, so probably a version of a package is released and that is confusing cabal. 

Anyhow, adding `tests: true` to `cabal.project` as suggested seems to fix the issue. I added it to `cabal.project` instead of `cabal.project.local` because I don't see why anyone developing linear-base wouldn't want the tests. 

Alternatives I can think of:

* We can leave `cabal.project` as is, and pass `--enable-test` to `cabal` invocations which does the same thing.
* We can figure out why the solver is not able to figure things out and try to fix that with adding version bounds; but it's not clear to me if this is better or how to do this.