### PR TITLE
Implements `Semigroup` / `Monoid` instances for `Ur`

### DIFF
--- a/src/Data/Monoid/Linear/Internal/Monoid.hs
+++ b/src/Data/Monoid/Linear/Internal/Monoid.hs
@@ -30,6 +30,7 @@ import Data.Monoid.Linear.Internal.Semigroup
 import Data.Ord (Down (Down))
 import Data.Proxy (Proxy (Proxy))
 import Data.Unrestricted.Linear.Internal.Consumable (Consumable)
+import qualified Data.Unrestricted.Linear.Internal.Ur as Ur
 import GHC.Types hiding (Any)
 import Prelude.Linear.Internal
 import Prelude (Maybe (Nothing))
@@ -141,3 +142,8 @@ instance (Monoid (f (g a))) => Monoid (Functor.Compose f g a) where
 
 instance (Monoid a, Monoid b, Monoid c, Monoid d, Monoid e) => Monoid (a, b, c, d, e) where
   mempty = (mempty, mempty, mempty, mempty, mempty)
+
+-- | Useful to treat /unrestricted/ monoids as linear ones.
+instance (Prelude.Monoid a) => Monoid (Ur.Ur a) where
+  mempty = Ur.Ur Prelude.mempty
+  {-# INLINE mempty #-}

--- a/src/Data/Monoid/Linear/Internal/Semigroup.hs
+++ b/src/Data/Monoid/Linear/Internal/Semigroup.hs
@@ -49,6 +49,7 @@ import Data.Semigroup
 import qualified Data.Semigroup as Prelude
 import qualified Data.Tuple.Linear.Compat as Tuple
 import Data.Unrestricted.Linear.Internal.Consumable (Consumable, lseq)
+import qualified Data.Unrestricted.Linear.Internal.Ur as Ur
 import Data.Void (Void)
 import GHC.Tuple
 import GHC.Types hiding (Any)
@@ -208,3 +209,8 @@ instance (Semigroup (f (g a))) => Semigroup (Functor.Compose f g a) where
 
 instance (Semigroup a, Semigroup b, Semigroup c, Semigroup d, Semigroup e) => Semigroup (a, b, c, d, e) where
   (x1, x2, x3, x4, x5) <> (y1, y2, y3, y4, y5) = (x1 <> y1, x2 <> y2, x3 <> y3, x4 <> y4, x5 <> y5)
+
+-- | Useful to treat /unrestricted/ semigroups as linear ones.
+instance (Prelude.Semigroup a) => Semigroup (Ur.Ur a) where
+  (<>) = Ur.lift2 (Prelude.<>)
+  {-# INLINE (<>) #-}


### PR DESCRIPTION
# Description
This PR adds linear `Semigroup` and `Monoid` instances for `Ur`, which turns unrestricted ones into linear ones.

## Motivation

This instance is particuarly useful when one extract unrestricted monoidal value out of linear values; e.g. `foldMap` of Pull and/or Push Arrays.
I used them to [test my custom vector-generic `fromVector` for pull arrays without allocating vector](https://github.com/konn/linear-array-extra/blob/main/test/Data/Array/Polarized/Pull/ExtraSpec.hs#L50) ([corresponding instance definition](https://github.com/konn/linear-array-extra/blob/c6c89ac424620a2ebde41a52dce8241c2799e65f/test/Linear/Array/Extra/TestUtils.hs#L249-L253))
