### PR TITLE
Deprecate cycle, repeat, and iterate

### DIFF
--- a/src/Data/List/Linear.hs
+++ b/src/Data/List/Linear.hs
@@ -284,14 +284,17 @@ or = foldl' (||) False
 -- # Building Lists
 --------------------------------------------------
 
+{-# DEPRECATED iterate "The result cannot be consumed linearly, so this function is not useful." #-}
 iterate :: (Dupable a) => (a %1 -> a) -> a %1 -> [a]
 iterate f a =
   dup2 a & \(a', a'') ->
     a' : iterate f (f a'')
 
+{-# DEPRECATED repeat "The result cannot be consumed linearly, so this function is not useful." #-}
 repeat :: (Dupable a) => a %1 -> [a]
 repeat = iterate id
 
+{-# DEPRECATED cycle "The result cannot be consumed linearly, so this function is not useful." #-}
 cycle :: (HasCallStack, Dupable a) => [a] %1 -> [a]
 cycle [] = Prelude.error "cycle: empty list"
 cycle xs = dup2 xs & \(xs', xs'') -> xs' ++ cycle xs''


### PR DESCRIPTION
Deprecate `Data.List.Linear.{cycle,repeat,iterate}`. Infinite results cannot be consumed linearly, so they are not really useful in a linear context. They could be consumed by a program that exits via an exception, but I don't think that's something that should really be supported.

Begins to address #453