### PR TITLE
Add some Handle operations to RIO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### New additions
 
+- Add `System.IO.Resource.Linear.hSeek`
 - Add `System.IO.Resource.Linear.openBinaryFile`
+- Re-export `System.IO.SeekMode(..)` from `System.IO.Resource.Linear`
 
 ## [v0.2.0](https://github.com/tweag/linear-base/tree/v0.2.0) - 2022-03-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,5 @@
 # Change Log
 
-## Unreleased
-
-### New additions
-
-- Add `System.IO.Resource.Linear.hSeek`
-- Add `System.IO.Resource.Linear.hTell`
-- Add `System.IO.Resource.Linear.openBinaryFile`
-- Re-export `System.IO.SeekMode(..)` from `System.IO.Resource.Linear`
-
 ## [v0.2.0](https://github.com/tweag/linear-base/tree/v0.2.0) - 2022-03-25
 
 [Full Changelog](https://github.com/tweag/linear-base/compare/v0.1.0...v0.2.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Unreleased
+
+### New additions
+
+- Add `System.IO.Resource.Linear.openBinaryFile`
+
 ## [v0.2.0](https://github.com/tweag/linear-base/tree/v0.2.0) - 2022-03-25
 
 [Full Changelog](https://github.com/tweag/linear-base/compare/v0.1.0...v0.2.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New additions
 
 - Add `System.IO.Resource.Linear.hSeek`
+- Add `System.IO.Resource.Linear.hTell`
 - Add `System.IO.Resource.Linear.openBinaryFile`
 - Re-export `System.IO.SeekMode(..)` from `System.IO.Resource.Linear`
 

--- a/src/System/IO/Resource/Linear.hs
+++ b/src/System/IO/Resource/Linear.hs
@@ -39,6 +39,7 @@ module System.IO.Resource.Linear
 
     -- ** File I/O
     openFile,
+    openBinaryFile,
     System.IOMode (..),
 
     -- ** Working with Handles

--- a/src/System/IO/Resource/Linear.hs
+++ b/src/System/IO/Resource/Linear.hs
@@ -50,6 +50,8 @@ module System.IO.Resource.Linear
     hGetLine,
     hPutStr,
     hPutStrLn,
+    hSeek,
+    System.SeekMode(..),
 
     -- * Creating new types of resources
     -- $new-resources

--- a/src/System/IO/Resource/Linear.hs
+++ b/src/System/IO/Resource/Linear.hs
@@ -52,6 +52,7 @@ module System.IO.Resource.Linear
     hPutStrLn,
     hSeek,
     System.SeekMode(..),
+    hTell,
 
     -- * Creating new types of resources
     -- $new-resources

--- a/src/System/IO/Resource/Linear/Internal.hs
+++ b/src/System/IO/Resource/Linear/Internal.hs
@@ -158,6 +158,16 @@ hPutStrLn h s = flipHPutStrLn s h -- needs a multiplicity polymorphic flip
     flipHPutStrLn s =
       coerce (unsafeFromSystemIOResource_ (\h' -> Text.hPutStrLn h' s))
 
+-- | See @System.IO.'System.IO.hSeek'@.
+--
+-- @since 0.2.1
+hSeek :: Handle %1 -> System.SeekMode -> Integer -> RIO Handle
+hSeek h mode i = coerce hSeek' h
+  where
+    hSeek' :: Handle %1 -> RIO Handle
+    hSeek' =
+      coerce (unsafeFromSystemIOResource_ (\h' -> System.hSeek h' mode i))
+
 -- new-resources
 
 -- | The type of system resources.  To create and use resources, you need to

--- a/src/System/IO/Resource/Linear/Internal.hs
+++ b/src/System/IO/Resource/Linear/Internal.hs
@@ -114,6 +114,17 @@ openFile path mode = Control.do
       (\h -> Linear.fromSystemIO $ System.hClose h)
   Control.return $ Handle h
 
+-- | See @System.IO.'System.IO.openBinaryFile'@
+--
+-- @since 0.2.1
+openBinaryFile :: FilePath -> System.IOMode -> RIO Handle
+openBinaryFile path mode = Control.do
+  h <-
+    unsafeAcquire
+      (Linear.fromSystemIOU $ System.openFile path mode)
+      (\h -> Linear.fromSystemIO $ System.hClose h)
+  Control.pure $ Handle h
+
 hClose :: Handle %1 -> RIO ()
 hClose (Handle h) = unsafeRelease h
 

--- a/src/System/IO/Resource/Linear/Internal.hs
+++ b/src/System/IO/Resource/Linear/Internal.hs
@@ -168,6 +168,12 @@ hSeek h mode i = coerce hSeek' h
     hSeek' =
       coerce (unsafeFromSystemIOResource_ (\h' -> System.hSeek h' mode i))
 
+-- | See @System.IO.'System.IO.hTell'@.
+--
+-- @since 0.2.1
+hTell :: Handle %1 -> RIO (Ur Integer, Handle)
+hTell = coerce (unsafeFromSystemIOResource System.hTell)
+
 -- new-resources
 
 -- | The type of system resources.  To create and use resources, you need to

--- a/src/System/IO/Resource/Linear/Internal.hs
+++ b/src/System/IO/Resource/Linear/Internal.hs
@@ -105,7 +105,7 @@ instance Control.Monad RIO where
 
 newtype Handle = Handle (UnsafeResource System.Handle)
 
--- | See 'System.IO.openFile'
+-- | See @System.IO.'System.IO.openFile'@
 openFile :: FilePath -> System.IOMode -> RIO Handle
 openFile path mode = Control.do
   h <-

--- a/src/System/IO/Resource/Linear/Internal.hs
+++ b/src/System/IO/Resource/Linear/Internal.hs
@@ -116,7 +116,7 @@ openFile path mode = Control.do
 
 -- | See @System.IO.'System.IO.openBinaryFile'@
 --
--- @since 0.2.1
+-- @since 0.3.0
 openBinaryFile :: FilePath -> System.IOMode -> RIO Handle
 openBinaryFile path mode = Control.do
   h <-
@@ -160,7 +160,7 @@ hPutStrLn h s = flipHPutStrLn s h -- needs a multiplicity polymorphic flip
 
 -- | See @System.IO.'System.IO.hSeek'@.
 --
--- @since 0.2.1
+-- @since 0.3.0
 hSeek :: Handle %1 -> System.SeekMode -> Integer -> RIO Handle
 hSeek h mode i = coerce hSeek' h
   where
@@ -170,7 +170,7 @@ hSeek h mode i = coerce hSeek' h
 
 -- | See @System.IO.'System.IO.hTell'@.
 --
--- @since 0.2.1
+-- @since 0.3.0
 hTell :: Handle %1 -> RIO (Ur Integer, Handle)
 hTell = coerce (unsafeFromSystemIOResource System.hTell)
 


### PR DESCRIPTION
Add `System.IO.Resource.Linear.{openBinaryFile,hSeek,SeekMode(..),hTell}`.

Haddocks are in anticipation of a near 0.2.1 release; happy to change/remove the `@since` annotations if they're likely to be wrong.

Related: #424.