### PR TITLE
Changing (>>) in monad to accept consumable first inputs

### DIFF
--- a/src/Control/Functor/Linear/Internal/Class.hs
+++ b/src/Control/Functor/Linear/Internal/Class.hs
@@ -119,8 +119,8 @@ class Applicative m => Monad m where
   -- | @x >>= g@ applies a /linear/ function @g@ linearly (i.e., using it
   -- exactly once) on the value of type @a@ inside the value of type @m a@
   (>>=) :: m a %1-> (a %1-> m b) %1-> m b
-  (>>) :: m () %1-> m a %1-> m a
-  m >> k = m >>= (\() -> k)
+  (>>) :: (Consumable a) => m a %1-> m b %1-> m b
+  m >> k = m >>= ((\() -> k) . consume)
 
 -- | This class handles pattern-matching failure in do-notation.
 -- See "Control.Monad.Fail" for details.


### PR DESCRIPTION
Currently (>>) has type m () %1-> m b %1-> m b .

This can easily be generalized to (Consumable a) =>  m a %1-> m b %1-> m b  .

This change would make (>>) more similar to the nonlinear prelude and much more ergonomic to work with in effectful code. But it would technically break backwards compatibility for anyone who explicitly implemented (>>) on their types by making it more constraining, since they'd have to revert to using the default impl or sprinkle a consume somewhere.

As far as disadvantages go, I guess it might also make the library less explicit by adding the implicit consume? So in that sense there may be a tradeoff between ergonomics and being explicit.