### PR TITLE
Adds `Functor` instances for a linear arrow

### DIFF
--- a/src/Control/Functor/Linear/Internal/Class.hs
+++ b/src/Control/Functor/Linear/Internal/Class.hs
@@ -47,11 +47,12 @@ import Data.Functor.Identity
 import qualified Data.Functor.Linear.Internal.Applicative as Data
 import qualified Data.Functor.Linear.Internal.Functor as Data
 import Data.Functor.Sum
+import Data.Kind (FUN)
 import Data.Monoid.Linear hiding (Sum)
 import Data.Type.Bool
 import Data.Unrestricted.Linear.Internal.Consumable
 import GHC.TypeLits
-import GHC.Types (Type)
+import GHC.Types (Multiplicity (..), Type)
 import Generics.Linear
 import Prelude.Linear.Generically
 import Prelude.Linear.Internal
@@ -249,6 +250,9 @@ deriving via
   Generically1 (Compose (f :: Type -> Type) (g :: Type -> Type))
   instance
     (Functor f, Functor g) => Functor (Compose f g)
+
+instance Functor (FUN 'One a) where
+  fmap = (.)
 
 ------------------------
 -- Generics instances --

--- a/src/Data/Functor/Linear/Internal/Functor.hs
+++ b/src/Data/Functor/Linear/Internal/Functor.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -30,8 +31,10 @@ import Data.Functor.Const
 import Data.Functor.Identity
 import Data.Functor.Product
 import Data.Functor.Sum
+import Data.Kind (FUN)
 import Data.Unrestricted.Linear.Internal.Consumable
 import Data.Unrestricted.Linear.Internal.Ur
+import GHC.Types (Multiplicity (..))
 import Generics.Linear
 import Prelude.Linear.Generically
 import Prelude.Linear.Internal
@@ -125,6 +128,9 @@ instance (Functor f, Functor g) => Functor (Compose f g) where
 
 instance Functor Ur where
   fmap f (Ur a) = Ur (f a)
+
+instance Functor (FUN 'One a) where
+  fmap = (.)
 
 ---------------------------------
 -- Monad transformer instances --


### PR DESCRIPTION
As reported in #459, `linear-base` accidentally lacked `Functor` instances for a linear arrow.
This PR adds them.