### PR TITLE
Add warnings to the cabal file

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -6,5 +6,9 @@ set -e
 export LANG="C.UTF-8"
 
 stack build ormolu
-cabal format
+## We can't format cabal at the moment because `cabal format` inlines
+## common stanzas, which is very much something that we don't want. See
+## https://github.com/haskell/cabal/issues/5734
+#
+# cabal format
 stack exec ormolu -- -m inplace $(find . -type f -name "*.hs-boot" -o -name "*.hs")

--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -1,4 +1,4 @@
-cabal-version:      >=1.10
+cabal-version:      3.0
 name:               linear-base
 version:            0.1.1
 license:            MIT
@@ -21,7 +21,13 @@ source-repository head
     type:     git
     location: https://github.com/tweag/linear-base
 
+common warnings
+    ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wnoncanonical-monad-instances
+                 -- Additional warnings we may consider adding:
+                 -- * -Wredundant-constraints : would need deactivating in the modules which use Nat
+
 library
+    import: warnings
     exposed-modules:
         Control.Monad.IO.Class.Linear
         Control.Functor.Linear
@@ -109,6 +115,7 @@ library
     default-language: Haskell2010
     ghc-options:      -O
     build-depends:
+
         base >=4.15 && <5,
         containers,
         ghc-prim,
@@ -120,6 +127,7 @@ library
         primitive
 
 test-suite test
+    import: warnings
     type:             exitcode-stdio-1.0
     main-is:          Main.hs
     hs-source-dirs:   test
@@ -148,6 +156,7 @@ test-suite test
         vector
 
 test-suite examples
+    import: warnings
     type:             exitcode-stdio-1.0
     main-is:          Main.hs
     hs-source-dirs:   examples
@@ -174,6 +183,7 @@ test-suite examples
         text
 
 benchmark mutable-data
+    import: warnings
     type:             exitcode-stdio-1.0
     main-is:          Main.hs
     hs-source-dirs:   bench

--- a/test/Test/Data/Mutable/Vector.hs
+++ b/test/Test/Data/Mutable/Vector.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE LinearTypes #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# OPTIONS_GHC -Wno-name-shadowing #-}
+{-# OPTIONS_GHC -Wno-name-shadowing -Wno-incomplete-uni-patterns #-}
 
 -- |
 -- Tests for mutable vectors.


### PR DESCRIPTION
This helps, in particular, when developping with ghcid, which
otherwise doesn't raise warnings.

I've had to deactivate `cabal` format in the formatting script due to
the fact that it inlines `common` stanzas, which I'm using to ensure
consistent warning settings in every target. See
[haskell/cabal#5734](https://github.com/haskell/cabal/issues/5734).

---

I've written this while I was trying to do something smart with the
`Elim` and `Make` type classes. It didn't work. So there won't be a
followup PR, but this one is worth it on its own, I think.