### PR TITLE
Moving from gauge to tasty-bench

### DIFF
--- a/bench/Data/Mutable/Array.hs
+++ b/bench/Data/Mutable/Array.hs
@@ -10,8 +10,8 @@ import qualified Data.Array.Mutable.Linear as Array.Linear
 import Data.Function ((&))
 import qualified Data.Unrestricted.Linear as Linear
 import qualified Data.Vector
-import Gauge
 import qualified Prelude.Linear as Linear
+import Test.Tasty.Bench
 
 dontFuse :: a -> a
 dontFuse a = a

--- a/bench/Data/Mutable/HashMap.hs
+++ b/bench/Data/Mutable/HashMap.hs
@@ -11,7 +11,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TupleSections #-}
 
-module Data.Mutable.HashMap (hmbench) where
+module Data.Mutable.HashMap (benchmarks) where
 
 import Control.DeepSeq (NFData (..), deepseq, force)
 import qualified Control.Monad.Random as Random
@@ -25,9 +25,9 @@ import Data.Hashable (Hashable (..), hashWithSalt)
 import Data.List (foldl')
 import qualified Data.Unrestricted.Linear as Linear
 import GHC.Generics (Generic)
-import Gauge
 import qualified Prelude.Linear as Linear
 import qualified System.Random.Shuffle as Random
+import Test.Tasty.Bench
 
 -- # Exported benchmarks
 -------------------------------------------------------------------------------
@@ -60,8 +60,8 @@ data BenchInput where
 
 instance NFData BenchInput
 
-hmbench :: Benchmark
-hmbench =
+benchmarks :: Benchmark
+benchmarks =
   bgroup
     "hashmaps"
     [ bgroup "linear-base:Data.HashMap.Mutable.Linear" $

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -1,12 +1,12 @@
 module Main where
 
 import qualified Data.Mutable.Array as Array
-import Data.Mutable.HashMap (hmbench)
-import Gauge
+import qualified Data.Mutable.HashMap as HashMap
+import Test.Tasty.Bench (defaultMain)
 
 main :: IO ()
 main = do
   defaultMain
-    [ hmbench,
-      Array.benchmarks
+    [ Array.benchmarks,
+      HashMap.benchmarks
     ]

--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -216,11 +216,11 @@ benchmark mutable-data
         base,
         vector,
         deepseq,
-        gauge,
         hashtables,
         hashable,
         linear-base,
         random,
         random-shuffle,
+        tasty-bench >= 0.3,
         unordered-containers,
         MonadRandom


### PR DESCRIPTION
This commit replaces the `gauge` benchmark framework with `tasty-bench` for the `linear-base:bench` target. The API is the same in both tools, so the change is mostly transparent.