### PR TITLE
In scope-passing style: use a `Movable b` instead of `Ur b`

### DIFF
--- a/src/Data/Array/Mutable/Linear/Internal.hs
+++ b/src/Data/Array/Mutable/Linear/Internal.hs
@@ -62,11 +62,11 @@ data Array a = Array (Array# a)
 -- | Allocate a constant array given a size and an initial value
 -- The size must be non-negative, otherwise this errors.
 alloc ::
-  (HasCallStack) =>
+  (HasCallStack, Movable b) =>
   Int ->
   a ->
-  (Array a %1 -> Ur b) %1 ->
-  Ur b
+  (Array a %1 -> b) %1 ->
+  b
 alloc s x f
   | s < 0 =
       (error ("Array.alloc: negative size: " ++ show s) :: x %1 -> x)
@@ -89,11 +89,11 @@ allocBeside s x (Array orig)
 
 -- | Allocate an array from a list
 fromList ::
-  (HasCallStack) =>
+  (HasCallStack, Movable b) =>
   [a] ->
-  (Array a %1 -> Ur b) %1 ->
-  Ur b
-fromList list (f :: Array a %1 -> Ur b) =
+  (Array a %1 -> b) %1 ->
+  b
+fromList list (f :: Array a %1 -> b) =
   alloc
     (Prelude.length list)
     (error "invariant violation: unintialized array position")

--- a/src/Data/HashMap/Mutable/Linear/Internal.hs
+++ b/src/Data/HashMap/Mutable/Linear/Internal.hs
@@ -133,10 +133,10 @@ data ProbeResult k v where
 -- | Run a computation with an empty 'HashMap' with given capacity.
 empty ::
   forall k v b.
-  (Keyed k) =>
+  (Keyed k, Movable b) =>
   Int ->
-  (HashMap k v %1 -> Ur b) %1 ->
-  Ur b
+  (HashMap k v %1 -> b) %1 ->
+  b
 empty size scope =
   let cap = max 1 size
    in Array.alloc cap Nothing (\arr -> scope (HashMap 0 cap arr))
@@ -151,10 +151,10 @@ allocBeside size (HashMap s' c' arr) =
 -- | Run a computation with an 'HashMap' containing given key-value pairs.
 fromList ::
   forall k v b.
-  (Keyed k) =>
+  (Keyed k, Movable b) =>
   [(k, v)] ->
-  (HashMap k v %1 -> Ur b) %1 ->
-  Ur b
+  (HashMap k v %1 -> b) %1 ->
+  b
 fromList xs scope =
   let cap =
         max

--- a/src/Data/Set/Mutable/Linear/Internal.hs
+++ b/src/Data/Set/Mutable/Linear/Internal.hs
@@ -29,8 +29,8 @@ type Keyed a = Linear.Keyed a
 -- # Constructors and Mutators
 -------------------------------------------------------------------------------
 
-empty :: (Keyed a) => Int -> (Set a %1 -> Ur b) %1 -> Ur b
-empty s (f :: Set a %1 -> Ur b) =
+empty :: (Keyed a, Movable b) => Int -> (Set a %1 -> b) %1 -> b
+empty s (f :: Set a %1 -> b) =
   Linear.empty s (\hm -> f (Set hm))
 
 toList :: (Keyed a) => Set a %1 -> Ur [a]
@@ -63,7 +63,7 @@ member :: (Keyed a) => a -> Set a %1 -> (Ur Bool, Set a)
 member a (Set hm) =
   Linear.member a hm Linear.& \(b, hm') -> (b, Set hm')
 
-fromList :: (Keyed a) => [a] -> (Set a %1 -> Ur b) %1 -> Ur b
+fromList :: (Keyed a, Movable b) => [a] -> (Set a %1 -> b) %1 -> b
 fromList xs f =
   Linear.fromList (Prelude.map (,()) xs) (\hm -> f (Set hm))
 

--- a/src/Data/Vector/Mutable/Linear/Internal.hs
+++ b/src/Data/Vector/Mutable/Linear/Internal.hs
@@ -56,17 +56,17 @@ fromArray arr =
     & \(Ur size', arr') -> Vec size' arr'
 
 -- Allocate an empty vector
-empty :: (Vector a %1 -> Ur b) %1 -> Ur b
+empty :: (Movable b) => (Vector a %1 -> b) %1 -> b
 empty f = Array.fromList [] (f . fromArray)
 
 -- | Allocate a constant vector of a given non-negative size (and error on a
 -- bad size)
 constant ::
-  (HasCallStack) =>
+  (HasCallStack, Movable b) =>
   Int ->
   a ->
-  (Vector a %1 -> Ur b) %1 ->
-  Ur b
+  (Vector a %1 -> b) %1 ->
+  b
 constant size' x f
   | size' < 0 =
       (error ("Trying to construct a vector of size " ++ show size') :: x %1 -> x)
@@ -74,7 +74,7 @@ constant size' x f
   | otherwise = Array.alloc size' x (f . fromArray)
 
 -- | Allocator from a list
-fromList :: (HasCallStack) => [a] -> (Vector a %1 -> Ur b) %1 -> Ur b
+fromList :: (HasCallStack, Movable b) => [a] -> (Vector a %1 -> b) %1 -> b
 fromList xs f = Array.fromList xs (f . fromArray)
 
 -- | Number of elements inside the vector.


### PR DESCRIPTION
Functions of the form

```haskell
f :: (A %1 -> Ur b) %1 -> Ur b
```

are now of the form

```haskell
f :: Movable b => (A %1 -> b) %1 -> b
```

The new type is strictly more general. Technically this seems to involve some extra allocations here and there. I expect it to be negligible (we don't want to call too many scoped functions anyway).

The extra allocation is interesting, in that it's not always strictly necessary: when returning an `Int`, I don't need to produce an `Ur Int` to make sure that I've actually forced everything, just returning the forced `Int` would do the trick. Yet we use an `Ur Int` to communicate that we've indeed done the job (in some cases the optimiser can actually remove the extra allocation, but not in every case as far as I can tell). Maybe there are cheaper way to tell the compiler that we've, in fact, moved the value. But that's a question for the future.

See https://github.com/tweag/linear-base/discussions/468 for the initial discussion.