### PR TITLE
Run CI on PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,5 @@
 name: Continuous integration
-on: [push]
+on: [push, pull_request]
 env:
   # Bump this number to invalidate the Github-actions cache
   cache-invalidation-key: 0


### PR DESCRIPTION
With just `push`, CI doesn't run on third party PRs.