### PR TITLE
More polymorphic type for `Array.alloc` and `HashMap.empty`

### DIFF
--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -183,7 +183,7 @@ test-suite examples
         base,
         linear-base,
         tasty,
-        tasty-hedgehog,
+        tasty-hedgehog < 1.2,
         hedgehog,
         storable-tuple,
         vector,

--- a/src/Data/Array/Mutable/Linear/Internal.hs
+++ b/src/Data/Array/Mutable/Linear/Internal.hs
@@ -65,8 +65,8 @@ alloc ::
   HasCallStack =>
   Int ->
   a ->
-  (Array a %1 -> Ur b) %1 ->
-  Ur b
+  (Array a %1 -> b) %1 ->
+  b
 alloc s x f
   | s < 0 =
       (error ("Array.alloc: negative size: " ++ show s) :: x %1 -> x)

--- a/src/Data/Array/Mutable/Unlifted/Linear.hs
+++ b/src/Data/Array/Mutable/Unlifted/Linear.hs
@@ -60,7 +60,7 @@ infixr 0 `lseq` -- same fixity as base.seq
 -- | Allocate a mutable array of given size using a default value.
 --
 -- The size should be non-negative.
-alloc :: Int -> a -> (Array# a %1 -> Ur b) %1 -> Ur b
+alloc :: Int -> a -> (Array# a %1 -> b) %1 -> b
 alloc (GHC.I# s) a f =
   let new = GHC.runRW# Prelude.$ \st ->
         case GHC.newArray# s a st of

--- a/src/Data/HashMap/Mutable/Linear/Internal.hs
+++ b/src/Data/HashMap/Mutable/Linear/Internal.hs
@@ -135,8 +135,8 @@ empty ::
   forall k v b.
   Keyed k =>
   Int ->
-  (HashMap k v %1 -> Ur b) %1 ->
-  Ur b
+  (HashMap k v %1 -> b) %1 ->
+  b
 empty size scope =
   let cap = max 1 size
    in Array.alloc cap Nothing (\arr -> scope (HashMap 0 cap arr))


### PR DESCRIPTION
Replacing response type `Ur b` by simply `b` also type checks and enables uses like
```haskell
let (i, _) = HashMap.empty 100 (\ env -> runState (eval e) env)
```
(see issue #404). Without this PR, the respective code would be
```haskell
let Ur i = HashMap.empty 100 (\ env -> move (fst (runState (eval e) env)))
```
with `fst :: Consumable b => (a, b) -> a`.  
The old typing of `empty` forces the insertion of `move` which can only happen after consuming the `env` via `fst` (because `HashMap` does not implement `Consumable`).  
The new code seem to be better, allowing `env` to be garbage-collected unforced once we want to dispose of it.

Caveat: I am relying on the linear type checker (which might be in alpha state, dunno), so there might be reasons unknown to me why this generalization is invalid.  Test suite passes, though.

Also in this PR: Restrict `tasty-hedgehog < 1.2` to make `cabal build` succeed.