### PR TITLE
Fix typo in comment: resrouce -> resource

### DIFF
--- a/src/System/IO/Resource/Linear/Internal.hs
+++ b/src/System/IO/Resource/Linear/Internal.hs
@@ -157,7 +157,7 @@ data UnsafeResource a where
 -- Note that both components are unrestricted.
 
 -- | Given an unsafe resource, release it with the linear IO action provided
--- when the resrouce was acquired.
+-- when the resource was acquired.
 unsafeRelease :: UnsafeResource a %1 -> RIO ()
 unsafeRelease (UnsafeResource key _) = RIO (\st -> Linear.mask_ (releaseWith key st))
   where


### PR DESCRIPTION
Hope it’s ok to make such a minor PR! Saw the typo and figured it might as well be fixed.