### PR TITLE
Add Quicksort benchmark and export benchmark results as an artifact

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,13 +33,24 @@ jobs:
     - name: Update Cabal's database
       run: nix-shell --arg ghcVersion '"${{ matrix.ghc-version }}"' --arg installHls 'false' --pure --run "cabal update"
     - name: Build Cabal's dependencies
-      run: nix-shell --arg ghcVersion '"${{ matrix.ghc-version }}"' --arg installHls 'false' --pure --run "cabal build --allow-newer --disable-tests --disable-benchmarks --dependencies-only"
+      run: nix-shell --arg ghcVersion '"${{ matrix.ghc-version }}"' --arg installHls 'false' --pure --run "cabal build --dependencies-only"
     - name: Build
-      run: nix-shell --arg ghcVersion '"${{ matrix.ghc-version }}"' --arg installHls 'false' --pure --run "cabal build --allow-newer --disable-tests --disable-benchmarks"
+      run: nix-shell --arg ghcVersion '"${{ matrix.ghc-version }}"' --arg installHls 'false' --pure --run "cabal build"
     - name: Haddock
-      run: nix-shell --arg ghcVersion '"${{ matrix.ghc-version }}"' --arg installHls 'false' --pure --run "cabal --allow-newer haddock"
+      run: nix-shell --arg ghcVersion '"${{ matrix.ghc-version }}"' --arg installHls 'false' --pure --run "cabal haddock"
     - name: cabal-docspec
-      run: nix-shell --arg ghcVersion '"${{ matrix.ghc-version }}"' --arg installHls 'false' --pure --run cabal-docspec
+      run: nix-shell --arg ghcVersion '"${{ matrix.ghc-version }}"' --arg installHls 'false' --pure --run "cabal-docspec"
+    - name: Build benchmarks
+      run: nix-shell --arg ghcVersion '"${{ matrix.ghc-version }}"' --arg installHls 'false' --pure --run "cabal build linear-base:bench:bench"
+    - name: Run benchmarks
+      run: nix-shell --arg ghcVersion '"${{ matrix.ghc-version }}"' --arg installHls 'false' --pure --run "cabal bench 2>&1 | tee benchmark_ghc${{ matrix.ghc-version }}.txt"
+    - name: Upload benchmark results
+      uses: actions/upload-artifact@v3
+      with:
+        name: linear-base_benchmarks_ghc${{ matrix.ghc-version }}
+        path: |
+          benchmark_ghc${{ matrix.ghc-version }}.txt
+        retention-days: 90
 
   ormolu:
     name: check formatting with ormolu

--- a/bench/Data/Mutable/Quicksort.hs
+++ b/bench/Data/Mutable/Quicksort.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE NumericUnderscores #-}
+
+module Data.Mutable.Quicksort (benchmarks) where
+
+import Control.DeepSeq (force)
+import Control.Exception (evaluate)
+import Data.List (sort)
+import Simple.Quicksort (quicksortUsingArray, quicksortUsingList)
+import System.Random
+import Test.Tasty.Bench
+
+-- Follows thread from https://discourse.haskell.org/t/linear-haskell-quicksort-performance/10280
+
+gen :: StdGen
+gen = mkStdGen 4541645642
+
+randomListBuilder :: Int -> IO [Int]
+randomListBuilder size = evaluate $ force $ take size (randoms gen :: [Int])
+
+sizes :: [Int]
+sizes = [1_000, 50_000, 1_000_000]
+
+benchmarks :: Benchmark
+benchmarks =
+  bgroup
+    "quicksort"
+    ( ( \size ->
+          env (randomListBuilder size) $ \randomList ->
+            bgroup
+              ("size " ++ (show size))
+              [ bench "quicksortUsingArray" $
+                  nf quicksortUsingArray randomList,
+                bench "quicksortUsingList" $
+                  nf quicksortUsingList randomList,
+                bench "sortStdLib" $
+                  nf sort randomList
+              ]
+      )
+        <$> sizes
+    )

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -2,11 +2,13 @@ module Main where
 
 import qualified Data.Mutable.Array as Array
 import qualified Data.Mutable.HashMap as HashMap
+import qualified Data.Mutable.Quicksort as Quicksort
 import Test.Tasty.Bench (defaultMain)
 
 main :: IO ()
 main = do
   defaultMain
     [ Array.benchmarks,
-      HashMap.benchmarks
+      HashMap.benchmarks,
+      Quicksort.benchmarks
     ]

--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,9 @@
 packages: *.cabal
+
+allow-newer: all
+index-state: 2024-09-13T13:31:57Z
+
+-- But as of 2024-09-11, the latest version of the `unix` 2.8.5.1 package has a conditional bound on `filepath` depending on the `os-string` flag (see https://hackage.haskell.org/package/unix-2.8.5.1/dependencies).
+-- With no extra parameter or setting, we get a dependency conflict on `filepath`, as other libs use a version of `filepath` incompatible with the one `unix` wants.
+-- Setting `filepath` to 1.4.2.2 fixes that.
+constraints: filepath ==1.4.2.2

--- a/cabal.project
+++ b/cabal.project
@@ -1,9 +1,6 @@
 packages: *.cabal
 
+tests: True
+benchmarks: True
 allow-newer: all
 index-state: 2024-09-13T13:31:57Z
-
--- But as of 2024-09-11, the latest version of the `unix` 2.8.5.1 package has a conditional bound on `filepath` depending on the `os-string` flag (see https://hackage.haskell.org/package/unix-2.8.5.1/dependencies).
--- With no extra parameter or setting, we get a dependency conflict on `filepath`, as other libs use a version of `filepath` incompatible with the one `unix` wants.
--- Setting `filepath` to 1.4.2.2 fixes that.
-constraints: filepath ==1.4.2.2

--- a/examples/Simple/Quicksort.hs
+++ b/examples/Simple/Quicksort.hs
@@ -1,6 +1,10 @@
 {-# LANGUAGE LinearTypes #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
+-- Uncomment the line below to observe the generated (optimised) Core. It will
+-- land in a file named “Quicksort.dump-simpl”
+-- {-# OPTIONS_GHC -ddump-simpl -ddump-to-file -dsuppress-all -dsuppress-uniques #-}
+
 -- | This module implements quicksort with mutable arrays from linear-base
 module Simple.Quicksort where
 
@@ -13,15 +17,22 @@ import Prelude.Linear hiding (partition)
 -- # Quicksort
 -------------------------------------------------------------------------------
 
-quickSort :: [Int] -> [Int]
-quickSort xs = unur $ Array.fromList xs $ Array.toList . arrQuicksort
+quicksortUsingList :: (Ord a) => [a] -> [a]
+quicksortUsingList [] = []
+quicksortUsingList (x : xs) = quicksortUsingList ltx ++ x : quicksortUsingList gex
+  where
+    ltx = [y | y <- xs, y < x]
+    gex = [y | y <- xs, y >= x]
 
-arrQuicksort :: Array Int %1 -> Array Int
-arrQuicksort arr =
+quicksortUsingArray :: (Ord a) => [a] -> [a]
+quicksortUsingArray xs = unur $ Array.fromList xs $ Array.toList . quicksortArray
+
+quicksortArray :: (Ord a) => Array a %1 -> Array a
+quicksortArray arr =
   Array.size arr
     & \(Ur len, arr1) -> go 0 (len - 1) arr1
 
-go :: Int -> Int -> Array Int %1 -> Array Int
+go :: (Ord a) => Int -> Int -> Array a %1 -> Array a
 go lo hi arr
   | lo >= hi = arr
   | otherwise =
@@ -39,23 +50,23 @@ go lo hi arr
 -- @arr'[j] > pivot@ for @ix < j <= hi@,
 -- @arr'[k] = arr[k]@ for @k < lo@ and @k > hi@, and
 -- @arr'@ is a permutation of @arr@.
-partition :: Array Int %1 -> Int -> Int -> Int -> (Array Int, Ur Int)
-partition arr pivot lx rx
-  | (rx < lx) = (arr, Ur (lx - 1))
+partition :: (Ord a) => Array a %1 -> a -> Int -> Int -> (Array a, Ur Int)
+partition arr pivot lo hi
+  | (hi < lo) = (arr, Ur (lo - 1))
   | otherwise =
-      Array.read arr lx
+      Array.read arr lo
         & \(Ur lVal, arr1) ->
-          Array.read arr1 rx
+          Array.read arr1 hi
             & \(Ur rVal, arr2) -> case (lVal <= pivot, pivot < rVal) of
-              (True, True) -> partition arr2 pivot (lx + 1) (rx - 1)
-              (True, False) -> partition arr2 pivot (lx + 1) rx
-              (False, True) -> partition arr2 pivot lx (rx - 1)
+              (True, True) -> partition arr2 pivot (lo + 1) (hi - 1)
+              (True, False) -> partition arr2 pivot (lo + 1) hi
+              (False, True) -> partition arr2 pivot lo (hi - 1)
               (False, False) ->
-                swap arr2 lx rx
-                  & \arr3 -> partition arr3 pivot (lx + 1) (rx - 1)
+                swap arr2 lo hi
+                  & \arr3 -> partition arr3 pivot (lo + 1) (hi - 1)
 
 -- | @swap a i j@ exchanges the positions of values at @i@ and @j@ of @a@.
-swap :: (HasCallStack) => Array Int %1 -> Int -> Int -> Array Int
+swap :: (HasCallStack) => Array a %1 -> Int -> Int -> Array a
 swap arr i j =
   Array.read arr i
     & \(Ur ival, arr1) ->

--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -219,6 +219,7 @@ benchmark bench
     other-modules:
         Data.Mutable.HashMap
         Data.Mutable.Array
+        Data.Mutable.Quicksort
     default-language: Haskell2010
     build-depends:
         base,

--- a/test-examples/Main.hs
+++ b/test-examples/Main.hs
@@ -1,7 +1,7 @@
 module Main where
 
 import Test.Foreign (foreignGCTests)
-import Test.Simple.Quicksort (quickSortTests)
+import Test.Simple.Quicksort (quicksortTests)
 import Test.Tasty
 
 main :: IO ()
@@ -12,5 +12,5 @@ allTests =
   testGroup
     "All tests"
     [ foreignGCTests,
-      quickSortTests
+      quicksortTests
     ]

--- a/test-examples/Test/Simple/Quicksort.hs
+++ b/test-examples/Test/Simple/Quicksort.hs
@@ -1,19 +1,29 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Test.Simple.Quicksort (quickSortTests) where
+module Test.Simple.Quicksort (quicksortTests) where
 
 import Data.List (sort)
 import Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
-import Simple.Quicksort (quickSort)
+import Simple.Quicksort (quicksortUsingArray, quicksortUsingList)
 import Test.Tasty
 import Test.Tasty.Hedgehog (testPropertyNamed)
 
-quickSortTests :: TestTree
-quickSortTests = testPropertyNamed "quicksort sorts" "testQuicksort" testQuicksort
+quicksortTests :: TestTree
+quicksortTests =
+  testGroup
+    "quicksort tests"
+    [ testPropertyNamed "sort xs === quicksortUsingArray xs" "testQuicksortUsingArray" testQuicksortUsingArray,
+      testPropertyNamed "sort xs === quicksortUsingList xs" "testQuicksortUsingList" testQuicksortUsingList
+    ]
 
-testQuicksort :: Property
-testQuicksort = property $ do
+testQuicksortUsingArray :: Property
+testQuicksortUsingArray = property $ do
   xs <- forAll $ Gen.list (Range.linear 0 1000) (Gen.int $ Range.linear 0 100)
-  sort xs === quickSort xs
+  sort xs === quicksortUsingArray xs
+
+testQuicksortUsingList :: Property
+testQuicksortUsingList = property $ do
+  xs <- forAll $ Gen.list (Range.linear 0 1000) (Gen.int $ Range.linear 0 100)
+  sort xs === quicksortUsingList xs


### PR DESCRIPTION
This PR adds a proper benchmark for quicksort, across 3 methods and 3 list sizes, as encouraged by [this thread](https://discourse.haskell.org/t/linear-haskell-quicksort-performance/10280/9). It also runs and exports benchmark results to an artifact for each GHC version in the CI matrix so it will be easier to check for potential performance regression in the future. The PR builds upon https://github.com/tweag/linear-base/pull/479 and https://github.com/tweag/linear-base/pull/480

Here are the results I got :

**GHC 9.4.8**

**/!\\** *Done locally on my computer, so ordering between methods is valid, but absolute times should not be compared to other results below* **/!\\**

```
  quicksort
    size 1000
      linArrayQuicksort:                                                         OK
        773  μs ±  65 μs
      lazyListQuicksort:                                                         OK
        276  μs ±  16 μs
      stdLibSort:                                                                OK
        219  μs ±  12 μs
    size 50000
      linArrayQuicksort:                                                         OK
        63.9 ms ± 3.2 ms
      lazyListQuicksort:                                                         OK
        32.4 ms ± 2.3 ms
      stdLibSort:                                                                OK
        38.1 ms ± 1.9 ms
    size 1000000
      linArrayQuicksort:                                                         OK
        3.557 s ± 322 ms
      lazyListQuicksort:                                                         OK
        2.135 s ±  72 ms
      stdLibSort:                                                                OK
        4.309 s ± 212 ms
```

*Results below are extracted from artifacts of https://github.com/tweag/linear-base/actions/runs/10851885368*

**GHC 9.6.6**

```
  quicksort
    size 1000
      linArrayQuicksort:                                                         OK
        1.37 ms ±  91 μs, 6.5 MB allocated,  15 KB copied,  89 MB peak memory
      lazyListQuicksort:                                                         OK
        320  μs ±  22 μs, 1.0 MB allocated,  13 KB copied,  89 MB peak memory
      stdLibSort:                                                                OK
        246  μs ±  24 μs, 665 KB allocated, 3.4 KB copied,  89 MB peak memory
    size 50000
      linArrayQuicksort:                                                         OK
        115  ms ±  11 ms, 520 MB allocated, 1.1 MB copied,  89 MB peak memory
      lazyListQuicksort:                                                         OK
        44.3 ms ± 2.0 ms,  85 MB allocated,  25 MB copied,  89 MB peak memory
      stdLibSort:                                                                OK
        42.5 ms ± 2.3 ms,  52 MB allocated,  16 MB copied,  89 MB peak memory
    size 1000000
      linArrayQuicksort:                                                         OK
        3.105 s ± 239 ms,  13 GB allocated,  47 MB copied, 227 MB peak memory
      lazyListQuicksort:                                                         OK
        1.730 s ± 140 ms, 2.1 GB allocated, 910 MB copied, 484 MB peak memory
      stdLibSort:                                                                OK
        2.299 s ±  70 ms, 1.3 GB allocated, 996 MB copied, 484 MB peak memory
```

**GHC 9.8.2**

```
  quicksort
    size 1000
      linArrayQuicksort:                                                         OK
        145  μs ±  12 μs, 247 KB allocated,  42 B  copied,  82 MB peak memory
      lazyListQuicksort:                                                         OK
        303  μs ±  30 μs, 1.0 MB allocated,  13 KB copied,  82 MB peak memory
      stdLibSort:                                                                OK
        241  μs ±  11 μs, 665 KB allocated, 3.3 KB copied,  82 MB peak memory
    size 50000
      linArrayQuicksort:                                                         OK
        14.3 ms ± 1.2 ms,  15 MB allocated, 1.0 MB copied,  82 MB peak memory
      lazyListQuicksort:                                                         OK
        43.5 ms ± 2.9 ms,  85 MB allocated,  24 MB copied,  82 MB peak memory
      stdLibSort:                                                                OK
        42.2 ms ± 1.4 ms,  52 MB allocated,  16 MB copied,  82 MB peak memory
    size 1000000
      linArrayQuicksort:                                                         OK
        471  ms ±  33 ms, 369 MB allocated,  43 MB copied, 318 MB peak memory
      lazyListQuicksort:                                                         OK
        1.655 s ± 111 ms, 2.1 GB allocated, 928 MB copied, 492 MB peak memory
      stdLibSort:                                                                OK
        2.308 s ± 9.4 ms, 1.3 GB allocated, 996 MB copied, 492 MB peak memory
```

**GHC 9.10.1**

```
  quicksort
    size 1000
      linArrayQuicksort:                                                         OK
        152  μs ±  11 μs, 247 KB allocated,  42 B  copied,  88 MB peak memory
      lazyListQuicksort:                                                         OK
        318  μs ±  13 μs, 1.0 MB allocated,  13 KB copied,  88 MB peak memory
      stdLibSort:                                                                OK
        242  μs ±  24 μs, 665 KB allocated, 3.4 KB copied,  88 MB peak memory
    size 50000
      linArrayQuicksort:                                                         OK
        15.3 ms ± 1.4 ms,  15 MB allocated, 947 KB copied,  88 MB peak memory
      lazyListQuicksort:                                                         OK
        47.6 ms ± 1.8 ms,  85 MB allocated,  24 MB copied,  88 MB peak memory
      stdLibSort:                                                                OK
        40.6 ms ± 3.5 ms,  51 MB allocated, 9.9 MB copied,  88 MB peak memory
    size 1000000
      linArrayQuicksort:                                                         OK
        602  ms ± 6.6 ms, 369 MB allocated,  46 MB copied, 318 MB peak memory
      lazyListQuicksort:                                                         OK
        1.808 s ±  11 ms, 2.1 GB allocated, 900 MB copied, 498 MB peak memory
      stdLibSort:                                                                OK
        2.827 s ± 238 ms, 1.3 GB allocated, 996 MB copied, 498 MB peak memory
```

N.B as far as I know, peak memory usage reporting is quite unreliable when several benchmarks are run in a sequence. In particular, I don't think peak memory can go down, only up if the next bench uses more memory. On the other hand, the  "allocated memory" and "copied memory" reporting seems decently reliable. 

**Conclusion**

It appears that starting from GHC 9.8, the performance of quicksort using the linear arrays provided by Linear base gets much more efficient than naive quicksort. That may be related to `Ur` unboxing optimization that was initially disallowed on earlier GHC versions.