### PR TITLE
Improve `make`/`Make` implementation for `Data.V.Linear`

### DIFF
--- a/src/Data/V/Linear.hs
+++ b/src/Data/V/Linear.hs
@@ -24,9 +24,8 @@
 --  isTrue :: Bool
 --  isTrue = V.elim doSomething (build 4 9)
 --    where
---      -- GHC can't figure out this type equality, so this is needed.
 --      build :: Int %1-> Int %1-> V.V 2 Int
---      build = V.make @2 @Int
+--      build = V.make
 -- :}
 --
 -- A much more expensive library of vectors of known size (including matrices
@@ -48,8 +47,8 @@ module Data.V.Linear
     fromReplicator,
     dupV,
     theLength,
+    Make,
     make,
-    FunN,
   )
 where
 


### PR DESCRIPTION
`V n a` represents vector having `n` elements of type `a`. Such a vector can be built using the `make` function, taking `n` linear arguments of type `a`, and returning a `V n a`.

At the moment, `make` uses a lot of type-level machinery around `Nat`s, and is implemented in a way such that it cannot be inlined; even if `n` is compile-time known.

With https://github.com/tweag/linear-base/pull/360 (now merged), the `Data.V.Linear` module has been overhauled, and the `elim` function has been rewritten to be inlinable.

The aim of this PR is to provide an efficient `make` implementation using typeclasses so as to make it inlinable when `n` is known at compile-time. It also adds more symmetry between `make` and `elim`, and allows us to get rid of a lot of internal helper functions.
