### PR TITLE
Upgrade GHC to 9.2

### DIFF
--- a/bench/Data/Mutable/HashMap.hs
+++ b/bench/Data/Mutable/HashMap.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE LinearTypes #-}
@@ -39,7 +40,7 @@ deriving instance Ord Key
 
 deriving instance Generic Key
 
-deriving instance NFData Key
+deriving anyclass instance NFData Key
 
 instance Hashable Key where
   hash (Key x) =

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b2737d4980a17cc2b7d600d7d0b32fd7333aca88",
-        "sha256": "012db5d6k0lajp4q37byhgamz3ry04av1dcpgf3ahm9kzjwsjcch",
+        "rev": "7beebb590d541ffa534aa34b0b163f81c3c72c2c",
+        "sha256": "0lb134206mdrsxa3id61bn8p1ylwagv1k19jx1a0x9ywkfp0mvp1",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/b2737d4980a17cc2b7d600d7d0b32fd7333aca88.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/7beebb590d541ffa534aa34b0b163f81c3c72c2c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ system ? builtins.currentSystem, sources ? import ./nix/sources.nix, ghcVersion ? "902" }:
+{ system ? builtins.currentSystem, sources ? import ./nix/sources.nix, ghcVersion ? "922" }:
 
 let
   selectHls = self: super: {
@@ -19,9 +19,6 @@ let
         "
     '';
   };
-  brokenIn92 = if ghcVersion == "921" then [] else [
-    pkgs.haskell-language-server
-  ];
 in with pkgs;
 
 mkShell {
@@ -35,5 +32,6 @@ mkShell {
     stack-wrapped
     nix
     cabal-docspec
-  ] ++ brokenIn92;
+    pkgs.haskell-language-server
+  ];
 }

--- a/src/Control/Functor/Linear/Internal/Class.hs
+++ b/src/Control/Functor/Linear/Internal/Class.hs
@@ -241,12 +241,12 @@ instance Monoid a => Monad ((,) a) where
       go b1 (b2, y) = (b1 <> b2, y)
 
 deriving via
-  Generically1 (Sum f g)
+  Generically1 (Sum (f :: Type -> Type) g)
   instance
     (Functor f, Functor g) => Functor (Sum f g)
 
 deriving via
-  Generically1 (Compose f g)
+  Generically1 (Compose (f :: Type -> Type) (g :: Type -> Type))
   instance
     (Functor f, Functor g) => Functor (Compose f g)
 

--- a/src/Data/Functor/Linear/Internal/Applicative.hs
+++ b/src/Data/Functor/Linear/Internal/Applicative.hs
@@ -32,6 +32,7 @@ import Data.Monoid (Ap (..))
 import Data.Monoid.Linear hiding (Product)
 import Data.Unrestricted.Linear.Internal.Ur (Ur (..))
 import GHC.TypeLits
+import GHC.Types
 import Generics.Linear
 import Prelude.Linear.Generically
 import Prelude.Linear.Internal
@@ -96,12 +97,12 @@ deriving via
     Monoid a => Applicative ((,) a)
 
 deriving via
-  Generically1 (Product f g)
+  Generically1 (Product (f :: Type -> Type) g)
   instance
     (Applicative f, Applicative g) => Applicative (Product f g)
 
 deriving via
-  Generically1 (f :*: g)
+  Generically1 ((f :: Type -> Type) :*: g)
   instance
     (Applicative f, Applicative g) => Applicative (f :*: g)
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,9 +1,3 @@
-resolver: nightly-2022-01-13
+resolver: nightly-2022-04-28
 packages:
 - '.'
-extra-deps:
-- tasty-hedgehog-1.2.0.0
-- ormolu-0.4.0.0
-- Cabal-3.6.2.0@sha256:ae204c95edd633538c3e502eee8838dc41d8b13c8f333955a39ff9df7b6de9e8,12852
-- ghc-lib-parser-9.2.1.20220109@sha256:5da80d84452a31b7d0dab46d849a9c3552897405048d466b766136d852d20cfe,12705
-- linear-generics-0.2@sha256:c1db1fcb96333be867978abfbed71e99dfbdcafa07d7d9642a89405e6bc971b1,5818

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,45 +3,10 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages:
-- completed:
-    pantry-tree:
-      sha256: 31987ee70107c5c204137d6f75b401cf8ed5e57df1047ee17d9eb0d4a6f7bc24
-      size: 330
-    hackage: tasty-hedgehog-1.2.0.0@sha256:3deb98e9a9de9e27c25d02b7fe92ad5cf68d5163fdaaf35bca3923b3e671d46d,1803
-  original:
-    hackage: tasty-hedgehog-1.2.0.0
-- completed:
-    pantry-tree:
-      sha256: 59c9524f7e7a40b5be044fc805a6b9d6de898dfc4d156767b2429c06e1fba724
-      size: 84091
-    hackage: ormolu-0.4.0.0@sha256:cd5d2aee5fdeaee39fd0020b6c222578319cd79d5b09ece63d7c3346d363dcf2,4803
-  original:
-    hackage: ormolu-0.4.0.0
-- completed:
-    pantry-tree:
-      sha256: 4a5049fc88e0f97447501b4daf6f2f21576db16b3e500812342b23c77a3570c9
-      size: 19757
-    hackage: Cabal-3.6.2.0@sha256:ae204c95edd633538c3e502eee8838dc41d8b13c8f333955a39ff9df7b6de9e8,12852
-  original:
-    hackage: Cabal-3.6.2.0@sha256:ae204c95edd633538c3e502eee8838dc41d8b13c8f333955a39ff9df7b6de9e8,12852
-- completed:
-    pantry-tree:
-      sha256: adcd797fed395273b05a0e7fdf254cba76c6a9ceab573d78211447c6430ebb2a
-      size: 27578
-    hackage: ghc-lib-parser-9.2.1.20220109@sha256:5da80d84452a31b7d0dab46d849a9c3552897405048d466b766136d852d20cfe,12705
-  original:
-    hackage: ghc-lib-parser-9.2.1.20220109@sha256:5da80d84452a31b7d0dab46d849a9c3552897405048d466b766136d852d20cfe,12705
-- completed:
-    pantry-tree:
-      sha256: 62c6d4bb56b01f240bbc8cf276ddbe7f65ffa3f73cc430772a26d8769c08066b
-      size: 2818
-    hackage: linear-generics-0.2@sha256:c1db1fcb96333be867978abfbed71e99dfbdcafa07d7d9642a89405e6bc971b1,5818
-  original:
-    hackage: linear-generics-0.2@sha256:c1db1fcb96333be867978abfbed71e99dfbdcafa07d7d9642a89405e6bc971b1,5818
+packages: []
 snapshots:
 - completed:
-    sha256: df0d2c3ff3cd0424bf178914a068d76f3e48c89edfdcf9b015698836a106b507
-    size: 621061
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2022/1/13.yaml
-  original: nightly-2022-01-13
+    sha256: eb778a9c971802e22068265fb7b14d357c3eb7d76229402b9444a3db1a2bc153
+    size: 554661
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2022/4/28.yaml
+  original: nightly-2022-04-28


### PR DESCRIPTION
Part of #389.

---

This PR originally fixed the tasty-hedgehog deprecation warning. But because it turned out to that GHC 9.2 is having problem with our PR, I extracted this bit in #415.

I'll rebase on master as soon as #415 is merged to clear up the tasty-hedgehog bits.

---

Edit: I wanted to only make a draft PR, but I misclicked. I don't think that
I can convert it back. I don't know how anyway. I don't want to merge quite
yet, as there is a bug related to `stack ghci` which causes an anomaly in GHC:

```
$ stack ghci
Stack has not been tested with GHC versions above 9.0, and using 9.2.2, this may fail
Stack has not been tested with Cabal versions above 3.4, but version 3.6.3.0 was found, this may fail
Configuring GHCi with the following packages: linear-base
GHCi, version 9.2.2: https://www.haskell.org/ghc/  :? for help
[ 1 of 86] Compiling Data.Arity.Linear.Internal ( /home/aspiwack/projects/tweag/linear-base/master/src/Data/Arity/Linear/Internal.hs, interpreted )
[ 2 of 86] Compiling Data.Arity.Linear ( /home/aspiwack/projects/tweag/linear-base/master/src/Data/Arity/Linear.hs, interpreted )
[ 3 of 86] Compiling Data.Bool.Linear ( /home/aspiwack/projects/tweag/linear-base/master/src/Data/Bool/Linear.hs, interpreted )
[ 4 of 86] Compiling Prelude.Linear.GenericUtil ( /home/aspiwack/projects/tweag/linear-base/master/src/Prelude/Linear/GenericUtil.hs, interpreted )
[ 5 of 86] Compiling Data.Unrestricted.Linear.Internal.Ur ( /home/aspiwack/projects/tweag/linear-base/master/src/Data/Unrestricted/Linear/Internal/Ur.hs, interpreted )
[ 6 of 86] Compiling Prelude.Linear.Generically ( /home/aspiwack/projects/tweag/linear-base/master/src/Prelude/Linear/Generically.hs, interpreted )
[ 7 of 86] Compiling Prelude.Linear.Internal ( /home/aspiwack/projects/tweag/linear-base/master/src/Prelude/Linear/Internal.hs, interpreted )
[ 8 of 86] Compiling Data.Replicator.Linear.Internal.ReplicationStream ( /home/aspiwack/projects/tweag/linear-base/master/src/Data/Replicator/Linear/Internal/ReplicationStream.hs, interpreted )
[ 9 of 86] Compiling Data.Replicator.Linear.Internal ( /home/aspiwack/projects/tweag/linear-base/master/src/Data/Replicator/Linear/Internal.hs, interpreted )
[10 of 86] Compiling Prelude.Linear.Unsatisfiable ( /home/aspiwack/projects/tweag/linear-base/master/src/Prelude/Linear/Unsatisfiable.hs, interpreted )
[11 of 86] Compiling Unsafe.Linear    ( /home/aspiwack/projects/tweag/linear-base/master/src/Unsafe/Linear.hs, interpreted )
[12 of 86] Compiling Data.Unrestricted.Linear.Internal.Consumable ( /home/aspiwack/projects/tweag/linear-base/master/src/Data/Unrestricted/Linear/Internal/Consumable.hs, interpreted )
[13 of 86] Compiling Data.Unrestricted.Linear.Internal.Dupable ( /home/aspiwack/projects/tweag/linear-base/master/src/Data/Unrestricted/Linear/Internal/Dupable.hs, interpreted )
[14 of 86] Compiling Data.V.Linear.Internal ( /home/aspiwack/projects/tweag/linear-base/master/src/Data/V/Linear/Internal.hs, interpreted )
[15 of 86] Compiling Data.Tuple.Linear ( /home/aspiwack/projects/tweag/linear-base/master/src/Data/Tuple/Linear.hs, interpreted )
[16 of 86] Compiling Data.Monoid.Linear.Internal.Semigroup ( /home/aspiwack/projects/tweag/linear-base/master/src/Data/Monoid/Linear/Internal/Semigroup.hs, interpreted )
[17 of 86] Compiling Data.Monoid.Linear.Internal.Monoid ( /home/aspiwack/projects/tweag/linear-base/master/src/Data/Monoid/Linear/Internal/Monoid.hs, interpreted )
[18 of 86] Compiling Data.Monoid.Linear ( /home/aspiwack/projects/tweag/linear-base/master/src/Data/Monoid/Linear.hs, interpreted )
[19 of 86] Compiling Data.Functor.Linear.Internal.Functor ( /home/aspiwack/projects/tweag/linear-base/master/src/Data/Functor/Linear/Internal/Functor.hs, interpreted )
[20 of 86] Compiling Data.Functor.Linear.Internal.Applicative ( /home/aspiwack/projects/tweag/linear-base/master/src/Data/Functor/Linear/Internal/Applicative.hs, interpreted )

/home/aspiwack/projects/tweag/linear-base/master/src/Data/Functor/Linear/Internal/Applicative.hs:101:18: error:ghc: panic! (the 'impossible' happened)
  (GHC version 9.2.2:
	No skolem info:
  [k_ad3j]
  Call stack:
      CallStack (from HasCallStack):
        callStackDoc, called at compiler/GHC/Utils/Panic.hs:181:37 in ghc:GHC.Utils.Panic
        pprPanic, called at compiler/GHC/Tc/Errors.hs:2912:17 in ghc:GHC.Tc.Errors

Please report this as a GHC bug:  https://www.haskell.org/ghc/reportabug


<no location info>: error:
    Could not load module ‘Control.Functor.Linear’
    It is a member of the hidden package ‘linear-base-0.2.0’.
    You can run ‘:set -package linear-base’ to expose it.
    (Note: this unloads all the modules in the current scope.)
Loaded GHCi configuration from /tmp/haskell-stack-ghci/eea5bf06/ghci-script
```

I haven't investigated this problem yet, and I want to know a bit more before we merge

---

Another problem that I noticed is that the format script cannot install Ormolu anymore (due to an upper bound somewher)

- [ ] Investigate the anomaly
- [x] Fix Ormolu installation in the format script