### PR TITLE
A more robust implementation of Replicator.elim

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -19,6 +19,9 @@ let
         "
     '';
   };
+  brokenIn92 = if ghcVersion == "921" then [] else [
+    pkgs.haskell-language-server
+  ];
 in with pkgs;
 
 mkShell {
@@ -28,10 +31,9 @@ mkShell {
 
   buildInputs = [
     haskell.compiler."ghc${ghcVersion}"
-    haskell-language-server
     cabal-install
     stack-wrapped
     nix
     cabal-docspec
-  ];
+  ] ++ brokenIn92;
 }

--- a/src/Control/Functor/Linear/Internal/Kan.hs
+++ b/src/Control/Functor/Linear/Internal/Kan.hs
@@ -98,13 +98,13 @@ instance Functor (Yoneda f) where
 instance Applicative f => Data.Applicative (Yoneda f) where
   pure a = Yoneda (\f -> pure (f a))
   {-# INLINE pure #-}
-  Yoneda m <*> Yoneda n = Yoneda (\f -> m (f .) <*> n id)
+  Yoneda m <*> Yoneda n = Yoneda (\f -> m (\g -> f . g) <*> n id)
   {-# INLINE (<*>) #-}
 
 instance Applicative f => Applicative (Yoneda f) where
   pure a = Yoneda (\f -> pure (f a))
   {-# INLINE pure #-}
-  Yoneda m <*> Yoneda n = Yoneda (\f -> m (f .) <*> n id)
+  Yoneda m <*> Yoneda n = Yoneda (\f -> m (\g -> f . g) <*> n id)
   {-# INLINE (<*>) #-}
 
 lowerYoneda :: Yoneda f a %1 -> f a
@@ -117,5 +117,5 @@ liftCurriedYonedaC fa = Curried (`yap` fa)
 {-# INLINE liftCurriedYonedaC #-}
 
 yap :: Applicative f => Yoneda f (a %1 -> b) %1 -> f a %1 -> Yoneda f b
-yap (Yoneda k) fa = Yoneda (\ab_r -> k (ab_r .) <*> fa)
+yap (Yoneda k) fa = Yoneda (\ab_r -> k (\g -> ab_r . g) <*> fa)
 {-# INLINE yap #-}

--- a/src/Data/Arity/Linear/Internal.hs
+++ b/src/Data/Arity/Linear/Internal.hs
@@ -1,13 +1,56 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Data.Arity.Linear.Internal (Arity) where
+module Data.Arity.Linear.Internal where
 
+import Data.Kind
 import GHC.TypeLits
+import GHC.Types
 
+data Peano = Z | S Peano
+
+type NatToPeano :: Nat -> Peano
+type family NatToPeano n where
+  NatToPeano 0 = 'Z
+  NatToPeano n = 'S (NatToPeano (n - 1))
+
+type PeanoToNat :: Peano -> Nat
+type family PeanoToNat n where
+  PeanoToNat 'Z = 0
+  PeanoToNat ('S n) = 1 + PeanoToNat n
+
+type FunN :: Peano -> Type -> Type -> Type
+type family FunN n a b where
+  FunN 'Z _ b = b
+  FunN ('S n) a b = a %1 -> FunN n a b
+
+-- | The 'Arity' type family exists to help the type checker fill in
+-- blanks. Chances are that you can safely ignore 'Arity' completely if it's in
+-- the type of a function you care. But read on if you are curious.
+--
+-- The idea is that in a function like 'Data.Replicator.Linear.elim' some of the
+-- type arguments are redundant. The function has an ambiguous type, so you will
+-- always have to help the compiler either with a type annotation or a type
+-- application. But there are several complete ways to do so. In
+-- 'Data.Replicator.Linear.elim', if you give the values of `n`, `a`, and `b`,
+-- then you can deduce the value of `f` (indeed, it's @'FunN' n a b@). With
+-- 'Arity' we can go in the other direction: if `b` and `f` are both known, then
+-- we know that `n` is @'Arity' b f@
+--
+-- 'Arity' returns a 'Nat' rather than a 'Peano' because the result is never
+-- consumed. It exists to infer arguments to functions such as
+-- 'Data.Replicator.Linear.elim' from the other arguments if they are known.
+--
+-- 'Arity' could be an associated type family to the 'IsFunN' type class. But
+-- it's better to make it a closed type family (which can't be associated to a
+-- type class) because it lets us give a well-defined error case.
+type Arity :: Type -> Type -> Nat
 type family Arity b f where
   Arity b b = 0
   Arity b (a %1 -> f) = Arity b f + 1
@@ -19,3 +62,26 @@ type family Arity b f where
           ':<>: 'ShowType b
           ':<>: 'Text "."
       )
+
+-- | The 'IsFun' type class is meant to help the type checker fill in
+-- blanks. Chances are that you can safely ignore 'IsFun' completely if it's in
+-- the type of a function you care. But read on if you are curious.
+--
+-- The type class 'IsFun' is a kind of inverse to 'FunN', it is meant to be
+-- read as @'IsFunN' a b f@ if and only if there exists `n` such that @f =
+-- 'FunN' n a b@ (`n` can be retrieved as @'Arity' b f@).
+--
+-- The reason why 'Arity' (read its documentation first) is not sufficient for
+-- our purpose, is that it can find `n` /if/ `f` is a linear function of the
+-- appropriate shape. But what if `f` is partially undetermined? Then it is
+-- likely that 'Arity' will be stuck. But we know, for instance, that if `f = a1
+-- %1 -> a2 %1 -> c` then we must have `a1 ~ a2`. The trick is that instance
+-- resolution of 'IsFun' will add unification constraints that the type checker
+-- has to solve. Look in particular at the instance @'IsFunN' a b (a' %p ->
+-- f))@: it matches liberally, so triggers on quite underdetermined `f`, but has
+-- equality constraints in its context which will help the type checker.
+class IsFunN a b f
+
+instance IsFunN a b b
+
+instance (IsFunN a b f, a' ~ a, p ~ 'One) => IsFunN a b (a' %p -> f)

--- a/src/Data/Unrestricted/Linear/Internal/Dupable.hs
+++ b/src/Data/Unrestricted/Linear/Internal/Dupable.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE LinearTypes #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# OPTIONS_HADDOCK hide #-}
 

--- a/test/Test/Data/V.hs
+++ b/test/Test/Data/V.hs
@@ -17,7 +17,7 @@ vInspectionTests :: TestTree
 vInspectionTests =
   testGroup
     "Inspection testing of elim and make for V"
-    [ $(inspectTest $ 'make3 === 'manualMake3),
+    [ $(inspectTest $ 'make3 ==- 'manualMake3),
       $(inspectTest $ 'elim3 ==- 'manualElim3)
     ]
 


### PR DESCRIPTION
I rely on more type families (I resurrected the `FunN` type family,
for instance) and additional type classes in order to give robust
hints to the type checker to infer some of the arguments based on the
others in multiple possible ways.

The previous version was abusing functional dependencies to that
effect. The problem is that it almost certainly depended on bugs. Plus
some behaviour changed in 9.2 making the recursive instance not
typecheck anymore.

The actual (staging) recursion now uses (type-level) Peano integers,
this way we can get rid of the `OVERLAPPABLE` instances altogether,
and avoid the sort of fragile behaviour that caused the failure in
9.2.

The 'elim' function itself has more type arguments, so I took it out
of the type class. A collection of type families and type classes fill
the role that functional dependencies used to play: figuring out `f`
from `n` or `n` from `f`.

Fixes #388.

---

Interestingly I've only had to fix `Replicator.elim` for the sake of
fixing the compilation in GHC 9.2. The rest works fine. But it'd be
better to make similar changes to `V.make` and `V.elim`. I won't have
time to, though, @tbagrel1 can I untrust you with this?

I've made some additional small changes for the sake of GHC 9.2
compilation:

### Minimal shell.nix changes to be able to run GHC 9.2

### Some 𝜂-expansions to compile with GHC 9.2

This is really suspicious, there may be a bug in GHC 9.2 where
sections do not preserve linearity. Grmpf.