### PR TITLE
Improve consistency of module naming

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -14,7 +14,7 @@ Linear base consists of the following:
 * tools ported from [`base`] and from other critical haskell
   libraries, like `lens`,
 * new APIs for using system resources, e.g., file I/O in
-  [`System.IO.Resource`],
+  [`System.IO.Resource.Linear`],
 * new abstractions made possible by linear types, like monad-free
   mutable arrays in ([`Data.Array.Mutable.Linear`]).
 
@@ -91,5 +91,5 @@ more details.
 [`Data.Array.Mutable.Linear`]: https://github.com/tweag/linear-base/blob/master/src/Data/Array/Mutable/Linear.hs
 [blog post]: https://www.tweag.io/posts/2020-01-16-data-vs-control.html
 [contributor's guide]: ../CONTRIBUTING.md
-[`System.IO.Resource`]: https://github.com/tweag/linear-base/blob/master/src/System/IO/Resource.hs
+[`System.IO.Resource.Linear`]: https://github.com/tweag/linear-base/blob/master/src/System/IO/Resource/Linear.hs
 [issue-147]: https://github.com/tweag/linear-base/issues/147

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -19,7 +19,7 @@ if you are unfamiliar).
    Consider looking at `Data.{Array, Hashmap, Vector, Set}.Mutable.Linear`.
  * A linear `IO` monad is in `System.IO.Linear`.
    * A variant of linear `IO` which lets you enforce resource safety
-     can be found in `System.IO.Resource`.
+     can be found in `System.IO.Resource.Linear`.
  * Streams in the style of the [`streaming`
    library](https://hackage.haskell.org/package/streaming) is in
    `Streaming.Linear` and `Streaming.Prelude.Linear`.

--- a/examples/Simple/FileIO.hs
+++ b/examples/Simple/FileIO.hs
@@ -33,7 +33,7 @@ import Control.Monad ()
 import Data.Text
 import Data.Unrestricted.Linear
 import qualified System.IO as System
-import qualified System.IO.Resource as Linear
+import qualified System.IO.Resource.Linear as Linear
 import Prelude
 
 -- *  Non-linear first line printing

--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -73,17 +73,17 @@ library
         Data.Set.Mutable.Linear.Internal
         Data.Tuple.Linear
         Data.Unrestricted.Linear
-        Data.Unrestricted.Internal.Consumable
-        Data.Unrestricted.Internal.Dupable
-        Data.Unrestricted.Internal.Movable
-        Data.Unrestricted.Internal.Instances
-        Data.Unrestricted.Internal.Ur
-        Data.Unrestricted.Internal.UrT
+        Data.Unrestricted.Linear.Internal.Consumable
+        Data.Unrestricted.Linear.Internal.Dupable
+        Data.Unrestricted.Linear.Internal.Movable
+        Data.Unrestricted.Linear.Internal.Instances
+        Data.Unrestricted.Linear.Internal.Ur
+        Data.Unrestricted.Linear.Internal.UrT
         Data.Replicator.Linear
         Data.Replicator.Linear.Internal
         Data.Replicator.Linear.Internal.ReplicationStream
         Data.Replicator.Linear.Internal.Instances
-        Data.Arity.Linear.Internal.Arity
+        Data.Arity.Linear.Internal
         Data.V.Linear
         Data.V.Linear.Internal
         Data.V.Linear.Internal.Instances
@@ -95,16 +95,16 @@ library
         Prelude.Linear
         Prelude.Linear.Internal
         Streaming.Linear
+        Streaming.Linear.Internal.Consume
+        Streaming.Linear.Internal.Interop
+        Streaming.Linear.Internal.Many
+        Streaming.Linear.Internal.Process
+        Streaming.Linear.Internal.Produce
+        Streaming.Linear.Internal.Type
         Streaming.Prelude.Linear
-        Streaming.Internal.Consume
-        Streaming.Internal.Interop
-        Streaming.Internal.Many
-        Streaming.Internal.Process
-        Streaming.Internal.Produce
-        Streaming.Internal.Type
         System.IO.Linear
-        System.IO.Resource
-        System.IO.Resource.Internal
+        System.IO.Resource.Linear
+        System.IO.Resource.Linear.Internal
         Unsafe.Linear
 
     hs-source-dirs:   src

--- a/src/Control/Functor/Linear/Internal/Class.hs
+++ b/src/Control/Functor/Linear/Internal/Class.hs
@@ -34,7 +34,7 @@ where
 import qualified Control.Monad as NonLinear ()
 import qualified Data.Functor.Linear.Internal.Applicative as Data
 import qualified Data.Functor.Linear.Internal.Functor as Data
-import Data.Unrestricted.Internal.Consumable
+import Data.Unrestricted.Linear.Internal.Consumable
 import Prelude.Linear.Internal
 import Prelude (String)
 

--- a/src/Control/Functor/Linear/Internal/Reader.hs
+++ b/src/Control/Functor/Linear/Internal/Reader.hs
@@ -28,8 +28,8 @@ import qualified Control.Monad.Trans.Reader as NonLinear
 import Data.Functor.Identity
 import qualified Data.Functor.Linear.Internal.Applicative as Data
 import qualified Data.Functor.Linear.Internal.Functor as Data
-import Data.Unrestricted.Internal.Consumable
-import Data.Unrestricted.Internal.Dupable
+import Data.Unrestricted.Linear.Internal.Consumable
+import Data.Unrestricted.Linear.Internal.Dupable
 import Prelude.Linear.Internal (runIdentity', ($), (.))
 
 -- # Linear ReaderT

--- a/src/Control/Functor/Linear/Internal/State.hs
+++ b/src/Control/Functor/Linear/Internal/State.hs
@@ -36,8 +36,8 @@ import qualified Control.Monad.Trans.State.Strict as NonLinear
 import Data.Functor.Identity
 import qualified Data.Functor.Linear.Internal.Applicative as Data
 import qualified Data.Functor.Linear.Internal.Functor as Data
-import Data.Unrestricted.Internal.Consumable
-import Data.Unrestricted.Internal.Dupable
+import Data.Unrestricted.Linear.Internal.Consumable
+import Data.Unrestricted.Linear.Internal.Dupable
 import Prelude.Linear.Internal
 
 -- # StateT

--- a/src/Data/Arity/Linear/Internal.hs
+++ b/src/Data/Arity/Linear/Internal.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Data.Arity.Linear.Internal.Arity (Arity) where
+module Data.Arity.Linear.Internal (Arity) where
 
 import GHC.TypeLits
 

--- a/src/Data/Functor/Linear/Internal/Functor.hs
+++ b/src/Data/Functor/Linear/Internal/Functor.hs
@@ -19,7 +19,7 @@ import Data.Functor.Compose
 import Data.Functor.Const
 import Data.Functor.Identity
 import Data.Functor.Sum
-import Data.Unrestricted.Internal.Consumable
+import Data.Unrestricted.Linear.Internal.Consumable
 import Prelude.Linear.Internal
 import Prelude (Either (..), Maybe (..))
 

--- a/src/Data/Replicator/Linear/Internal.hs
+++ b/src/Data/Replicator/Linear/Internal.hs
@@ -31,7 +31,7 @@ module Data.Replicator.Linear.Internal
   )
 where
 
-import Data.Arity.Linear.Internal.Arity
+import Data.Arity.Linear.Internal
 import Data.Kind (Constraint, Type)
 import Data.Replicator.Linear.Internal.ReplicationStream (ReplicationStream (..))
 import qualified Data.Replicator.Linear.Internal.ReplicationStream as ReplicationStream

--- a/src/Data/Replicator/Linear/Internal/ReplicationStream.hs
+++ b/src/Data/Replicator/Linear/Internal/ReplicationStream.hs
@@ -14,7 +14,7 @@ module Data.Replicator.Linear.Internal.ReplicationStream
   )
 where
 
-import Data.Unrestricted.Internal.Ur
+import Data.Unrestricted.Linear.Internal.Ur
 import Prelude.Linear.Internal
 
 -- | @ReplicationStream s g dup2 c@ is the infinite linear stream

--- a/src/Data/Unrestricted/Linear.hs
+++ b/src/Data/Unrestricted/Linear.hs
@@ -77,13 +77,13 @@ module Data.Unrestricted.Linear
     dup5,
     dup6,
     dup7,
-    module Data.Unrestricted.Internal.Instances,
+    module Data.Unrestricted.Linear.Internal.Instances,
   )
 where
 
-import Data.Unrestricted.Internal.Consumable
-import Data.Unrestricted.Internal.Dupable
-import Data.Unrestricted.Internal.Instances
-import Data.Unrestricted.Internal.Movable
-import Data.Unrestricted.Internal.Ur
-import Data.Unrestricted.Internal.UrT
+import Data.Unrestricted.Linear.Internal.Consumable
+import Data.Unrestricted.Linear.Internal.Dupable
+import Data.Unrestricted.Linear.Internal.Instances
+import Data.Unrestricted.Linear.Internal.Movable
+import Data.Unrestricted.Linear.Internal.Ur
+import Data.Unrestricted.Linear.Internal.UrT

--- a/src/Data/Unrestricted/Linear/Internal/Consumable.hs
+++ b/src/Data/Unrestricted/Linear/Internal/Consumable.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE LinearTypes #-}
 {-# OPTIONS_HADDOCK hide #-}
 
-module Data.Unrestricted.Internal.Consumable
+module Data.Unrestricted.Linear.Internal.Consumable
   ( -- * Consumable
     Consumable (..),
     lseq,

--- a/src/Data/Unrestricted/Linear/Internal/Dupable.hs
+++ b/src/Data/Unrestricted/Linear/Internal/Dupable.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# OPTIONS_HADDOCK hide #-}
 
-module Data.Unrestricted.Internal.Dupable
+module Data.Unrestricted.Linear.Internal.Dupable
   ( Dupable (..),
     dup,
     dup3,
@@ -20,7 +20,7 @@ where
 import Data.Replicator.Linear.Internal (Replicator (..))
 import qualified Data.Replicator.Linear.Internal as Replicator
 import Data.Replicator.Linear.Internal.ReplicationStream (ReplicationStream (..))
-import Data.Unrestricted.Internal.Consumable
+import Data.Unrestricted.Linear.Internal.Consumable
 import Prelude.Linear.Internal
 
 -- | The laws of 'Dupable' are dual to those of 'Monoid':

--- a/src/Data/Unrestricted/Linear/Internal/Instances.hs
+++ b/src/Data/Unrestricted/Linear/Internal/Instances.hs
@@ -19,7 +19,7 @@
 -- many instances of Movable which we might have put in the module with
 -- Movable depend on Ur. So, we just put the instances of Movable and the
 -- other classes (for cleanness) in this module to avoid this dependence.
-module Data.Unrestricted.Internal.Instances where
+module Data.Unrestricted.Linear.Internal.Instances where
 
 import qualified Data.Functor.Linear.Internal.Applicative as Data
 import qualified Data.Functor.Linear.Internal.Functor as Data
@@ -30,10 +30,10 @@ import qualified Data.Replicator.Linear.Internal as Replicator
 import Data.Replicator.Linear.Internal.Instances ()
 import Data.Replicator.Linear.Internal.ReplicationStream (ReplicationStream (..))
 import qualified Data.Replicator.Linear.Internal.ReplicationStream as ReplicationStream
-import Data.Unrestricted.Internal.Consumable
-import Data.Unrestricted.Internal.Dupable
-import Data.Unrestricted.Internal.Movable
-import Data.Unrestricted.Internal.Ur
+import Data.Unrestricted.Linear.Internal.Consumable
+import Data.Unrestricted.Linear.Internal.Dupable
+import Data.Unrestricted.Linear.Internal.Movable
+import Data.Unrestricted.Linear.Internal.Ur
 import Data.V.Linear.Internal (V (..))
 import qualified Data.V.Linear.Internal as V
 import qualified Data.Vector as Vector

--- a/src/Data/Unrestricted/Linear/Internal/Movable.hs
+++ b/src/Data/Unrestricted/Linear/Internal/Movable.hs
@@ -1,14 +1,14 @@
 {-# LANGUAGE LinearTypes #-}
 {-# OPTIONS_HADDOCK hide #-}
 
-module Data.Unrestricted.Internal.Movable
+module Data.Unrestricted.Linear.Internal.Movable
   ( -- * Movable
     Movable (..),
   )
 where
 
-import Data.Unrestricted.Internal.Dupable
-import Data.Unrestricted.Internal.Ur
+import Data.Unrestricted.Linear.Internal.Dupable
+import Data.Unrestricted.Linear.Internal.Ur
 
 -- | Use @'Movable' a@ to represent a type which can be used many times even
 -- when given linearly. Simple data types such as 'Bool' or @[]@ are 'Movable'.

--- a/src/Data/Unrestricted/Linear/Internal/Ur.hs
+++ b/src/Data/Unrestricted/Linear/Internal/Ur.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE LinearTypes #-}
 {-# OPTIONS_HADDOCK hide #-}
 
-module Data.Unrestricted.Internal.Ur
+module Data.Unrestricted.Linear.Internal.Ur
   ( Ur (..),
     unur,
     lift,

--- a/src/Data/Unrestricted/Linear/Internal/UrT.hs
+++ b/src/Data/Unrestricted/Linear/Internal/UrT.hs
@@ -8,7 +8,7 @@
 --
 -- A good use case is when you have a linear resource, then you can use @UrT (`Linear.State` s) a@
 -- to manipulate the resource linearly with regular do-notation.
-module Data.Unrestricted.Internal.UrT
+module Data.Unrestricted.Linear.Internal.UrT
   ( UrT (..),
     runUrT,
     liftUrT,
@@ -17,8 +17,8 @@ module Data.Unrestricted.Internal.UrT
 where
 
 import qualified Control.Functor.Linear as Linear
-import Data.Unrestricted.Internal.Movable
-import Data.Unrestricted.Internal.Ur
+import Data.Unrestricted.Linear.Internal.Movable
+import Data.Unrestricted.Linear.Internal.Ur
 
 -- | @UrT@ transforms linear control monads to non-linear monads.
 --

--- a/src/Data/V/Linear.hs
+++ b/src/Data/V/Linear.hs
@@ -63,7 +63,7 @@ Data.V.Internal.Linear.V and moved the instances here. The common import issue
 is as follows. Dupable depends on @V@ yet the instances of @V@ depend on
 a variety of things (data functors, control functors, traversable) which
 often end up depending on dupable. By moving the instances here, we
-can make sure that Data.Unrestricted.Internal.Dupable only depends on the data
+can make sure that Data.Unrestricted.Linear.Internal.Dupable only depends on the data
 type defintion in Data.V.Linear.V and does not require any of the dependencies
 of the instances.
 

--- a/src/Data/V/Linear/Internal.hs
+++ b/src/Data/V/Linear/Internal.hs
@@ -40,11 +40,11 @@ module Data.V.Linear.Internal
   )
 where
 
-import Data.Arity.Linear.Internal.Arity
+import Data.Arity.Linear.Internal
 import Data.Kind
 import Data.Replicator.Linear.Internal (Replicator)
 import qualified Data.Replicator.Linear.Internal as Replicator
-import Data.Unrestricted.Internal.Dupable (Dupable (dupR))
+import Data.Unrestricted.Linear.Internal.Dupable (Dupable (dupR))
 import Data.Vector (Vector)
 import qualified Data.Vector as Vector
 import GHC.Exts (proxy#)

--- a/src/Streaming/Linear.hs
+++ b/src/Streaming/Linear.hs
@@ -8,7 +8,7 @@
 
 module Streaming.Linear
   ( -- $stream
-    module Streaming.Internal.Type,
+    module Streaming.Linear.Internal.Type,
 
     -- * Constructing a 'Stream' on a given functor
     yields,
@@ -66,8 +66,8 @@ import Data.Functor.Sum
 import Data.Unrestricted.Linear
 import GHC.Stack
 import Prelude.Linear (($), (&), (.))
-import Streaming.Internal.Process (destroyExposed)
-import Streaming.Internal.Type
+import Streaming.Linear.Internal.Process (destroyExposed)
+import Streaming.Linear.Internal.Type
 import qualified Streaming.Prelude.Linear as Stream
 import System.IO.Linear
 import Prelude

--- a/src/Streaming/Linear/Internal/Consume.hs
+++ b/src/Streaming/Linear/Internal/Consume.hs
@@ -9,7 +9,7 @@
 
 -- | This module provides all functions that take input streams
 -- but do not return output streams.
-module Streaming.Internal.Consume
+module Streaming.Linear.Internal.Consume
   ( -- * Consuming 'Stream's of elements
 
     -- ** IO Consumers
@@ -69,11 +69,11 @@ import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import Data.Unrestricted.Linear
 import Prelude.Linear (($), (&), (.))
-import Streaming.Internal.Process
-import Streaming.Internal.Type
+import Streaming.Linear.Internal.Process
+import Streaming.Linear.Internal.Type
 import qualified System.IO as System
 import System.IO.Linear
-import System.IO.Resource
+import System.IO.Resource.Linear
 import Prelude
   ( Bool (..),
     Eq (..),

--- a/src/Streaming/Linear/Internal/Interop.hs
+++ b/src/Streaming/Linear/Internal/Interop.hs
@@ -7,7 +7,7 @@
 
 -- | This module contains functions for interoperating with other
 -- streaming libraries.
-module Streaming.Internal.Interop
+module Streaming.Linear.Internal.Interop
   ( -- * Interoperating with other streaming libraries
     reread,
   )
@@ -16,8 +16,8 @@ where
 import qualified Control.Functor.Linear as Control
 import Data.Unrestricted.Linear
 import Prelude.Linear (($))
-import Streaming.Internal.Produce
-import Streaming.Internal.Type
+import Streaming.Linear.Internal.Produce
+import Streaming.Linear.Internal.Type
 import Prelude (Maybe (..))
 
 -- | Read an @IORef (Maybe a)@ or a similar device until it reads @Nothing@.

--- a/src/Streaming/Linear/Internal/Many.hs
+++ b/src/Streaming/Linear/Internal/Many.hs
@@ -10,7 +10,7 @@
 -- | This module contains all functions that do something with
 -- multiple streams as input or output. This includes combining
 -- streams, splitting a stream, etc.
-module Streaming.Internal.Many
+module Streaming.Linear.Internal.Many
   ( -- * Operations that use or return multiple 'Stream's
 
     -- ** Zips and Unzip
@@ -37,8 +37,8 @@ where
 
 import qualified Control.Functor.Linear as Control
 import Prelude.Linear (($), (&))
-import Streaming.Internal.Consume
-import Streaming.Internal.Type
+import Streaming.Linear.Internal.Consume
+import Streaming.Linear.Internal.Type
 import Prelude (Either (..), Ord (..), Ordering (..))
 
 -- # Zips and Unzip

--- a/src/Streaming/Linear/Internal/Process.hs
+++ b/src/Streaming/Linear/Internal/Process.hs
@@ -11,7 +11,7 @@
 -- | This module provides functions that take one input
 -- stream and produce one output stream. These are functions that
 -- process a single stream.
-module Streaming.Internal.Process
+module Streaming.Linear.Internal.Process
   ( -- * Stream processors
 
     -- ** Splitting and inspecting streams of elements
@@ -97,7 +97,7 @@ import qualified Data.Set as Set
 import Data.Unrestricted.Linear
 import GHC.Stack
 import Prelude.Linear (($), (&), (.))
-import Streaming.Internal.Type
+import Streaming.Linear.Internal.Type
 import System.IO.Linear
 import Text.Read (readMaybe)
 import Prelude

--- a/src/Streaming/Linear/Internal/Produce.hs
+++ b/src/Streaming/Linear/Internal/Produce.hs
@@ -10,7 +10,7 @@
 
 -- | This module provides all functions which produce a
 -- 'Stream (Of a) m r' from some given non-stream inputs.
-module Streaming.Internal.Produce
+module Streaming.Linear.Internal.Produce
   ( -- * Constructing Finite 'Stream's
     yield,
     each',
@@ -50,12 +50,12 @@ import qualified Data.Text as Text
 import Data.Unrestricted.Linear
 import GHC.Stack
 import Prelude.Linear (($), (&))
-import Streaming.Internal.Consume (effects)
-import Streaming.Internal.Process
-import Streaming.Internal.Type
+import Streaming.Linear.Internal.Consume (effects)
+import Streaming.Linear.Internal.Process
+import Streaming.Linear.Internal.Type
 import qualified System.IO as System
 import System.IO.Linear
-import System.IO.Resource
+import System.IO.Resource.Linear
 import Prelude
   ( Bool (..),
     Either (..),

--- a/src/Streaming/Linear/Internal/Type.hs
+++ b/src/Streaming/Linear/Internal/Type.hs
@@ -8,7 +8,7 @@
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
 {-# OPTIONS_HADDOCK hide #-}
 
-module Streaming.Internal.Type
+module Streaming.Linear.Internal.Type
   ( -- * The 'Stream' and 'Of' types
     -- $stream
     Stream (..),

--- a/src/Streaming/Prelude/Linear.hs
+++ b/src/Streaming/Prelude/Linear.hs
@@ -47,18 +47,18 @@
 -- > --------------------------------------------------------------------------------------------------------------------
 -- >
 module Streaming.Prelude.Linear
-  ( module Streaming.Internal.Type,
-    module Streaming.Internal.Consume,
-    module Streaming.Internal.Interop,
-    module Streaming.Internal.Many,
-    module Streaming.Internal.Process,
-    module Streaming.Internal.Produce,
+  ( module Streaming.Linear.Internal.Type,
+    module Streaming.Linear.Internal.Consume,
+    module Streaming.Linear.Internal.Interop,
+    module Streaming.Linear.Internal.Many,
+    module Streaming.Linear.Internal.Process,
+    module Streaming.Linear.Internal.Produce,
   )
 where
 
-import Streaming.Internal.Consume
-import Streaming.Internal.Interop
-import Streaming.Internal.Many
-import Streaming.Internal.Process
-import Streaming.Internal.Produce
-import Streaming.Internal.Type
+import Streaming.Linear.Internal.Consume
+import Streaming.Linear.Internal.Interop
+import Streaming.Linear.Internal.Many
+import Streaming.Linear.Internal.Process
+import Streaming.Linear.Internal.Produce
+import Streaming.Linear.Internal.Type

--- a/src/System/IO/Resource/Linear.hs
+++ b/src/System/IO/Resource/Linear.hs
@@ -11,7 +11,7 @@
 -- >>> :set -XLinearTypes
 -- >>> :set -XQualifiedDo
 -- >>> :set -XNoImplicitPrelude
--- >>> import qualified System.IO.Resource as Linear
+-- >>> import qualified System.IO.Resource.Linear as Linear
 -- >>> import qualified Control.Functor.Linear as Control
 -- >>> import qualified Data.Text as Text
 -- >>> import Prelude.Linear
@@ -27,7 +27,7 @@
 --
 -- To enable do notation, `QualifiedDo` extension is used. But since QualifiedDo
 -- only modifies the desugaring of binds, we still need to qualify `Control.return`.
-module System.IO.Resource
+module System.IO.Resource.Linear
   ( -- * The Resource I/O Monad
     RIO,
     run,
@@ -61,4 +61,4 @@ module System.IO.Resource
 where
 
 import qualified System.IO as System
-import System.IO.Resource.Internal
+import System.IO.Resource.Linear.Internal

--- a/src/System/IO/Resource/Linear/Internal.hs
+++ b/src/System/IO/Resource/Linear/Internal.hs
@@ -11,7 +11,7 @@
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 {-# OPTIONS_HADDOCK hide #-}
 
-module System.IO.Resource.Internal where
+module System.IO.Resource.Linear.Internal where
 
 import Control.Exception (finally, mask, onException)
 import qualified Control.Functor.Linear as Control


### PR DESCRIPTION
Before 1.0 release, I think that we should ensure that our naming conventions are respected for both internal and public modules.
In this PR, I renamed:

+ System.IO.Resource -> System.IO.Resource.Linear
+ Streaming.Internal -> System.Linear.Internal
+ Data.Unrestricted.Internal -> Data.Unrestricted.Linear.Internal
+ Data.Arity.Linear.Internal.Arity -> Data.Arity.Linear.Internal

The `Control.Optics` directory structure seemed a bit odd to me (but I haven't changed it yet), because it contains modules not ending with either `.Linear` or `.Linear.Internal.xxx` as this is the case in every other namespace. Should we rename something for this one?

Closes #373 . Closes #380 .