### PR TITLE
`Semigroup` and `Monoid` overhaul

### DIFF
--- a/examples/Generic/Traverse.hs
+++ b/examples/Generic/Traverse.hs
@@ -36,10 +36,10 @@ pairTest =
   testProperty "traverse via genericTraverse with WithLog and Pair" $
     property $
       ( Data.traverse
-          (\x -> (Adding (1 :: Int), 2 * x))
+          (\x -> (Sum (1 :: Int), 2 * x))
           (MkPair 3 4 :: Pair Int)
       )
-        === (Adding 2, (MkPair 6 8))
+        === (Sum 2, (MkPair 6 8))
 
 genericTraverseTests :: TestTree
 genericTraverseTests =

--- a/src/Control/Optics/Linear/Internal.hs
+++ b/src/Control/Optics/Linear/Internal.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE LinearTypes #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeOperators #-}
@@ -170,8 +171,10 @@ build (Optical l) x = Linear.runCoKleisli (l (Linear.CoKleisli getConst')) (Cons
 getConst' :: Const a b %1 -> a
 getConst' (Const x) = x
 
-lengthOf :: MultIdentity r => Optic_ (NonLinear.Kleisli (Const (Adding r))) s t a b -> s -> r
-lengthOf l s = getAdded (gets l (const (Adding one)) s)
+lengthOf :: MultIdentity r => Optic_ (NonLinear.Kleisli (Const (Sum r))) s t a b -> s -> r
+lengthOf l s =
+  (gets l (const (Sum one)) s) & \case
+    Sum r -> r
 
 -- XXX: the below two functions will be made redundant with multiplicity
 -- polymorphism on over and traverseOfU

--- a/src/Data/List/Linear.hs
+++ b/src/Data/List/Linear.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE LinearTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -- |
 -- Linear versions of 'Data.List' functions.
@@ -374,3 +375,16 @@ unzip = Unsafe.toLinear NonLinear.unzip
 
 unzip3 :: [(a, b, c)] %1 -> ([a], [b], [c])
 unzip3 = Unsafe.toLinear NonLinear.unzip3
+
+-- # Instances
+--------------------------------------------------
+
+instance Semigroup (NonEmpty a) where
+  (x :| xs) <> (y :| ys) = x :| (xs ++ (y : ys))
+
+instance Semigroup [a] where
+  (<>) = (++)
+  {-# INLINE (<>) #-}
+
+instance Monoid [a] where
+  mempty = []

--- a/src/Data/Monoid/Linear/Internal/Monoid.hs
+++ b/src/Data/Monoid/Linear/Internal/Monoid.hs
@@ -1,9 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LinearTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# OPTIONS_HADDOCK hide #-}
@@ -16,20 +14,38 @@ module Data.Monoid.Linear.Internal.Monoid
   ( -- * Monoid operations
     Monoid (..),
     mconcat,
+    mappend,
+    -- Cannot export Data.Monoid.{First,Last} because of the name clash with Data.Semigroup.{First,Last}
   )
 where
 
+import Data.Functor.Compose (Compose (Compose))
+import qualified Data.Functor.Compose as Functor
+import Data.Functor.Const (Const)
+import Data.Functor.Identity (Identity (Identity))
+import Data.Functor.Product (Product (Pair))
+import qualified Data.Functor.Product as Functor
+import qualified Data.Monoid as Monoid
 import Data.Monoid.Linear.Internal.Semigroup
+import Data.Ord (Down (Down))
+import Data.Proxy (Proxy (Proxy))
+import Data.Unrestricted.Linear.Internal.Consumable (Consumable)
 import GHC.Types hiding (Any)
 import Prelude.Linear.Internal
+import Prelude (Maybe (Nothing))
 import qualified Prelude
 
 -- | A linear monoid is a linear semigroup with an identity on the binary
 -- operation.
-class (Semigroup a, Prelude.Monoid a) => Monoid a where
-  {-# MINIMAL #-}
+--
+-- Laws (same as 'Data.Monoid.Monoid'):
+--   * ∀ x ∈ G, x <> mempty = mempty <> x = x
+class Semigroup a => Monoid a where
+  {-# MINIMAL mempty #-}
   mempty :: a
-  mempty = Prelude.mempty
+
+instance (Prelude.Semigroup a, Monoid a) => Prelude.Monoid (NonLinear a) where
+  mempty = NonLinear mempty
 
 -- convenience redefine
 
@@ -40,6 +56,9 @@ mconcat (xs' :: [a]) = go mempty xs'
     go acc [] = acc
     go acc (x : xs) = go (acc <> x) xs
 
+mappend :: Monoid a => a %1 -> a %1 -> a
+mappend = (<>)
+
 ---------------
 -- Instances --
 ---------------
@@ -47,17 +66,78 @@ mconcat (xs' :: [a]) = go mempty xs'
 instance Prelude.Monoid (Endo a) where
   mempty = Endo id
 
-instance Monoid (Endo a)
+-- Instances below are listed in the same order as in https://hackage.haskell.org/package/base-4.16.0.0/docs/Data-Monoid.html
 
-instance Monoid ()
+instance Monoid All where
+  mempty = All True
 
-instance (Monoid a, Monoid b) => Monoid (a, b)
-
-instance Monoid a => Monoid (Dual a)
-
-instance Monoid All
-
-instance Monoid Any
+instance Monoid Any where
+  mempty = Any False
 
 instance Monoid Ordering where
   mempty = EQ
+
+instance Monoid () where
+  mempty = ()
+
+instance Monoid a => Monoid (Identity a) where
+  mempty = Identity mempty
+
+instance Consumable a => Monoid (Monoid.First a) where
+  mempty = Monoid.First Nothing
+
+instance Consumable a => Monoid (Monoid.Last a) where
+  mempty = Monoid.Last Nothing
+
+instance Monoid a => Monoid (Down a) where
+  mempty = Down mempty
+
+-- Cannot add instance (Ord a, Bounded a) => Monoid (Max a); would require (NonLinear.Ord a, Consumable a)
+-- Cannot add instance (Ord a, Bounded a) => Monoid (Min a); would require (NonLinear.Ord a, Consumable a)
+
+instance Monoid a => Monoid (Dual a) where
+  mempty = Dual mempty
+
+instance Monoid (Endo a) where
+  mempty = Endo id
+
+-- See Data.Num.Linear for instance ... => Monoid (Product a)
+-- See Data.Num.Linear for instance ... => Monoid (Sum a)
+-- See System.IO.Linear for instance ... => Monoid (IO a)
+-- See System.IO.Resource.Internal for instance ... => Monoid (RIO a)
+
+instance Monoid a => Monoid (Maybe a) where
+  mempty = Nothing
+
+-- See Data.List.Linear for instance ... => Monoid [a]
+-- Cannot add instance Monoid a => Monoid (Op a b); would require Dupable b
+
+instance Monoid (Proxy a) where
+  mempty = Proxy
+
+-- Cannot add instance Monoid a => Monoid (ST s a); I think that it would require a linear ST monad
+-- Cannot add instance Monoid b => Monoid (a -> b); would require Dupable a
+
+instance (Monoid a, Monoid b) => Monoid (a, b) where
+  mempty = (mempty, mempty)
+
+instance Monoid a => Monoid (Const a b) where
+  mempty = mempty
+
+-- See Data.Functor.Linear.Applicative for instance ... => Monoid (Ap f a)
+-- Cannot add instance Alternative f => Monoid (Alt f a); we don't have a linear Alternative
+
+instance (Monoid a, Monoid b, Monoid c) => Monoid (a, b, c) where
+  mempty = (mempty, mempty, mempty)
+
+instance (Monoid (f a), Monoid (g a)) => Monoid (Functor.Product f g a) where
+  mempty = Pair mempty mempty
+
+instance (Monoid a, Monoid b, Monoid c, Monoid d) => Monoid (a, b, c, d) where
+  mempty = (mempty, mempty, mempty, mempty)
+
+instance Monoid (f (g a)) => Monoid (Functor.Compose f g a) where
+  mempty = Compose mempty
+
+instance (Monoid a, Monoid b, Monoid c, Monoid d, Monoid e) => Monoid (a, b, c, d, e) where
+  mempty = (mempty, mempty, mempty, mempty, mempty)

--- a/src/Data/Monoid/Linear/Internal/Semigroup.hs
+++ b/src/Data/Monoid/Linear/Internal/Semigroup.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE LinearTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# OPTIONS_HADDOCK hide #-}
 
@@ -15,30 +15,55 @@ module Data.Monoid.Linear.Internal.Semigroup
     -- * Endo
     Endo (..),
     appEndo,
+
+    -- * NonLinear newtype
     NonLinear (..),
-    module Data.Semigroup,
+
+    -- * Data.Semigroup reexports
+    All (..),
+    Any (..),
+    First (..),
+    Last (..),
+    Dual (..),
+    Sum (..),
+    Product (..),
   )
 where
 
-import Data.Semigroup hiding (Endo (..), Semigroup (..))
+import qualified Data.Functor.Compose as Functor
+import Data.Functor.Const (Const (..))
+import Data.Functor.Identity (Identity (..))
+import qualified Data.Functor.Product as Functor
+import qualified Data.Monoid as Monoid
+import Data.Ord (Down (..))
+import Data.Proxy (Proxy (..))
+import Data.Semigroup
+  ( All (..),
+    Any (..),
+    Dual (..),
+    First (..),
+    Last (..),
+    Product (..),
+    Sum (..),
+  )
 import qualified Data.Semigroup as Prelude
+import Data.Unrestricted.Linear.Internal.Consumable (Consumable, lseq)
+import Data.Void (Void)
+import GHC.Tuple
 import GHC.Types hiding (Any)
 import Prelude.Linear.Internal
+import Prelude (Either (..), Maybe (..))
 
 -- | A linear semigroup @a@ is a type with an associative binary operation @<>@
 -- that linearly consumes two @a@s.
-class Prelude.Semigroup a => Semigroup a where
+--
+-- Laws (same as 'Data.Semigroup.Semigroup'):
+--   * ∀ x ∈ G, y ∈ G, z ∈ G, x <> (y <> z) = (x <> y) <> z
+class Semigroup a where
   (<>) :: a %1 -> a %1 -> a
   infixr 6 <> -- same fixity as base.<>
 
----------------
--- Instances --
----------------
-
-instance Semigroup () where
-  () <> () = ()
-
--- | An @Endo a@ is just a linear function of type @a %1-> a@.
+-- | An @'Endo' a@ is just a linear function of type @a %1-> a@.
 -- This has a classic monoid definition with 'id' and '(.)'.
 newtype Endo a = Endo (a %1 -> a)
   deriving (Prelude.Semigroup) via NonLinear (Endo a)
@@ -50,14 +75,21 @@ newtype Endo a = Endo (a %1 -> a)
 appEndo :: Endo a %1 -> a %1 -> a
 appEndo (Endo f) = f
 
-instance Semigroup (Endo a) where
-  Endo f <> Endo g = Endo (f . g)
+-- | @DerivingVia@ combinator for 'Prelude.Semigroup' (resp. 'Prelude.Monoid')
+-- given linear 'Semigroup' (resp. 'Monoid').
+--
+-- > newtype Endo a = Endo (a %1-> a)
+-- >   deriving (Prelude.Semigroup) via NonLinear (Endo a)
+newtype NonLinear a = NonLinear a
 
-instance (Semigroup a, Semigroup b) => Semigroup (a, b) where
-  (a, x) <> (b, y) = (a <> b, x <> y)
+---------------
+-- Instances --
+---------------
 
-instance Semigroup a => Semigroup (Dual a) where
-  Dual x <> Dual y = Dual (y <> x)
+instance Semigroup a => Prelude.Semigroup (NonLinear a) where
+  NonLinear a <> NonLinear b = NonLinear (a <> b)
+
+-- Instances below are listed in the same order as in https://hackage.haskell.org/package/base-4.16.0.0/docs/Data-Semigroup.html
 
 instance Semigroup All where
   All False <> All False = All False
@@ -71,16 +103,8 @@ instance Semigroup Any where
   Any True <> Any False = Any True
   Any True <> Any True = Any True
 
--- | DerivingVia combinator for Prelude.Semigroup given (linear) Semigroup.
--- For linear monoids, you should supply a Prelude.Monoid instance and either
--- declare an empty Monoid instance, or use DeriveAnyClass. For example:
---
--- > newtype Endo a = Endo (a %1-> a)
--- >   deriving (Prelude.Semigroup) via NonLinear (Endo a)
-newtype NonLinear a = NonLinear a
-
-instance Semigroup a => Prelude.Semigroup (NonLinear a) where
-  NonLinear a <> NonLinear b = NonLinear (a <> b)
+instance Semigroup Void where
+  (<>) = \case {}
 
 instance Semigroup Ordering where
   LT <> LT = LT
@@ -91,5 +115,95 @@ instance Semigroup Ordering where
   GT <> GT = GT
   GT <> EQ = GT
 
--- We can not use `lseq` above because of an import loop.
--- So it's easier to just expand the cases here.
+instance Semigroup () where
+  () <> () = ()
+
+instance Semigroup a => Semigroup (Identity a) where
+  Identity x <> Identity y = Identity (x <> y)
+
+instance Consumable a => Semigroup (Monoid.First a) where
+  (Monoid.First Nothing) <> y = y
+  x <> (Monoid.First y) =
+    y & \case
+      Nothing -> x
+      Just y' -> y' `lseq` x
+
+instance Consumable a => Semigroup (Monoid.Last a) where
+  x <> (Monoid.Last Nothing) = x
+  (Monoid.Last x) <> y =
+    x & \case
+      Nothing -> y
+      Just x' -> x' `lseq` y
+
+instance Semigroup a => Semigroup (Down a) where
+  (Down x) <> (Down y) = Down (x <> y)
+
+instance Consumable a => Semigroup (First a) where
+  x <> (First y) = y `lseq` x
+
+instance Consumable a => Semigroup (Last a) where
+  (Last x) <> y = x `lseq` y
+
+-- Cannot add instance Ord a => Semigroup (Max a); would require (NonLinear.Ord a, Consumable a)
+-- Cannot add instance Ord a => Semigroup (Min a); would require (NonLinear.Ord a, Consumable a)
+
+instance Semigroup a => Semigroup (Dual a) where
+  Dual x <> Dual y = Dual (y <> x)
+
+instance Semigroup (Endo a) where
+  Endo f <> Endo g = Endo (f . g)
+
+-- See Data.Num.Linear for instance ... => Semigroup (Product a)
+-- See Data.Num.Linear for instance ... => Semigroup (Sum a)
+-- See System.IO.Linear for instance ... => Semigroup (IO a)
+-- See System.IO.Resource.Internal for instance ... => Semigroup (RIO a)
+-- See Data.List.Linear for instance ... => Semigroup (NonEmpty a)
+
+instance Semigroup a => Semigroup (Maybe a) where
+  x <> Nothing = x
+  Nothing <> y = y
+  Just x <> Just y = Just (x <> y)
+
+instance Semigroup a => Semigroup (Solo a) where
+  Solo x <> Solo y = Solo (x <> y)
+
+-- See Data.List.Linear for instance ... => Semigroup [a]
+
+instance (Consumable a, Consumable b) => Semigroup (Either a b) where
+  Left x <> y = x `lseq` y
+  x <> y =
+    y & \case
+      Left y' -> y' `lseq` x
+      Right y' -> y' `lseq` x
+
+-- Cannot add instance Semigroup a => Semigroup (Op a b); would require Dupable b
+
+instance Semigroup (Proxy a) where
+  Proxy <> Proxy = Proxy
+
+-- Cannot add instance Semigroup a => Semigroup (ST s a); I think that it would require a linear ST monad
+-- Cannot add instance Semigroup b => Semigroup (a -> b); would require Dupable a
+
+instance (Semigroup a, Semigroup b) => Semigroup (a, b) where
+  (x1, x2) <> (y1, y2) = (x1 <> y1, x2 <> y2)
+
+instance Semigroup a => Semigroup (Const a b) where
+  Const x <> Const y = Const (x <> y)
+
+-- See Data.Functor.Linear.Applicative for instance ... => Semigroup (Ap f a)
+-- Cannot add instance Alternative f => Semigroup (Alt f a); we don't have a linear Alternative
+
+instance (Semigroup a, Semigroup b, Semigroup c) => Semigroup (a, b, c) where
+  (x1, x2, x3) <> (y1, y2, y3) = (x1 <> y1, x2 <> y2, x3 <> y3)
+
+instance (Semigroup (f a), Semigroup (g a)) => Semigroup (Functor.Product f g a) where
+  Functor.Pair x1 x2 <> Functor.Pair y1 y2 = Functor.Pair (x1 <> y1) (x2 <> y2)
+
+instance (Semigroup a, Semigroup b, Semigroup c, Semigroup d) => Semigroup (a, b, c, d) where
+  (x1, x2, x3, x4) <> (y1, y2, y3, y4) = (x1 <> y1, x2 <> y2, x3 <> y3, x4 <> y4)
+
+instance (Semigroup (f (g a))) => Semigroup (Functor.Compose f g a) where
+  Functor.Compose x <> Functor.Compose y = Functor.Compose (x <> y)
+
+instance (Semigroup a, Semigroup b, Semigroup c, Semigroup d, Semigroup e) => Semigroup (a, b, c, d, e) where
+  (x1, x2, x3, x4, x5) <> (y1, y2, y3, y4, y5) = (x1 <> y1, x2 <> y2, x3 <> y3, x4 <> y4, x5 <> y5)

--- a/src/Data/Num/Linear.hs
+++ b/src/Data/Num/Linear.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE LinearTypes #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | This module provides a linear 'Num' class with instances.
 -- Import this module to use linear versions of @(+)@, @(-)@, etc, on numeric
@@ -153,37 +154,59 @@ liftU2 f x y = lifted f (move x) (move y)
     lifted :: (a -> b -> c) %1 -> (Ur a %1 -> Ur b %1 -> c)
     lifted g (Ur a) (Ur b) = g a b
 
--- A newtype wrapper to give the underlying monoid for an additive structure.
+-- | A newtype wrapper to give the underlying monoid for an additive structure.
+--
+-- Deprecated because 'Data.Semigroup.Sum' (reexported as
+-- 'Data.Monoid.Linear.Sum') now has a linear 'Semigroup' and
+-- 'Data.Monoid.Linear.Monoid' instance.
 newtype Adding a = Adding a
   deriving (Prelude.Eq, Prelude.Ord, Prelude.Show)
   deriving (Prelude.Semigroup) via NonLinear (Adding a)
+  deriving (Prelude.Monoid) via NonLinear (Adding a)
+{-# DEPRECATED Adding "Use 'Data.Semigroup.Sum' (reexported as 'Data.Monoid.Linear.Sum') instead" #-}
 
 getAdded :: Adding a %1 -> a
 getAdded (Adding x) = x
+{-# DEPRECATED getAdded "Use 'Data.Semigroup.Sum' (reexported as 'Data.Monoid.Linear.Sum') and pattern-match to extract the inner value linearly" #-}
 
 instance Additive a => Semigroup (Adding a) where
   Adding a <> Adding b = Adding (a + b)
 
-instance AddIdentity a => Prelude.Monoid (Adding a) where
+instance AddIdentity a => Monoid (Adding a) where
   mempty = Adding zero
 
-instance AddIdentity a => Monoid (Adding a)
-
--- A newtype wrapper to give the underlying monoid for a multiplicative structure.
+-- | A newtype wrapper to give the underlying monoid for a multiplicative structure.
+--
+-- Deprecated because 'Data.Semigroup.Product' (reexported as
+-- 'Data.Monoid.Linear.Product') now has a linear 'Semigroup' and
+-- 'Data.Monoid.Linear.Monoid' instance.
 newtype Multiplying a = Multiplying a
   deriving (Prelude.Eq, Prelude.Ord, Prelude.Show)
   deriving (Prelude.Semigroup) via NonLinear (Multiplying a)
+  deriving (Prelude.Monoid) via NonLinear (Multiplying a)
+{-# DEPRECATED Multiplying "Use 'Data.Semigroup.Product' (reexported as 'Data.Monoid.Linear.Product') instead" #-}
 
 getMultiplied :: Multiplying a %1 -> a
 getMultiplied (Multiplying x) = x
+{-# DEPRECATED getMultiplied "Use 'Data.Semigroup.Product' (reexported as 'Data.Monoid.Linear.Product') and pattern-match to extract the inner value linearly" #-}
 
 instance Multiplicative a => Semigroup (Multiplying a) where
   Multiplying a <> Multiplying b = Multiplying (a * b)
 
-instance MultIdentity a => Prelude.Monoid (Multiplying a) where
+instance MultIdentity a => Monoid (Multiplying a) where
   mempty = Multiplying one
 
-instance MultIdentity a => Monoid (Multiplying a)
+instance Multiplicative a => Semigroup (Product a) where
+  (Product x) <> (Product y) = Product (x * y)
+
+instance Additive a => Semigroup (Sum a) where
+  (Sum x) <> (Sum y) = Sum (x + y)
+
+instance MultIdentity a => Monoid (Product a) where
+  mempty = Product one
+
+instance AddIdentity a => Monoid (Sum a) where
+  mempty = Sum zero
 
 deriving via MovableNum Prelude.Int instance Additive Prelude.Int
 

--- a/src/Data/Unrestricted/Linear/Internal/Instances.hs
+++ b/src/Data/Unrestricted/Linear/Internal/Instances.hs
@@ -354,7 +354,8 @@ instance (Movable a, Prelude.Semigroup a) => Semigroup (MovableMonoid a) where
       combine :: Prelude.Semigroup a => Ur a %1 -> Ur a %1 -> a
       combine (Ur x) (Ur y) = x Prelude.<> y
 
-instance (Movable a, Prelude.Monoid a) => Monoid (MovableMonoid a)
+instance (Movable a, Prelude.Monoid a) => Monoid (MovableMonoid a) where
+  mempty = MovableMonoid Prelude.mempty
 
 instance Consumable (ReplicationStream a) where
   consume = ReplicationStream.consume

--- a/src/System/IO/Linear.hs
+++ b/src/System/IO/Linear.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE LinearTypes #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE NoImplicitPrelude #-}
@@ -156,6 +155,12 @@ instance Control.Monad IO where
     where
       cont :: (# State# RealWorld, () #) %1 -> IO b %1 -> (# State# RealWorld, b #)
       cont (# s', () #) y' = unIO y' s'
+
+instance Semigroup a => Semigroup (IO a) where
+  (<>) = Control.liftA2 (<>)
+
+instance Monoid a => Monoid (IO a) where
+  mempty = Control.pure mempty
 
 -- $ioref
 -- @IORef@s are mutable references to values, or pointers to values.

--- a/src/System/IO/Resource/Linear/Internal.hs
+++ b/src/System/IO/Resource/Linear/Internal.hs
@@ -3,11 +3,9 @@
 -- function. Which is a good argument for having support for F#-style builders.
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE LinearTypes #-}
 {-# LANGUAGE QualifiedDo #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 {-# OPTIONS_HADDOCK hide #-}
 
@@ -22,6 +20,7 @@ import Data.IORef (IORef)
 import qualified Data.IORef as System
 import Data.IntMap.Strict (IntMap)
 import qualified Data.IntMap.Strict as IntMap
+import Data.Monoid (Ap (..))
 import Data.Text (Text)
 import qualified Data.Text.IO as Text
 import Prelude.Linear hiding (IO)
@@ -38,6 +37,7 @@ newtype ReleaseMap = ReleaseMap (IntMap (Linear.IO ()))
 -- are always released.
 newtype RIO a = RIO (IORef ReleaseMap -> Linear.IO a)
   deriving (Data.Functor, Data.Applicative) via (Control.Data RIO)
+  deriving (Semigroup, Monoid) via (Ap RIO a)
 
 unRIO :: RIO a %1 -> IORef ReleaseMap -> Linear.IO a
 unRIO (RIO action) = action


### PR DESCRIPTION
+ Break relationship between `Data.Monoid.Linear.{Semigroup,Monoid}` and their
non-linear counterparts (see https://github.com/tweag/linear-base/issues/379)
+ Add as many instances as possible for these classes (to replicate what is done
  in `base`

Closes #379. Closes #372. 