### PR TITLE
Update nix-shell to enable building with GHC 9.4.1

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7beebb590d541ffa534aa34b0b163f81c3c72c2c",
-        "sha256": "0lb134206mdrsxa3id61bn8p1ylwagv1k19jx1a0x9ywkfp0mvp1",
+        "rev": "f7af248d6037c02bfaa244abffa366db65412c42",
+        "sha256": "18blmhkd60wifcp7lfjwxjbvn6r94wpqgrfll2f22lr6ljiz7sd4",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/7beebb590d541ffa534aa34b0b163f81c3c72c2c.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/f7af248d6037c02bfaa244abffa366db65412c42.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ system ? builtins.currentSystem, sources ? import ./nix/sources.nix, ghcVersion ? "922" }:
+{ system ? builtins.currentSystem, sources ? import ./nix/sources.nix, ghcVersion ? "924" }:
 
 let
   selectHls = self: super: {
@@ -19,6 +19,9 @@ let
         "
     '';
   };
+  brokenIn94 = if ghcVersion == "941" then [] else [
+    pkgs.haskell-language-server
+  ];
 in with pkgs;
 
 mkShell {
@@ -32,6 +35,5 @@ mkShell {
     stack-wrapped
     nix
     cabal-docspec
-    pkgs.haskell-language-server
-  ];
+  ] ++ brokenIn94;
 }

--- a/src/Data/Functor/Linear/Internal/Applicative.hs
+++ b/src/Data/Functor/Linear/Internal/Applicative.hs
@@ -169,7 +169,8 @@ class GApplicative (s :: ErrorMessage) f where
 
 instance
   Unsatisfiable
-    ( 'Text "Cannot derive a data Applicative instance for" ':$$: s
+    ( 'Text "Cannot derive a data Applicative instance for"
+        ':$$: s
         ':$$: 'Text "because empty types cannot implement pure."
     ) =>
   GApplicative s V1
@@ -209,7 +210,8 @@ instance (GApplicative s f, GApplicative s g) => GApplicative s (f :*: g) where
 
 instance
   Unsatisfiable
-    ( 'Text "Cannot derive a data Applicative instance for" ':$$: s
+    ( 'Text "Cannot derive a data Applicative instance for"
+        ':$$: s
         ':$$: 'Text "because sum types do not admit a uniform Applicative definition."
     ) =>
   GApplicative s (x :+: y)
@@ -231,7 +233,8 @@ instance Monoid c => GApplicative s (K1 i c) where
 
 instance
   Unsatisfiable
-    ( 'Text "Cannot derive a data Applicative instance for" ':$$: s
+    ( 'Text "Cannot derive a data Applicative instance for"
+        ':$$: s
         ':$$: 'Text "because it contains one or more primitive unboxed fields."
         ':$$: 'Text "Such unboxed types lack canonical monoid operations."
     ) =>

--- a/src/Streaming/Linear/Internal/Many.hs
+++ b/src/Streaming/Linear/Internal/Many.hs
@@ -128,10 +128,10 @@ Zip functions have two design choices:
 (2) If the streams are of different length, do we keep or throw out the
 remainder of the longer stream?
 
-* We are assuming not to take infinite streams as input and instead deal with
+\* We are assuming not to take infinite streams as input and instead deal with
 reasonably small finite streams.
-* To avoid making choices for the user, we keep both end-of-stream payloads
-* The default zips (ones without a prime in the name) use @effects@ to consume
+\* To avoid making choices for the user, we keep both end-of-stream payloads
+\* The default zips (ones without a prime in the name) use @effects@ to consume
 the remainder stream after zipping. We include zip function variants that
 return no remainder (for equal length streams), or the remainder of the
 longer stream.

--- a/src/Streaming/Linear/Internal/Produce.hs
+++ b/src/Streaming/Linear/Internal/Produce.hs
@@ -277,7 +277,8 @@ untilM = loop
           testResult & \case
             False ->
               Control.return $
-                Step $ a :> loop test (AffineStream next step end)
+                Step $
+                  a :> loop test (AffineStream next step end)
             True -> Control.fmap Control.return $ end next
 {-# INLINEABLE untilM #-}
 
@@ -320,7 +321,8 @@ zip = loop
       stream & \case
         Return r1 ->
           Effect $
-            Control.fmap (\r2 -> Control.return $ (r1, r2)) $ end s
+            Control.fmap (\r2 -> Control.return $ (r1, r2)) $
+              end s
         Effect m ->
           Effect $
             Control.fmap (\str -> loop str (AffineStream s step end)) m
@@ -367,7 +369,8 @@ iterate a step =
     stepper :: Ur a %1 -> m (Either (Of a (Ur a)) ())
     stepper (Ur a) =
       Control.return $
-        Left $ a :> Ur (step a)
+        Left $
+          a :> Ur (step a)
 
 -- | An affine stream monadically iterating an initial state forever.
 iterateM ::
@@ -413,7 +416,8 @@ cycle stream =
           m Control.>>= (\stream -> stepStream (Ur s, stream))
         Step f ->
           Control.return $
-            Left $ Control.fmap ((,) (Ur s)) f
+            Left $
+              Control.fmap ((,) (Ur s)) f
 
 -- | An affine stream iterating an enumerated stream forever.
 enumFrom :: (Control.Monad m, Enum e) => e -> AffineStream (Of e) m ()

--- a/src/System/IO/Resource/Linear.hs
+++ b/src/System/IO/Resource/Linear.hs
@@ -51,7 +51,7 @@ module System.IO.Resource.Linear
     hPutStr,
     hPutStrLn,
     hSeek,
-    System.SeekMode(..),
+    System.SeekMode (..),
     hTell,
 
     -- * Creating new types of resources

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: nightly-2022-04-28
+resolver: nightly-2022-08-24 
 packages:
 - '.'

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: eb778a9c971802e22068265fb7b14d357c3eb7d76229402b9444a3db1a2bc153
-    size: 554661
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2022/4/28.yaml
-  original: nightly-2022-04-28
+    sha256: ff431937a638ebfaa5e6fec13c7ae575f01e02744d6ca5e5b1554f78cb5f88ad
+    size: 631953
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2022/8/24.yaml
+  original: nightly-2022-08-24


### PR DESCRIPTION
This PR updates `nix-shell` to enable building with either GHC 9.2.4 or 9.4.1. This required updating the stackage resolver to a 9.2.4-compatible one, which then also resulted in some formatting changes. 

The actual work of updating linear-base to build in 9.4.1 will come in a separate PR, so as not to muddle the diffs too much.