### PR TITLE
Force eta-expansion of `{Replicator,V}.elim`

### DIFF
--- a/test/Test/Data/Replicator.hs
+++ b/test/Test/Data/Replicator.hs
@@ -19,7 +19,7 @@ replicatorInspectionTests =
     [$(inspectTest $ 'elim3 === 'manualElim3)]
 
 elim3 :: (a %1 -> a %1 -> a %1 -> [a]) %1 -> Replicator a %1 -> [a]
-elim3 f r = Replicator.elim f r
+elim3 = Replicator.elim
 
 manualElim3 :: (a %1 -> a %1 -> a %1 -> [a]) %1 -> Replicator a %1 -> [a]
 manualElim3 f r =

--- a/test/Test/Data/V.hs
+++ b/test/Test/Data/V.hs
@@ -28,7 +28,7 @@ manualMake3 :: a %1 -> a %1 -> a %1 -> V 3 a
 manualMake3 x y z = V.cons x . V.cons y . V.cons z $ V.empty
 
 elim3 :: (a %1 -> a %1 -> a %1 -> [a]) %1 -> V 3 a %1 -> [a]
-elim3 f v = V.elim f v
+elim3 = V.elim
 
 manualElim3 :: (a %1 -> a %1 -> a %1 -> [a]) %1 -> V 3 a %1 -> [a]
 manualElim3 f v =


### PR DESCRIPTION
`Replicator.elim` and `V.elim` are currently not inlined if they are not fully applied (as we found out when writing inspection tests for this method). For example, in the following case, `elim` doesn't get inlined:

```haskell
elim3 :: (a %1 -> a %1 -> a %1 -> [a]) %1 -> V 3 a %1 -> [a]
elim3 = V.elim
```

This PR renames `elim` to `elim'` and add a `elim` wrapper ensuring that `elim'` can always get inlined.

(I also move `make` into the `Make` class in this PR, for consistency with `Elim`)

Closes #369 .