### PR TITLE
Add fixity declaration for every operator of `linear-base`

### DIFF
--- a/examples/Simple/FileIO.hs
+++ b/examples/Simple/FileIO.hs
@@ -118,6 +118,8 @@ type LinHandle = Linear.Handle
 (>>#=) :: RIO a %1 -> (a %1 -> RIO b) %1 -> RIO b
 (>>#=) = (Control.>>=)
 
+infixl 1 >>#= -- same fixity as base.>>=
+
 -- | Non-linear bind
 -- Notice the continuation has a non-linear arrow,
 -- i.e., (() -> RIO b). For simplicity, we don't use
@@ -125,6 +127,8 @@ type LinHandle = Linear.Handle
 -- (>>==) :: RIO (Ur a) %1-> (a -> RIO b) %1-> RIO b
 (>>==) :: RIO () %1 -> (() -> RIO b) %1 -> RIO b
 (>>==) ma f = ma Control.>>= (\() -> f ())
+
+infixl 1 >>== -- same fixity as base.>>=
 
 -- | Inject
 -- provided just to make the type explicit

--- a/examples/Simple/Pure.hs
+++ b/examples/Simple/Pure.hs
@@ -192,6 +192,8 @@ regularIdentity x = linearIdentity x
 (#.) :: (b %1 -> c) -> (a %1 -> b) -> (a %1 -> c)
 g #. f = \a -> g (f a)
 
+infixr 9 #. -- same fixity as base..
+
 linearCompose :: (a, a) %1 -> (a, a)
 linearCompose = linearIdentity #. linearSwap
 

--- a/src/Control/Functor/Linear/Internal/Class.hs
+++ b/src/Control/Functor/Linear/Internal/Class.hs
@@ -71,6 +71,8 @@ dataFmapDefault f = fmap f
 (<$>) = fmap
 {-# INLINE (<$>) #-}
 
+infixl 4 <$> -- same fixity as base.<$>
+
 -- |  @
 --    ('<&>') = 'flip' 'fmap'
 --    @
@@ -78,9 +80,13 @@ dataFmapDefault f = fmap f
 (<&>) a f = f <$> a
 {-# INLINE (<&>) #-}
 
+infixl 1 <&> -- same fixity as base.<&>
+
 -- | Linearly typed replacement for the standard '(Prelude.<$)' function.
 (<$) :: (Functor f, Consumable b) => a %1 -> f b %1 -> f a
 a <$ fb = fmap (`lseq` a) fb
+
+infixl 4 <$ -- same fixity as base.<$
 
 -- | Discard a consumable value stored in a control functor.
 void :: (Functor f, Consumable a) => f a %1 -> f ()
@@ -106,6 +112,8 @@ class (Data.Applicative f, Functor f) => Applicative f where
   (<*>) :: f (a %1 -> b) %1 -> f a %1 -> f b
   (<*>) = liftA2 id
 
+  infixl 4 <*> -- same fixity as base.<*>
+
   -- | @liftA2 g@ consumes @g@ linearly as it lifts it
   -- over two functors: @liftA2 g :: f a %1-> f b %1-> f c@.
   liftA2 :: (a %1 -> b %1 -> c) %1 -> f a %1 -> f b %1 -> f c
@@ -128,8 +136,11 @@ class Applicative m => Monad m where
   -- exactly once) on the value of type @a@ inside the value of type @m a@
   (>>=) :: m a %1 -> (a %1 -> m b) %1 -> m b
 
+  infixl 1 >>= -- same fixity as base.>>=
+
   (>>) :: m () %1 -> m a %1 -> m a
   m >> k = m >>= (\() -> k)
+  infixl 1 >> -- same fixity as base.>>
 
 -- | This class handles pattern-matching failure in do-notation.
 -- See "Control.Monad.Fail" for details.

--- a/src/Control/Optics/Linear/Internal.hs
+++ b/src/Control/Optics/Linear/Internal.hs
@@ -104,6 +104,8 @@ assoc = iso Bifunctor.lassoc Bifunctor.rassoc
 (.>) :: Optic_ arr s t a b -> Optic_ arr a b x y -> Optic_ arr s t x y
 Optical f .> Optical g = Optical (f Prelude.. g)
 
+infixr 9 .> -- same fixity as lens..>
+
 lens :: (s %1 -> (a, b %1 -> t)) -> Lens s t a b
 lens k = Optical $ \f -> dimap k (\(x, g) -> g $ x) (first f)
 

--- a/src/Data/Array/Mutable/Unlifted/Linear.hs
+++ b/src/Data/Array/Mutable/Unlifted/Linear.hs
@@ -55,6 +55,8 @@ unArray# f = Unsafe.toLinear (\(Array# a) -> Ur (f a))
 lseq :: Array# a %1 -> b %1 -> b
 lseq = Unsafe.toLinear2 (\_ b -> b)
 
+infixr 0 `lseq` -- same fixity as base.seq
+
 -- | Allocate a mutable array of given size using a default value.
 --
 -- The size should be non-negative.

--- a/src/Data/Bool/Linear.hs
+++ b/src/Data/Bool/Linear.hs
@@ -23,7 +23,7 @@ False && False = False
 False && True = False
 True && x = x
 
-infixr 3 &&
+infixr 3 && -- same as base.&&
 
 -- | @True@ iff either is @True@
 -- __NOTE:__ this is strict and not lazy!
@@ -32,7 +32,7 @@ True || False = True
 True || True = True
 False || x = x
 
-infixr 2 ||
+infixr 2 || -- same as base.||
 
 -- | @not b@ is @True@ iff b is @False@
 -- __NOTE:__ this is strict and not lazy!

--- a/src/Data/Functor/Linear/Internal/Applicative.hs
+++ b/src/Data/Functor/Linear/Internal/Applicative.hs
@@ -49,6 +49,7 @@ class Functor f => Applicative f where
   {-# MINIMAL pure, (liftA2 | (<*>)) #-}
   pure :: a -> f a
   (<*>) :: f (a %1 -> b) %1 -> f a %1 -> f b
+  infixl 4 <*> -- same fixity as base.<*>
   f <*> x = liftA2 ($) f x
   liftA2 :: (a %1 -> b %1 -> c) -> f a %1 -> f b %1 -> f c
   liftA2 f x y = f <$> x <*> y

--- a/src/Data/Functor/Linear/Internal/Functor.hs
+++ b/src/Data/Functor/Linear/Internal/Functor.hs
@@ -36,10 +36,14 @@ class Functor f where
 (<$>) :: Functor f => (a %1 -> b) -> f a %1 -> f b
 (<$>) = fmap
 
+infixl 4 <$> -- same fixity as base.<$>
+
 -- | Replace all occurances of @b@ with the given @a@
 -- and consume the functor @f b@.
 (<$) :: (Functor f, Consumable b) => a -> f b %1 -> f a
 a <$ fb = fmap (`lseq` a) fb
+
+infixl 4 <$ -- same fixity as base.<$
 
 -- | Discard a consumable value stored in a data functor.
 void :: (Functor f, Consumable a) => f a %1 -> f ()

--- a/src/Data/List/Linear.hs
+++ b/src/Data/List/Linear.hs
@@ -105,6 +105,8 @@ import qualified Prelude as Prelude
 (++) :: [a] %1 -> [a] %1 -> [a]
 (++) = Unsafe.toLinear2 (NonLinear.++)
 
+infixr 5 ++ -- same fixity as base.++
+
 map :: (a %1 -> b) -> [a] %1 -> [b]
 map = fmap
 

--- a/src/Data/Monoid/Linear/Internal/Semigroup.hs
+++ b/src/Data/Monoid/Linear/Internal/Semigroup.hs
@@ -29,6 +29,7 @@ import Prelude.Linear.Internal
 -- that linearly consumes two @a@s.
 class Prelude.Semigroup a => Semigroup a where
   (<>) :: a %1 -> a %1 -> a
+  infixr 6 <> -- same fixity as base.<>
 
 ---------------
 -- Instances --

--- a/src/Data/Num/Linear.hs
+++ b/src/Data/Num/Linear.hs
@@ -53,6 +53,7 @@ import qualified Prelude
 -- > a + b = b + c
 class Additive a where
   (+) :: a %1 -> a %1 -> a
+  infixl 6 + -- same fixity as base.+
 
 -- | An 'Additive' type with an identity on @(+)@.
 class Additive a => AddIdentity a where
@@ -65,13 +66,15 @@ class AddIdentity a => AdditiveGroup a where
   negate :: a %1 -> a
   negate x = zero - x
   (-) :: a %1 -> a %1 -> a
+  infixl 6 - -- same fixity as base.-
   x - y = x + negate y
 
 -- | A numeric type with an associative @(*)@ operation
 class Multiplicative a where
   (*) :: a %1 -> a %1 -> a
+  infixl 7 * -- same fixity as base.*
 
--- | A 'Multipcative' type with an identity for @(*)@
+-- | A 'Multiplicative' type with an identity for @(*)@
 class Multiplicative a => MultIdentity a where
   one :: a
 

--- a/src/Data/Ord/Linear/Internal/Eq.hs
+++ b/src/Data/Ord/Linear/Internal/Eq.hs
@@ -29,9 +29,10 @@ class Eq a where
   {-# MINIMAL (==) | (/=) #-}
   (==) :: a %1 -> a %1 -> Bool
   x == y = not (x /= y)
+  infix 4 == -- same fixity as base.==
   (/=) :: a %1 -> a %1 -> Bool
   x /= y = not (x == y)
-  infix 4 ==, /=
+  infix 4 /= -- same fixity as base./=
 
 -- * Instances
 

--- a/src/Data/Ord/Linear/Internal/Ord.hs
+++ b/src/Data/Ord/Linear/Internal/Ord.hs
@@ -47,19 +47,25 @@ class Eq a => Ord a where
   -- which should be understood as \"x is @(compare x y)@ y\".
   compare :: a %1 -> a %1 -> Ordering
 
+  -- /!\ `compare` doesn't have a specified fixity in base
+  -- but we chose infix 4 for consistency with `elem`, <, <=, ==, /= ...
+  infix 4 `compare`
+
   (<=) :: a %1 -> a %1 -> Bool
   x <= y = not (x > y)
+  infix 4 <= -- same fixity as base.<=
 
   (<) :: a %1 -> a %1 -> Bool
   x < y = compare x y == LT
+  infix 4 < -- same fixity as base.<
 
   (>) :: a %1 -> a %1 -> Bool
   x > y = compare x y == GT
+  infix 4 > -- same fixity as base.>
 
   (>=) :: a %1 -> a %1 -> Bool
   x >= y = not (x < y)
-
-  infix 4 <=, <, >, >=
+  infix 4 >= -- same fixity as base.>=
 
 -- | @max x y@ returns the larger input, or  'y'
 -- in case of a tie.

--- a/src/Data/Profunctor/Linear.hs
+++ b/src/Data/Profunctor/Linear.hs
@@ -80,6 +80,7 @@ class Profunctor (arr :: Type -> Type -> Type) where
 -- with the bifunctor @m@.
 class (SymmetricMonoidal m u, Profunctor arr) => Monoidal m u arr where
   (***) :: a `arr` b -> x `arr` y -> (a `m` x) `arr` (b `m` y)
+  infixr 3 *** -- same fixity as base.***
   unit :: u `arr` u
 
 -- | A @(Strong m u arr)@ instance means that the function-like thing

--- a/src/Data/Replicator/Linear/Internal.hs
+++ b/src/Data/Replicator/Linear/Internal.hs
@@ -74,6 +74,8 @@ sf <*> sx = Streamed (toStream sf ReplicationStream.<*> toStream sx)
       Moved x -> ReplicationStream.pure x
       Streamed stream -> stream
 
+infixl 4 <*> -- same fixity as base.<*>
+
 -- | Extracts the next item from the \"infinite stream\" @'Replicator' a@.
 next :: Replicator a %1 -> (a, Replicator a)
 next (Moved x) = (x, Moved x)

--- a/src/Data/Replicator/Linear/Internal/ReplicationStream.hs
+++ b/src/Data/Replicator/Linear/Internal/ReplicationStream.hs
@@ -76,3 +76,5 @@ pure x =
         consumesf sf' & \case
           () -> consumesx sx'
     )
+
+infixl 4 <*> -- same fixity as base.<*>

--- a/src/Data/Unrestricted/Linear/Internal/Consumable.hs
+++ b/src/Data/Unrestricted/Linear/Internal/Consumable.hs
@@ -22,3 +22,5 @@ seqUnit () b = b
 -- This is like 'seq' but the first argument is restricted to be 'Consumable'.
 lseq :: Consumable a => a %1 -> b %1 -> b
 lseq a b = seqUnit (consume a) b
+
+infixr 0 `lseq` -- same fixity as base.seq

--- a/src/Data/V/Linear/Internal.hs
+++ b/src/Data/V/Linear/Internal.hs
@@ -80,6 +80,8 @@ map f (V xs) = V $ Unsafe.toLinear (Vector.map (\x -> f x)) xs
   V $
     Unsafe.toLinear2 (Vector.zipWith (\f x -> f $ x)) fs xs
 
+infixl 4 <*> -- same fixity as base.<*>
+
 -- | Splits the head and tail of the 'V', returning an unboxed tuple.
 uncons# :: 1 <= n => V n a %1 -> (# a, V (n - 1) a #)
 uncons# = Unsafe.toLinear uncons'#

--- a/src/Prelude/Linear.hs
+++ b/src/Prelude/Linear.hs
@@ -168,3 +168,5 @@ flip f b a = f a b
 -- | Linearly typed replacement for the standard '(Prelude.<*)' function.
 (<*) :: (Data.Applicative f, Consumable b) => f a %1 -> f b %1 -> f a
 fa <* fb = Data.fmap (flip lseq) fa Data.<*> fb
+
+infixl 4 <* -- same fixity as base.<*

--- a/src/Prelude/Linear/Internal.hs
+++ b/src/Prelude/Linear/Internal.hs
@@ -20,12 +20,12 @@ import GHC.Exts (TYPE)
 ($) :: forall {rep} a (b :: TYPE rep) p q. (a %p -> b) %q -> a %p -> b
 ($) f x = f x
 
-infixr 0 $
+infixr 0 $ -- same fixity as base.$
 
 (&) :: forall {rep} a (b :: TYPE rep) p q. a %p -> (a %p -> b) %q -> b
 x & f = f x
 
-infixl 1 &
+infixl 1 & -- same fixity as base.&
 
 id :: a %q -> a
 id x = x
@@ -42,8 +42,12 @@ asTypeOf = const
 seq :: a -> b %q -> b
 seq !_ y = y
 
+infixr 0 `seq` -- same fixity as base.seq
+
 ($!) :: forall {rep} a (b :: TYPE rep) p q. (a %p -> b) %q -> a %p -> b
 ($!) f !a = f a
+
+infixr 0 $! -- same fixity as base.$!
 
 curry :: ((a, b) %p -> c) %q -> a %p -> b %p -> c
 curry f x y = f (x, y)
@@ -55,6 +59,8 @@ uncurry f (x, y) = f x y
 -- higher-order and we don't have sufficient multiplicity polymorphism yet.
 (.) :: forall {rep} b (c :: TYPE rep) a q m n. (b %1 -> c) %q -> (a %1 -> b) %m -> a %n -> c
 f . g = \x -> f (g x)
+
+infixr 9 . -- same fixity as base..
 
 -- | Convenience operator when a higher-order function expects a non-linear
 -- arrow but we have a linear arrow.

--- a/src/Streaming/Linear/Internal/Consume.hs
+++ b/src/Streaming/Linear/Internal/Consume.hs
@@ -530,6 +530,8 @@ elem a stream = loop stream
           False -> elem a stream'
 {-# INLINEABLE elem #-}
 
+infix 4 `elem` -- same fixity as base.elem
+
 elem_ ::
   forall a m r.
   (Consumable r, Control.Monad m, Eq a) =>

--- a/src/Streaming/Linear/Internal/Type.hs
+++ b/src/Streaming/Linear/Internal/Type.hs
@@ -55,7 +55,7 @@ data Stream f m r where
 data Of a b where
   (:>) :: !a -> b %1 -> Of a b
 
-infixr 5 :>
+infixr 5 :> -- same fixity as streaming.:>
 
 -- # Control.Monad instance for (Stream f m)
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Precedence levels are chosen to be same as in base.

The only exception is `compare`, for which I chose `infix 4` like every other `a -> b -> Bool` operator (`elem`, `<`, `<=`, `==`...).

Closes #374 .