### PR TITLE
Fix `linear-base.cabal` to allow upload on Hackage

### DIFF
--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -118,7 +118,6 @@ library
 
     hs-source-dirs:   src
     default-language: Haskell2010
-    ghc-options:      -O
     build-depends:
 
         base >=4.15 && <5,
@@ -201,7 +200,6 @@ benchmark mutable-data
         Data.Mutable.Array
 
     default-language: Haskell2010
-    ghc-options:      -O
     build-depends:
         base,
         vector,


### PR DESCRIPTION
When I tried to upload v0.2 to hackage with `stack upload .`, I got:
```
Getting file list for /home/tbagrel/tweag/linear-base/
linear-base> List of package sources written to file
linear-base> '/run/user/1000/stack-sdist-3581103229e842f1/source-files-list'
Building sdist tarball for /home/tbagrel/tweag/linear-base/
Checking package 'linear-base' for common mistakes
Package check reported the following warnings:
The 'description' field should be longer than the 'synopsis' field. It's useful to provide an informative 'description' to allow Haskell programmers who have never heard about your package to understand the purpose of your package. The 'description' field content is typically shown by tooling (e.g. 'cabal info', Haddock, Hackage) below the 'synopsis' which serves as a headline. Please refer to <https://www.haskell.org/cabal/users-guide/developing-packages.html#package-properties> for more details.
Package check reported the following errors:
'ghc-options: -O' is not needed. Cabal automatically adds the '-O' flag. Setting it yourself interferes with the --disable-optimization flag.
```