### PR TITLE
Add safeIndex for Pull Arrays

### DIFF
--- a/src/Data/Array/Polarized/Pull.hs
+++ b/src/Data/Array/Polarized/Pull.hs
@@ -28,6 +28,7 @@ module Data.Array.Polarized.Pull
     split,
     reverse,
     index,
+    safeIndex,
   )
 where
 

--- a/src/Data/Array/Polarized/Pull/Internal.hs
+++ b/src/Data/Array/Polarized/Pull/Internal.hs
@@ -113,3 +113,7 @@ reverse (Array f n) = Array (\x -> f (n + 1 - x)) n
 -- | Index a pull array (without checking bounds)
 index :: Array a %1 -> Int -> (a, Array a)
 index (Array f n) ix = (f ix, Array f n)
+
+-- | Index a pull array (with checking bounds)
+safeIndex :: Array a %1 -> Int -> (Maybe a, Array a)
+safeIndex (Array f n) ix = (if 0 <= ix && ix < n then Just (f ix) else Nothing, Array f n)

--- a/test/Test/Data/Polarized.hs
+++ b/test/Test/Data/Polarized.hs
@@ -27,18 +27,19 @@ import qualified Prelude
 
 polarizedArrayTests :: TestTree
 polarizedArrayTests =
-  testGroup
-    "Polarized arrays"
-    [ testPropertyNamed "Push.alloc . transfer . Pull.fromVector = id" "polarRoundTrip" polarRoundTrip,
-      testPropertyNamed "Push.append ~ Vec.append" "pushAppend" pushAppend,
-      testPropertyNamed "Push.make ~ Vec.replicate" "pushMake" pushMake,
-      testPropertyNamed "Pull.append ~ Vec.append" "pullAppend" pullAppend,
-      testPropertyNamed "Pull.asList . Pull.fromVector ~ id" "pullAsList" pullAsList,
-      testPropertyNamed "Pull.singleton x = [x]" "pullSingleton" pullSingleton,
-      testPropertyNamed "Pull.splitAt ~ splitAt" "pullSplitAt" pullSplitAt,
-      testPropertyNamed "Pull.make ~ Vec.replicate" "pullMake" pullMake,
-      testPropertyNamed "Pull.zip ~ zip" "pullZip" pullZip
-    ]
+    testGroup
+        "Polarized arrays"
+        [ testPropertyNamed "Push.alloc . transfer . Pull.fromVector = id" "polarRoundTrip" polarRoundTrip
+        , testPropertyNamed "Push.append ~ Vec.append" "pushAppend" pushAppend
+        , testPropertyNamed "Push.make ~ Vec.replicate" "pushMake" pushMake
+        , testPropertyNamed "Pull.append ~ Vec.append" "pullAppend" pullAppend
+        , testPropertyNamed "Pull.asList . Pull.fromVector ~ id" "pullAsList" pullAsList
+        , testPropertyNamed "Pull.singleton x = [x]" "pullSingleton" pullSingleton
+        , testPropertyNamed "Pull.splitAt ~ splitAt" "pullSplitAt" pullSplitAt
+        , testPropertyNamed "Pull.make ~ Vec.replicate" "pullMake" pullMake
+        , testPropertyNamed "Pull.zip ~ zip" "pullZip" pullZip
+        , testPropertyNamed "Pull.safeIndex" "safeIndex" safeIndex
+        ]
 
 list :: Gen [Int]
 list = Gen.list (Range.linear 0 1000) randInt
@@ -115,3 +116,17 @@ pullZip = property Prelude.$ do
   let xs' = Pull.fromVector (Vector.fromList xs)
   let ys' = Pull.fromVector (Vector.fromList ys)
   zip xs ys === Pull.asList (Pull.zip xs' ys')
+
+safeIndex :: Property
+safeIndex = property Prelude.$ do
+  x <- forAll randInt
+  n <- forAll (Prelude.fmap (Prelude.+ 1) randNonnegInt)
+  let array = Pull.make x n
+  let (x0, array0) = Pull.safeIndex array 0
+  let (x1, array1) = Pull.safeIndex array0 (n Prelude.- 1)
+  let (x2, array2) = Pull.safeIndex array1 n
+  let (x3, _) = Pull.safeIndex array2 (-1)
+  x0 === Just x
+  x1 === Just x
+  x2 === Nothing
+  x3 === Nothing


### PR DESCRIPTION
I wonder if there was a reason behind the absence of a `Array a %1 -> Int -> (Maybe a, Array a)` function.