### PR TITLE
Change relative links for absolute ones in the README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## [v0.2.0](https://github.com/tweag/linear-base/tree/v0.2.0) - 2022-03-17
+## [v0.2.0](https://github.com/tweag/linear-base/tree/v0.2.0) - 2022-03-25
 
 [Full Changelog](https://github.com/tweag/linear-base/compare/v0.1.0...v0.2.0)
 
@@ -116,6 +116,7 @@
 
 ### Documentation improvements
 
+- Change relative links for absolute ones in the README [\#401](https://github.com/tweag/linear-base/pull/401) ([tbagrel1](https://github.com/tbagrel1))
 - Add comparison table between `Prelude` and `Prelude.Linear` classes [\#368](https://github.com/tweag/linear-base/pull/368) ([tbagrel1](https://github.com/tbagrel1))
 - Add Hackage and Stackage badges [\#336](https://github.com/tweag/linear-base/pull/336) ([utdemir](https://github.com/utdemir))
 - Hide internal modules from `haddock` documentation [\#326](https://github.com/tweag/linear-base/pull/326) ([utdemir](https://github.com/utdemir)), [\#363](https://github.com/tweag/linear-base/pull/363) ([tbagrel1](https://github.com/tbagrel1))

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ the top:
 
 If you already know what `-XLinearTypes` does and what the linear
 arrow `a %1-> b` means, then read the [User Guide] and explore the
-[`examples/`](./examples) folder to know how to use `linear-base`.
+[`examples/`](https://github.com/tweag/linear-base/blob/master/examples) folder to know how to use `linear-base`.
 
 You can also find a table comparing `base` and `linear-base` typeclasses
-[here](./docs/CLASS_TABLE.md).
+[here](https://github.com/tweag/linear-base/blob/master/docs/CLASS_TABLE.md).
 
 ## Learning about `-XLinearTypes`
 
@@ -55,7 +55,7 @@ There are plenty of excellent resources and examples to help you.
 
 ### Tutorials and examples
 
- * See the [`examples/`](./examples) folder.
+ * See the [`examples/`](https://github.com/tweag/linear-base/blob/master/examples) folder.
  * [Linear examples on watertight 3D models](https://github.com/gelisam/linear-examples)
 
 ### Reading material
@@ -87,13 +87,13 @@ making pull requests.
 
 ## Licence
 
-See the [Licence file](./LICENSE).
+See the [Licence file](https://github.com/tweag/linear-base/blob/master/LICENSE).
 
 Copyright © Tweag Holding and its affiliates.
 
 [Tweag]: https://www.tweag.io/
 [`base`]: https://hackage.haskell.org/package/base
-[User Guide]: ./docs/USER_GUIDE.md
-[Design Document]: ./docs/DESIGN.md
+[User Guide]: https://github.com/tweag/linear-base/blob/master/docs/USER_GUIDE.md
+[Design Document]: https://github.com/tweag/linear-base/blob/master/docs/DESIGN.md
 [hackage-pkg]: https://hackage.haskell.org/package/linear-base
 [stackage-pkg]: https://www.stackage.org/nightly/package/linear-base

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -24,7 +24,7 @@ if you are unfamiliar).
    library](https://hackage.haskell.org/package/streaming) is in
    `Streaming.Linear` and `Streaming.Prelude.Linear`.
  * How `Prelude.Linear` classes relate to their `base` (non-linear) counterpart is
-   described in the [class comparison table](./CLASS_TABLE.md).
+   described in the [class comparison table](https://github.com/tweag/linear-base/blob/master/docs/CLASS_TABLE.md).
 
 There are many other modules of course but a lot of the ones not already listed
 are still experimental, such as system-heap memory management in `Foreign.Marshall.Pure`.
@@ -169,6 +169,6 @@ useSubfunction arr = fromRead (read arr 0)
     fromRead = undefined
 ```
 
-[`Data.Unrestricted`]: ../src/Data/Unrestricted/Linear.hs
-[`Prelude.Linear`]: ../src/Prelude/Linear.hs
-[`README`]: ../README.md
+[`Data.Unrestricted`]: https://github.com/tweag/linear-base/blob/master/src/Data/Unrestricted/Linear.hs
+[`Prelude.Linear`]: https://github.com/tweag/linear-base/blob/master/src/Prelude/Linear.hs
+[`README`]: https://github.com/tweag/linear-base/blob/master/README.md


### PR DESCRIPTION
Thanks to this PR, the README displayed on [Hackage](https://hackage.haskell.org/package/linear-base) will have valid links.