### PR TITLE
fix: build with GHC 9.6 (ghc-prim 0.10.0)

### DIFF
--- a/src/Data/Monoid/Linear/Internal/Semigroup.hs
+++ b/src/Data/Monoid/Linear/Internal/Semigroup.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE LinearTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_HADDOCK hide #-}
 
 -- | This module provides a linear version of 'Semigroup'.
@@ -165,7 +166,11 @@ instance Semigroup a => Semigroup (Maybe a) where
   Just x <> Just y = Just (x <> y)
 
 instance Semigroup a => Semigroup (Solo a) where
+#if MIN_VERSION_ghc_prim(0,10,0)
+  MkSolo x <> MkSolo y = MkSolo (x <> y)
+#else
   Solo x <> Solo y = Solo (x <> y)
+#endif
 
 -- See Data.List.Linear for instance ... => Semigroup [a]
 


### PR DESCRIPTION
Recent version of `ghc-prim` changed `Solo`.

With `ghc-prim < 0.10` , it was `data Solo = Solo a`, now it is `data Solo = MkSolo a` and `Solo` is a pattern.

This fixs the build with GHC 9.6 without breaking it with <9.6.