### PR TITLE
Remove `Prelude.Linear.asTypeOf`

### DIFF
--- a/src/Prelude/Linear.hs
+++ b/src/Prelude/Linear.hs
@@ -82,7 +82,6 @@ module Prelude.Linear
     ($),
     (&),
     Prelude.until,
-    asTypeOf,
     Prelude.error,
     Prelude.errorWithoutStackTrace,
     Prelude.undefined,

--- a/src/Prelude/Linear/Internal.hs
+++ b/src/Prelude/Linear/Internal.hs
@@ -33,9 +33,6 @@ id x = x
 const :: a %q -> b -> a
 const x _ = x
 
-asTypeOf :: a %q -> a -> a
-asTypeOf = const
-
 -- | @seq x y@ only forces @x@ to head normal form, therefore is not guaranteed
 -- to consume @x@ when the resulting computation is consumed. Therefore, @seq@
 -- cannot be linear in it's first argument.


### PR DESCRIPTION
Closes #354 . The linked issue gives the motivations behind this removal.