### PR TITLE
Finish robustness improvements on `make`/`elim`

### DIFF
--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -43,6 +43,8 @@ library
         Control.Optics.Linear.Lens
         Control.Optics.Linear.Prism
         Control.Optics.Linear.Traversal
+        Data.Arity.Linear
+        Data.Arity.Linear.Internal
         Data.Array.Destination
         Data.Array.Destination.Internal
         Data.Array.Mutable.Linear
@@ -89,7 +91,6 @@ library
         Data.Replicator.Linear.Internal
         Data.Replicator.Linear.Internal.ReplicationStream
         Data.Replicator.Linear.Internal.Instances
-        Data.Arity.Linear.Internal
         Data.V.Linear
         Data.V.Linear.Internal
         Data.V.Linear.Internal.Instances

--- a/src/Data/Arity/Linear.hs
+++ b/src/Data/Arity/Linear.hs
@@ -1,0 +1,17 @@
+-- |
+-- This module provides type-level helpers and classes to deal with n-ary
+-- functions.
+--
+-- See 'Data.V.Linear.make', 'Data.V.Linear.elim' and
+-- 'Data.Replicator.Linear.elim' for use-cases.
+module Data.Arity.Linear
+  ( Peano (..),
+    NatToPeano,
+    PeanoToNat,
+    FunN,
+    Arity,
+    IsFunN,
+  )
+where
+
+import Data.Arity.Linear.Internal

--- a/src/Data/Arity/Linear/Internal.hs
+++ b/src/Data/Arity/Linear/Internal.hs
@@ -4,8 +4,10 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneKindSignatures #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_HADDOCK hide #-}
 
 module Data.Arity.Linear.Internal where
 
@@ -15,16 +17,20 @@ import GHC.Types
 
 data Peano = Z | S Peano
 
+-- | Converts a GHC type-level 'Nat' to a structural type-level natural ('Peano').
 type NatToPeano :: Nat -> Peano
 type family NatToPeano n where
   NatToPeano 0 = 'Z
   NatToPeano n = 'S (NatToPeano (n - 1))
 
+-- | Converts a structural type-level natural ('Peano') to a GHC type-level 'Nat'.
 type PeanoToNat :: Peano -> Nat
 type family PeanoToNat n where
   PeanoToNat 'Z = 0
   PeanoToNat ('S n) = 1 + PeanoToNat n
 
+-- | @'FunN' n a b@ represents a function taking @n@ linear arguments of
+-- type @a@ and returning a result of type @b@.
 type FunN :: Peano -> Type -> Type -> Type
 type family FunN n a b where
   FunN 'Z _ b = b
@@ -47,9 +53,11 @@ type family FunN n a b where
 -- consumed. It exists to infer arguments to functions such as
 -- 'Data.Replicator.Linear.elim' from the other arguments if they are known.
 --
--- 'Arity' could be an associated type family to the 'IsFunN' type class. But
--- it's better to make it a closed type family (which can't be associated to a
--- type class) because it lets us give a well-defined error case.
+-- 'Arity' could /theorically/ be an associated type family to the 'IsFunN' type
+-- class. But it's better to make it a closed type family (which can't be
+-- associated to a type class) because it lets us give a well-defined error
+-- case. In addition, GHC cannot see that @0 /= 1 + (? :: Nat)@ and as a result we get
+-- some overlap which is only allowed in (ordered) closed type families.
 type Arity :: Type -> Type -> Nat
 type family Arity b f where
   Arity b b = 0
@@ -68,17 +76,18 @@ type family Arity b f where
 -- the type of a function you care. But read on if you are curious.
 --
 -- The type class 'IsFun' is a kind of inverse to 'FunN', it is meant to be
--- read as @'IsFunN' a b f@ if and only if there exists `n` such that @f =
--- 'FunN' n a b@ (`n` can be retrieved as @'Arity' b f@).
+-- read as @'IsFunN' a b f@ if and only if there exists @n@ such that @f =
+-- 'FunN' n a b@ (`n` can be retrieved as @'Arity' b f@ or
+-- @'Data.V.Linear.ArityV' f@).
 --
 -- The reason why 'Arity' (read its documentation first) is not sufficient for
--- our purpose, is that it can find `n` /if/ `f` is a linear function of the
--- appropriate shape. But what if `f` is partially undetermined? Then it is
--- likely that 'Arity' will be stuck. But we know, for instance, that if `f = a1
--- %1 -> a2 %1 -> c` then we must have `a1 ~ a2`. The trick is that instance
+-- our purpose, is that it can find @n@ /if/ @f@ is a linear function of the
+-- appropriate shape. But what if @f@ is partially undetermined? Then it is
+-- likely that 'Arity' will be stuck. But we know, for instance, that if @f = a1
+-- %1 -> a2 %1 -> c@ then we must have @a1 ~ a2@. The trick is that instance
 -- resolution of 'IsFun' will add unification constraints that the type checker
--- has to solve. Look in particular at the instance @'IsFunN' a b (a' %p ->
--- f))@: it matches liberally, so triggers on quite underdetermined `f`, but has
+-- has to solve. Look in particular at the instance @'IsFunN' a b (a\' %p ->
+-- f))@: it matches liberally, so triggers on quite underdetermined @f@, but has
 -- equality constraints in its context which will help the type checker.
 class IsFunN a b f
 

--- a/src/Data/Replicator/Linear/Internal.hs
+++ b/src/Data/Replicator/Linear/Internal.hs
@@ -133,13 +133,27 @@ extend f = map f . duplicate
 --
 -- > elim (,) :: Replicator a %1 -> (a, a)
 -- > elim (,,) :: Replicator a %1 -> (a, a, a)
-elim :: forall (n :: Nat) a b f. (Elim (NatToPeano n) a b, IsFunN a b f, f ~ FunN (NatToPeano n) a b, n ~ Arity b f) => f %1 -> Replicator a %1 -> b
+--
+-- About the constraints of this function (they won't get in your way):
+--
+-- * @'Elim' ('NatToPeano' n) a b@ provides the actual implementation of 'elim'; there is an instance of this class for any @(n, a, b)@
+-- * @'IsFunN' a b f, f ~ 'FunN' ('NatToPeano' n) a b, n ~ 'Arity' b f@ indicate the shape of @f@ to the typechecker (see documentation of 'IsFunN').
+elim ::
+  forall (n :: Nat) a b f.
+  ( Elim (NatToPeano n) a b,
+    IsFunN a b f,
+    f ~ FunN (NatToPeano n) a b,
+    n ~ Arity b f
+  ) =>
+  f %1 ->
+  Replicator a %1 ->
+  b
 elim f r = elim' @(NatToPeano n) f r
 
--- | @'Elim' n a b f@ asserts that @f@ is a function taking @n@ linear arguments
--- of type @a@ and then returning a value of type @b@.
+-- | @'Elim' n a b@ is used to implement 'elim' without recursion
+-- so that we can guarantee that 'elim' will be inlined and unrolled.
 --
--- It is solely used to define the type of the 'elim' function.
+-- 'Elim' is solely used in the signature of 'elim'.
 type Elim :: Peano -> Type -> Type -> Constraint
 class Elim n a b where
   -- Note that 'elim' is, in particular, used to force eta-expansion of

--- a/src/Data/V/Linear.hs
+++ b/src/Data/V/Linear.hs
@@ -50,6 +50,9 @@ module Data.V.Linear
     theLength,
     Make,
     make,
+
+    -- * Type-level helpers for staging
+    ArityV,
   )
 where
 


### PR DESCRIPTION
+ Rework `V.{make,elim}` to use the same type-level machinery as
  the new `Replicator.elim` implementation introduced by @aspiwack in https://github.com/tweag/linear-base/pull/390
+ Improve documentation of `V.{make,elim}`, `Replicator.elim` and `Arity` module
+ Expose the type-level helpers from the internal `Arity` module as `Data.Arity.Linear`