### PR TITLE
Add `void` function to consume `Control.Functor.Linear.Functor` inner value

### DIFF
--- a/src/Control/Functor/Linear.hs
+++ b/src/Control/Functor/Linear.hs
@@ -14,6 +14,7 @@ module Control.Functor.Linear
     (<$>),
     (<&>),
     (<$),
+    void,
     dataFmapDefault,
     Applicative (..),
     dataPureDefault,

--- a/src/Control/Functor/Linear/Internal/Class.hs
+++ b/src/Control/Functor/Linear/Internal/Class.hs
@@ -16,6 +16,7 @@ module Control.Functor.Linear.Internal.Class
     (<$>),
     (<&>),
     (<$),
+    void,
 
     -- * Applicative Functors
     Applicative (..),
@@ -80,6 +81,10 @@ dataFmapDefault f = fmap f
 -- | Linearly typed replacement for the standard '(Prelude.<$)' function.
 (<$) :: (Functor f, Consumable b) => a %1 -> f b %1 -> f a
 a <$ fb = fmap (`lseq` a) fb
+
+-- | Discard a consumable value stored in a control functor.
+void :: (Functor f, Consumable a) => f a %1 -> f ()
+void = fmap consume
 
 -- # Control Applicatives
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Apply decision of PR #356 : we should have a `void :: (Functor f, Consumable a) =>  f a %1 -> f ()` function not only for `Data.Functor.Linear.Functor` but for `Control.Functor.Linear.Functor` as well.

Closes #356.