### PR TITLE
Adds missing Data.Num.Linear.* instances for Word, Integer, Natural, Float, Word8/16/32/64 Int8/16/32/64

### DIFF
--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -135,6 +135,7 @@ library
         base >=4.16 && <5,
         containers,
         ghc-prim,
+        ghc-bignum,
         hashable,
         linear-generics >= 0.2,
         storable-tuple,

--- a/src/Data/Num/Linear.hs
+++ b/src/Data/Num/Linear.hs
@@ -46,6 +46,9 @@ import Data.Monoid.Linear
 import Data.Unrestricted.Linear
 import qualified Unsafe.Linear as Unsafe
 import qualified Prelude
+import qualified Data.Word
+import GHC.Num.Natural (Natural)
+import qualified Data.Int
 
 -- | A type that can be added linearly.  The operation @(+)@ is associative and
 -- commutative, i.e., for all @a@, @b@, @c@
@@ -209,37 +212,141 @@ instance (AddIdentity a) => Monoid (Sum a) where
   mempty = Sum zero
 
 deriving via MovableNum Prelude.Int instance Additive Prelude.Int
-
-deriving via MovableNum Prelude.Double instance Additive Prelude.Double
-
 deriving via MovableNum Prelude.Int instance AddIdentity Prelude.Int
-
-deriving via MovableNum Prelude.Double instance AddIdentity Prelude.Double
-
 deriving via MovableNum Prelude.Int instance AdditiveGroup Prelude.Int
-
-deriving via MovableNum Prelude.Double instance AdditiveGroup Prelude.Double
-
 deriving via MovableNum Prelude.Int instance Multiplicative Prelude.Int
-
-deriving via MovableNum Prelude.Double instance Multiplicative Prelude.Double
-
 deriving via MovableNum Prelude.Int instance MultIdentity Prelude.Int
-
-deriving via MovableNum Prelude.Double instance MultIdentity Prelude.Double
-
 deriving via MovableNum Prelude.Int instance Semiring Prelude.Int
-
-deriving via MovableNum Prelude.Double instance Semiring Prelude.Double
-
 deriving via MovableNum Prelude.Int instance Ring Prelude.Int
-
-deriving via MovableNum Prelude.Double instance Ring Prelude.Double
-
 deriving via MovableNum Prelude.Int instance FromInteger Prelude.Int
-
-deriving via MovableNum Prelude.Double instance FromInteger Prelude.Double
-
 deriving via MovableNum Prelude.Int instance Num Prelude.Int
 
+deriving via MovableNum Prelude.Word instance Additive Prelude.Word
+deriving via MovableNum Prelude.Word instance AddIdentity Prelude.Word
+deriving via MovableNum Prelude.Word instance AdditiveGroup Prelude.Word
+deriving via MovableNum Prelude.Word instance Multiplicative Prelude.Word
+deriving via MovableNum Prelude.Word instance MultIdentity Prelude.Word
+deriving via MovableNum Prelude.Word instance Semiring Prelude.Word
+deriving via MovableNum Prelude.Word instance Ring Prelude.Word
+deriving via MovableNum Prelude.Word instance FromInteger Prelude.Word
+deriving via MovableNum Prelude.Word instance Num Prelude.Word
+
+deriving via MovableNum Prelude.Double instance Additive Prelude.Double
+deriving via MovableNum Prelude.Double instance AddIdentity Prelude.Double
+deriving via MovableNum Prelude.Double instance AdditiveGroup Prelude.Double
+deriving via MovableNum Prelude.Double instance Multiplicative Prelude.Double
+deriving via MovableNum Prelude.Double instance MultIdentity Prelude.Double
+deriving via MovableNum Prelude.Double instance Semiring Prelude.Double
+deriving via MovableNum Prelude.Double instance Ring Prelude.Double
+deriving via MovableNum Prelude.Double instance FromInteger Prelude.Double
 deriving via MovableNum Prelude.Double instance Num Prelude.Double
+
+deriving via MovableNum Prelude.Float instance Additive Prelude.Float
+deriving via MovableNum Prelude.Float instance AddIdentity Prelude.Float
+deriving via MovableNum Prelude.Float instance AdditiveGroup Prelude.Float
+deriving via MovableNum Prelude.Float instance Multiplicative Prelude.Float
+deriving via MovableNum Prelude.Float instance MultIdentity Prelude.Float
+deriving via MovableNum Prelude.Float instance Semiring Prelude.Float
+deriving via MovableNum Prelude.Float instance Ring Prelude.Float
+deriving via MovableNum Prelude.Float instance FromInteger Prelude.Float
+deriving via MovableNum Prelude.Float instance Num Prelude.Float
+
+deriving via MovableNum Prelude.Integer instance Additive Prelude.Integer
+deriving via MovableNum Prelude.Integer instance AddIdentity Prelude.Integer
+deriving via MovableNum Prelude.Integer instance AdditiveGroup Prelude.Integer
+deriving via MovableNum Prelude.Integer instance Multiplicative Prelude.Integer
+deriving via MovableNum Prelude.Integer instance MultIdentity Prelude.Integer
+deriving via MovableNum Prelude.Integer instance Semiring Prelude.Integer
+deriving via MovableNum Prelude.Integer instance Ring Prelude.Integer
+deriving via MovableNum Prelude.Integer instance FromInteger Prelude.Integer
+deriving via MovableNum Prelude.Integer instance Num Prelude.Integer
+
+deriving via MovableNum Natural instance Additive Natural
+deriving via MovableNum Natural instance AddIdentity Natural
+deriving via MovableNum Natural instance AdditiveGroup Natural
+deriving via MovableNum Natural instance Multiplicative Natural
+deriving via MovableNum Natural instance MultIdentity Natural
+deriving via MovableNum Natural instance Semiring Natural
+-- NOTE: Natural is not a Ring; no element but 0 has an additive inverse.
+deriving via MovableNum Natural instance FromInteger Natural
+
+deriving via MovableNum Data.Int.Int8 instance Additive Data.Int.Int8
+deriving via MovableNum Data.Int.Int8 instance AddIdentity Data.Int.Int8
+deriving via MovableNum Data.Int.Int8 instance AdditiveGroup Data.Int.Int8
+deriving via MovableNum Data.Int.Int8 instance Multiplicative Data.Int.Int8
+deriving via MovableNum Data.Int.Int8 instance MultIdentity Data.Int.Int8
+deriving via MovableNum Data.Int.Int8 instance Semiring Data.Int.Int8
+deriving via MovableNum Data.Int.Int8 instance Ring Data.Int.Int8
+deriving via MovableNum Data.Int.Int8 instance FromInteger Data.Int.Int8
+deriving via MovableNum Data.Int.Int8 instance Num Data.Int.Int8
+
+deriving via MovableNum Data.Int.Int16 instance Additive Data.Int.Int16
+deriving via MovableNum Data.Int.Int16 instance AddIdentity Data.Int.Int16
+deriving via MovableNum Data.Int.Int16 instance AdditiveGroup Data.Int.Int16
+deriving via MovableNum Data.Int.Int16 instance Multiplicative Data.Int.Int16
+deriving via MovableNum Data.Int.Int16 instance MultIdentity Data.Int.Int16
+deriving via MovableNum Data.Int.Int16 instance Semiring Data.Int.Int16
+deriving via MovableNum Data.Int.Int16 instance Ring Data.Int.Int16
+deriving via MovableNum Data.Int.Int16 instance FromInteger Data.Int.Int16
+deriving via MovableNum Data.Int.Int16 instance Num Data.Int.Int16
+
+deriving via MovableNum Data.Int.Int32 instance Additive Data.Int.Int32
+deriving via MovableNum Data.Int.Int32 instance AddIdentity Data.Int.Int32
+deriving via MovableNum Data.Int.Int32 instance AdditiveGroup Data.Int.Int32
+deriving via MovableNum Data.Int.Int32 instance Multiplicative Data.Int.Int32
+deriving via MovableNum Data.Int.Int32 instance MultIdentity Data.Int.Int32
+deriving via MovableNum Data.Int.Int32 instance Semiring Data.Int.Int32
+deriving via MovableNum Data.Int.Int32 instance Ring Data.Int.Int32
+deriving via MovableNum Data.Int.Int32 instance FromInteger Data.Int.Int32
+deriving via MovableNum Data.Int.Int32 instance Num Data.Int.Int32
+
+deriving via MovableNum Data.Int.Int64 instance Additive Data.Int.Int64
+deriving via MovableNum Data.Int.Int64 instance AddIdentity Data.Int.Int64
+deriving via MovableNum Data.Int.Int64 instance AdditiveGroup Data.Int.Int64
+deriving via MovableNum Data.Int.Int64 instance Multiplicative Data.Int.Int64
+deriving via MovableNum Data.Int.Int64 instance MultIdentity Data.Int.Int64
+deriving via MovableNum Data.Int.Int64 instance Semiring Data.Int.Int64
+deriving via MovableNum Data.Int.Int64 instance Ring Data.Int.Int64
+deriving via MovableNum Data.Int.Int64 instance FromInteger Data.Int.Int64
+deriving via MovableNum Data.Int.Int64 instance Num Data.Int.Int64
+
+
+deriving via MovableNum Data.Word.Word8 instance Additive Data.Word.Word8
+deriving via MovableNum Data.Word.Word8 instance AddIdentity Data.Word.Word8
+deriving via MovableNum Data.Word.Word8 instance AdditiveGroup Data.Word.Word8
+deriving via MovableNum Data.Word.Word8 instance Multiplicative Data.Word.Word8
+deriving via MovableNum Data.Word.Word8 instance MultIdentity Data.Word.Word8
+deriving via MovableNum Data.Word.Word8 instance Semiring Data.Word.Word8
+deriving via MovableNum Data.Word.Word8 instance Ring Data.Word.Word8
+deriving via MovableNum Data.Word.Word8 instance FromInteger Data.Word.Word8
+deriving via MovableNum Data.Word.Word8 instance Num Data.Word.Word8
+
+deriving via MovableNum Data.Word.Word16 instance Additive Data.Word.Word16
+deriving via MovableNum Data.Word.Word16 instance AddIdentity Data.Word.Word16
+deriving via MovableNum Data.Word.Word16 instance AdditiveGroup Data.Word.Word16
+deriving via MovableNum Data.Word.Word16 instance Multiplicative Data.Word.Word16
+deriving via MovableNum Data.Word.Word16 instance MultIdentity Data.Word.Word16
+deriving via MovableNum Data.Word.Word16 instance Semiring Data.Word.Word16
+deriving via MovableNum Data.Word.Word16 instance Ring Data.Word.Word16
+deriving via MovableNum Data.Word.Word16 instance FromInteger Data.Word.Word16
+deriving via MovableNum Data.Word.Word16 instance Num Data.Word.Word16
+
+deriving via MovableNum Data.Word.Word32 instance Additive Data.Word.Word32
+deriving via MovableNum Data.Word.Word32 instance AddIdentity Data.Word.Word32
+deriving via MovableNum Data.Word.Word32 instance AdditiveGroup Data.Word.Word32
+deriving via MovableNum Data.Word.Word32 instance Multiplicative Data.Word.Word32
+deriving via MovableNum Data.Word.Word32 instance MultIdentity Data.Word.Word32
+deriving via MovableNum Data.Word.Word32 instance Semiring Data.Word.Word32
+deriving via MovableNum Data.Word.Word32 instance Ring Data.Word.Word32
+deriving via MovableNum Data.Word.Word32 instance FromInteger Data.Word.Word32
+deriving via MovableNum Data.Word.Word32 instance Num Data.Word.Word32
+
+deriving via MovableNum Data.Word.Word64 instance Additive Data.Word.Word64
+deriving via MovableNum Data.Word.Word64 instance AddIdentity Data.Word.Word64
+deriving via MovableNum Data.Word.Word64 instance AdditiveGroup Data.Word.Word64
+deriving via MovableNum Data.Word.Word64 instance Multiplicative Data.Word.Word64
+deriving via MovableNum Data.Word.Word64 instance MultIdentity Data.Word.Word64
+deriving via MovableNum Data.Word.Word64 instance Semiring Data.Word.Word64
+deriving via MovableNum Data.Word.Word64 instance Ring Data.Word.Word64
+deriving via MovableNum Data.Word.Word64 instance FromInteger Data.Word.Word64
+deriving via MovableNum Data.Word.Word64 instance Num Data.Word.Word64

--- a/src/Data/Num/Linear.hs
+++ b/src/Data/Num/Linear.hs
@@ -42,13 +42,13 @@ where
 
 -- TODO: flesh out laws
 
+import qualified Data.Int
 import Data.Monoid.Linear
 import Data.Unrestricted.Linear
-import qualified Unsafe.Linear as Unsafe
-import qualified Prelude
 import qualified Data.Word
 import GHC.Num.Natural (Natural)
-import qualified Data.Int
+import qualified Unsafe.Linear as Unsafe
+import qualified Prelude
 
 -- | A type that can be added linearly.  The operation @(+)@ is associative and
 -- commutative, i.e., for all @a@, @b@, @c@
@@ -211,6 +211,7 @@ instance (MultIdentity a) => Monoid (Product a) where
 instance (AddIdentity a) => Monoid (Sum a) where
   mempty = Sum zero
 
+{- ORMOLU_DISABLE -}
 deriving via MovableNum Prelude.Int instance Additive Prelude.Int
 deriving via MovableNum Prelude.Int instance AddIdentity Prelude.Int
 deriving via MovableNum Prelude.Int instance AdditiveGroup Prelude.Int
@@ -310,7 +311,6 @@ deriving via MovableNum Data.Int.Int64 instance Ring Data.Int.Int64
 deriving via MovableNum Data.Int.Int64 instance FromInteger Data.Int.Int64
 deriving via MovableNum Data.Int.Int64 instance Num Data.Int.Int64
 
-
 deriving via MovableNum Data.Word.Word8 instance Additive Data.Word.Word8
 deriving via MovableNum Data.Word.Word8 instance AddIdentity Data.Word.Word8
 deriving via MovableNum Data.Word.Word8 instance AdditiveGroup Data.Word.Word8
@@ -350,3 +350,4 @@ deriving via MovableNum Data.Word.Word64 instance Semiring Data.Word.Word64
 deriving via MovableNum Data.Word.Word64 instance Ring Data.Word.Word64
 deriving via MovableNum Data.Word.Word64 instance FromInteger Data.Word.Word64
 deriving via MovableNum Data.Word.Word64 instance Num Data.Word.Word64
+{- ORMOLU_ENABLE -}

--- a/src/Data/Unrestricted/Linear/Internal/Instances.hs
+++ b/src/Data/Unrestricted/Linear/Internal/Instances.hs
@@ -167,8 +167,8 @@ deriving via (AsMovable Natural) instance Consumable Natural
 deriving via (AsMovable Natural) instance Dupable Natural
 
 instance Movable Natural where
-  -- /!\ 'Integer' is a sum type whose three possibilities each are strict wrappers of unboxed unlifed data types.
-  -- (source: https://hackage.haskell.org/package/ghc-bignum-1.2/docs/GHC-Num-Integer.html#t:Integer)
+  -- /!\ 'Natural' is a sum type whose two possibilities each are strict wrappers of unboxed unlifed data types.
+  -- (source: https://hackage.haskell.org/package/ghc-bignum-1.2/docs/GHC-Num-Natural.html#t:Natural)
   -- Therefore it cannot have any linear values hidden in a closure anywhere. Therefore it is safe to call
   -- non-linear functions linearly on this type: there is no difference between 
   -- copying an 'Integer' and using it several times. /!\

--- a/src/Data/Unrestricted/Linear/Internal/Instances.hs
+++ b/src/Data/Unrestricted/Linear/Internal/Instances.hs
@@ -33,10 +33,10 @@ import Data.V.Linear.Internal (V (..))
 import qualified Data.V.Linear.Internal as V
 import qualified Data.Vector as Vector
 import GHC.Int
+import GHC.Num.Integer (Integer (..))
+import GHC.Num.Natural (Natural (..))
 import GHC.TypeLits
 import GHC.Word
-import GHC.Num.Integer (Integer(..))
-import GHC.Num.Natural (Natural(..))
 import Prelude.Linear.Internal
 import qualified Unsafe.Linear as Unsafe
 import qualified Prelude
@@ -156,7 +156,7 @@ instance Movable Integer where
   -- /!\ 'Integer' is a sum type whose three possibilities each are strict wrappers of unboxed unlifed data types.
   -- (source: https://hackage.haskell.org/package/ghc-bignum-1.2/docs/GHC-Num-Integer.html#t:Integer)
   -- Therefore it cannot have any linear values hidden in a closure anywhere. Therefore it is safe to call
-  -- non-linear functions linearly on this type: there is no difference between 
+  -- non-linear functions linearly on this type: there is no difference between
   -- copying an 'Integer' and using it several times. /!\
   move (IS i) = Unsafe.toLinear (\j -> Ur (IS j)) i
   move (IP i) = Unsafe.toLinear (\j -> Ur (IP j)) i
@@ -170,7 +170,7 @@ instance Movable Natural where
   -- /!\ 'Natural' is a sum type whose two possibilities each are strict wrappers of unboxed unlifed data types.
   -- (source: https://hackage.haskell.org/package/ghc-bignum-1.2/docs/GHC-Num-Natural.html#t:Natural)
   -- Therefore it cannot have any linear values hidden in a closure anywhere. Therefore it is safe to call
-  -- non-linear functions linearly on this type: there is no difference between 
+  -- non-linear functions linearly on this type: there is no difference between
   -- copying an 'Integer' and using it several times. /!\
   move (NS i) = Unsafe.toLinear (\j -> Ur (NS j)) i
   move (NB i) = Unsafe.toLinear (\j -> Ur (NB j)) i

--- a/src/Data/Unrestricted/Linear/Internal/Instances.hs
+++ b/src/Data/Unrestricted/Linear/Internal/Instances.hs
@@ -35,6 +35,8 @@ import qualified Data.Vector as Vector
 import GHC.Int
 import GHC.TypeLits
 import GHC.Word
+import GHC.Num.Integer (Integer(..))
+import GHC.Num.Natural (Natural(..))
 import Prelude.Linear.Internal
 import qualified Unsafe.Linear as Unsafe
 import qualified Prelude
@@ -145,6 +147,33 @@ instance Movable Word64 where
   -- non-linear functions linearly on this type: there is no difference between
   -- copying an 'Word64#' and using it several times. /!\
   move (W64# i) = Unsafe.toLinear (\j -> Ur (W64# j)) i
+
+deriving via (AsMovable Integer) instance Consumable Integer
+
+deriving via (AsMovable Integer) instance Dupable Integer
+
+instance Movable Integer where
+  -- /!\ 'Integer' is a sum type whose three possibilities each are strict wrappers of unboxed unlifed data types.
+  -- (source: https://hackage.haskell.org/package/ghc-bignum-1.2/docs/GHC-Num-Integer.html#t:Integer)
+  -- Therefore it cannot have any linear values hidden in a closure anywhere. Therefore it is safe to call
+  -- non-linear functions linearly on this type: there is no difference between 
+  -- copying an 'Integer' and using it several times. /!\
+  move (IS i) = Unsafe.toLinear (\j -> Ur (IS j)) i
+  move (IP i) = Unsafe.toLinear (\j -> Ur (IP j)) i
+  move (IN i) = Unsafe.toLinear (\j -> Ur (IN j)) i
+
+deriving via (AsMovable Natural) instance Consumable Natural
+
+deriving via (AsMovable Natural) instance Dupable Natural
+
+instance Movable Natural where
+  -- /!\ 'Integer' is a sum type whose three possibilities each are strict wrappers of unboxed unlifed data types.
+  -- (source: https://hackage.haskell.org/package/ghc-bignum-1.2/docs/GHC-Num-Integer.html#t:Integer)
+  -- Therefore it cannot have any linear values hidden in a closure anywhere. Therefore it is safe to call
+  -- non-linear functions linearly on this type: there is no difference between 
+  -- copying an 'Integer' and using it several times. /!\
+  move (NS i) = Unsafe.toLinear (\j -> Ur (NS j)) i
+  move (NB i) = Unsafe.toLinear (\j -> Ur (NB j)) i
 
 -- TODO: instances for longer primitive tuples
 -- TODO: default instances based on the Generic framework


### PR DESCRIPTION
This PR fixes two (related) issues (#403 and #466):

- Movable (and derived `Consumable`/`Dupable`) instances are added for `Integer` and `Natural`. This is safe since these types are represented as strict sum types whose elements are unlifed unboxed primitives so there is no way laziness might break linearity in there. (See also the [last part of the discussion in #403](https://github.com/tweag/linear-base/issues/403#issuecomment-1706679338))
- Instances for the typeclasses in `Data.Num.linear` (`Additive`/`AddIdentity`/`AdditiveGroup`/`Multiplicative`/`MultIdentity`/`Semiring`/`Ring`/`Num`) for the general-purpose number types that exist in the Prelude/`base` which were still missing them:
  - `Word`
  - `Float`
  - `Integer`
  - `Natural`
  - `Word8`/`Word16`/`Word32`/`Word64`
  - `Int8`/`Int16`/`Int32`/`Int64`

Still missing are:
- Instances for `Ratio a` and `Complex a`.
- Instances for `Foreign.C.Types` like `CInt`/`CFloat` etc.
- Instances for `Foreign.Ptr` types like `IntPtr`, `WordPtr`.

Those could be added just as easily but because I was not 100% sure whether adding linear instances for them would be (morally) correct or have unintended consequences that might break linearity in ineffable ways, I left them alone for now.