### PR TITLE
Bump nixpkgs, bump GHC to 9.6.6 and stackage to LTS 22.34

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,19 +27,19 @@ jobs:
         key: cabal-deps-${{ runner.os }}-${{ hashFiles('nix/sources.json') }}-${{ matrix.ghc-version }}-v${{ env.cache-invalidation-key }}-${{ hashFiles('linear-base.cabal') }}-${{ github.sha }}
         restore-keys: cabal-deps-${{ runner.os }}-${{ hashFiles('nix/sources.json') }}-${{ matrix.ghc-version }}-v${{ env.cache-invalidation-key }}-${{ hashFiles('linear-base.cabal') }}-
     - name: Build Nix dependencies
-      run: nix-shell --arg ghcVersion '"${{ matrix.ghc-version }}"' --pure --run "echo '=== Nix dependencies installed ==='"
+      run: nix-shell --arg ghcVersion '"${{ matrix.ghc-version }}"' --arg installHls 'false' --pure --run "echo '=== Nix dependencies installed ==='"
     - name: Init Cabal's config file
-      run: nix-shell --arg ghcVersion '"${{ matrix.ghc-version }}"' --pure --run "cabal --config-file=/home/runner/.cabal/config user-config -f init"
+      run: nix-shell --arg ghcVersion '"${{ matrix.ghc-version }}"' --arg installHls 'false' --pure --run "cabal --config-file=/home/runner/.cabal/config user-config -f init"
     - name: Update Cabal's database
-      run: nix-shell --arg ghcVersion '"${{ matrix.ghc-version }}"' --pure --run "cabal update"
+      run: nix-shell --arg ghcVersion '"${{ matrix.ghc-version }}"' --arg installHls 'false' --pure --run "cabal update"
     - name: Build Cabal's dependencies
-      run: nix-shell --arg ghcVersion '"${{ matrix.ghc-version }}"' --pure --run "cabal build --allow-newer --disable-tests --disable-benchmarks --dependencies-only"
+      run: nix-shell --arg ghcVersion '"${{ matrix.ghc-version }}"' --arg installHls 'false' --pure --run "cabal build --allow-newer --disable-tests --disable-benchmarks --dependencies-only"
     - name: Build
-      run: nix-shell --arg ghcVersion '"${{ matrix.ghc-version }}"' --pure --run "cabal build --allow-newer --disable-tests --disable-benchmarks"
+      run: nix-shell --arg ghcVersion '"${{ matrix.ghc-version }}"' --arg installHls 'false' --pure --run "cabal build --allow-newer --disable-tests --disable-benchmarks"
     - name: Haddock
-      run: nix-shell --arg ghcVersion '"${{ matrix.ghc-version }}"' --pure --run "cabal --allow-newer haddock"
+      run: nix-shell --arg ghcVersion '"${{ matrix.ghc-version }}"' --arg installHls 'false' --pure --run "cabal --allow-newer haddock"
     - name: cabal-docspec
-      run: nix-shell --arg ghcVersion '"${{ matrix.ghc-version }}"' --pure --run cabal-docspec
+      run: nix-shell --arg ghcVersion '"${{ matrix.ghc-version }}"' --arg installHls 'false' --pure --run cabal-docspec
 
   ormolu:
     name: check formatting with ormolu
@@ -56,9 +56,9 @@ jobs:
         key: stack-deps-ormolu-${{ runner.os }}-${{ hashFiles('nix/sources.json') }}-v${{ env.cache-invalidation-key }}-${{ hashFiles('stack.yaml.lock') }}-${{ github.sha }}
         restore-keys: stack-deps-ormolu-${{ runner.os }}-${{ hashFiles('nix/sources.json') }}-v${{ env.cache-invalidation-key }}-${{ hashFiles('stack.yaml.lock') }}-
     - name: Build Nix dependencies
-      run: nix-shell --pure --run "echo '=== Nix dependencies installed ==='"
+      run: nix-shell --arg installHls 'false' --pure --run "echo '=== Nix dependencies installed ==='"
     - name: check formatting
-      run: nix-shell --pure --run 'stack build ormolu && stack exec ormolu -- -m check $(find . -type f -name "*.hs-boot" -o -name "*.hs")'
+      run: nix-shell --arg installHls 'false' --pure --run 'stack build ormolu && stack exec ormolu -- -m check $(find . -type f -name "*.hs-boot" -o -name "*.hs")'
 
   stack-build:
     name: stack build
@@ -75,6 +75,6 @@ jobs:
         key: stack-deps-${{ runner.os }}-${{ hashFiles('nix/sources.json') }}-v${{ env.cache-invalidation-key }}-${{ hashFiles('stack.yaml.lock', 'linear-base.cabal') }}-${{ github.sha }}
         restore-keys: stack-deps-${{ runner.os }}-${{ hashFiles('nix/sources.json') }}-v${{ env.cache-invalidation-key }}-${{ hashFiles('stack.yaml.lock', 'linear-base.cabal') }}-
     - name: Build Nix dependencies
-      run: nix-shell --pure --run "echo '=== Nix dependencies installed ==='"
+      run: nix-shell --arg installHls 'false' --pure --run "echo '=== Nix dependencies installed ==='"
     - name: Build
-      run: nix-shell --pure --run "stack build --pedantic --test --bench --no-run-benchmarks"
+      run: nix-shell --arg installHls 'false' --pure --run "stack build --pedantic --test --bench --no-run-benchmarks"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     name: cabal test - GHC ${{ matrix.ghc-version }}
     strategy:
       matrix:
-        ghc-version: [94, 96]
+        ghc-version: [96, 98, 910]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,14 +3,14 @@ on: [push, pull_request]
 env:
   # Bump this number to invalidate the Github-actions cache
   cache-invalidation-key: 0
-  nixpkgs-url: https://github.com/NixOS/nixpkgs/archive/b2737d4980a17cc2b7d600d7d0b32fd7333aca88.tar.gz
+  nixpkgs-url: https://github.com/NixOS/nixpkgs/archive/574d1eac1c200690e27b8eb4e24887f8df7ac27c.tar.gz
 
 jobs:
   cabal-test:
     name: cabal test - GHC ${{ matrix.ghc-version }}
     strategy:
       matrix:
-        ghc-version: [944, 961]
+        ghc-version: [94, 96]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,1 @@
 packages: *.cabal
-
-tests: true
-
-package linear-base
-  ghc-options: -Wall

--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -21,13 +21,26 @@ source-repository head
     type:     git
     location: https://github.com/tweag/linear-base
 
-common warnings
-    ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wnoncanonical-monad-instances
+common build-opts
+    ghc-options: -O2 -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wnoncanonical-monad-instances
                  -- Additional warnings we may consider adding:
                  -- * -Wredundant-constraints : would need deactivating in the modules which use Nat
+common rts-opts-multithread
+    ghc-options: -threaded -rtsopts "-with-rtsopts=-N"
+common rts-opts-monothread-stats
+    ghc-options: -rtsopts "-with-rtsopts=-T"
 
 library
-    import: warnings
+    import: build-opts
+    hs-source-dirs:     src
+    if impl(ghc >= 9.4.0)
+        hs-source-dirs: src-version-changes/ghc94/after
+    else
+        hs-source-dirs: src-version-changes/ghc94/before
+    if impl(ghc >= 9.6.0)
+        hs-source-dirs: src-version-changes/ghc96/after
+    else
+        hs-source-dirs: src-version-changes/ghc96/before
     exposed-modules:
         Control.Monad.IO.Class.Linear
         Control.Functor.Linear
@@ -118,20 +131,8 @@ library
         System.IO.Resource.Linear
         System.IO.Resource.Linear.Internal
         Unsafe.Linear
-
-    hs-source-dirs:   src
-    if impl(ghc >= 9.4.0)
-        hs-source-dirs: src-version-changes/ghc94/after
-    else
-        hs-source-dirs: src-version-changes/ghc94/before
-    if impl(ghc >= 9.6.0)
-        hs-source-dirs: src-version-changes/ghc96/after
-    else
-        hs-source-dirs: src-version-changes/ghc96/before
-
     default-language: Haskell2010
     build-depends:
-
         base >=4.16 && <5,
         containers,
         ghc-prim,
@@ -145,7 +146,8 @@ library
         primitive
 
 test-suite test
-    import: warnings
+    import: build-opts
+    import: rts-opts-multithread
     type:             exitcode-stdio-1.0
     main-is:          Main.hs
     hs-source-dirs:   test
@@ -158,9 +160,7 @@ test-suite test
         Test.Data.Polarized
         Test.Data.V
         Test.Data.Replicator
-
     default-language: Haskell2010
-    ghc-options:      -threaded -rtsopts -with-rtsopts=-N
     build-depends:
         inspection-testing,
         tasty-inspection-testing,
@@ -174,7 +174,8 @@ test-suite test
         vector
 
 test-suite examples
-    import: warnings
+    import: build-opts
+    import: rts-opts-multithread
     type:             exitcode-stdio-1.0
     main-is:          Main.hs
     hs-source-dirs:   examples
@@ -189,9 +190,7 @@ test-suite examples
         Simple.Quicksort
         Simple.TopSort
         Generic.Traverse
-
     default-language: Haskell2010
-    ghc-options:      -threaded -rtsopts -with-rtsopts=-N
     build-depends:
         base,
         linear-base,
@@ -204,14 +203,14 @@ test-suite examples
         linear-generics
 
 benchmark mutable-data
-    import: warnings
+    import: build-opts
+    import: rts-opts-monothread-stats
     type:             exitcode-stdio-1.0
     main-is:          Main.hs
     hs-source-dirs:   bench
     other-modules:
         Data.Mutable.HashMap
         Data.Mutable.Array
-
     default-language: Haskell2010
     build-depends:
         base,

--- a/nix/cabal-docspec.nix
+++ b/nix/cabal-docspec.nix
@@ -4,8 +4,8 @@ pkgs.stdenv.mkDerivation {
   name = "cabal-docspec";
 
   src = pkgs.fetchurl {
-    url = "https://github.com/phadej/cabal-extras/releases/download/cabal-docspec-0.0.0.20230406/cabal-docspec-0.0.0.20230406-x86_64-linux.xz";
-    sha256 = "68fa9addd5dc453d533a74a763950499d4593b1297c9a05c3ea5bd1acc04c9dd";
+    url = "https://github.com/phadej/cabal-extras/releases/download/cabal-docspec-0.0.0.20240703/cabal-docspec-0.0.0.20240703-x86_64-linux.xz";
+    sha256 = "48bf3b7fd2f7f0caa6162afee57a755be8523e7f467b694900eb420f5f9a7b76";
   };
 
   phases = ["installPhase"];

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "5830a4dd348d77e39a0f3c4c762ff2663b602d4c",
-        "sha256": "1d3lsrqvci4qz2hwjrcnd8h5vfkg8aypq3sjd4g3izbc8frwz5sm",
+        "rev": "f7c538837892dd2eb83567c9f380a11efb59b53f",
+        "sha256": "0xl33k24vfc29cg9lnp95kvcq69qbq5fzb7jk9ig4lgrhaarh651",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/5830a4dd348d77e39a0f3c4c762ff2663b602d4c.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/f7c538837892dd2eb83567c9f380a11efb59b53f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -17,10 +17,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "052eabdcb15dff97a742b3a43fda1fe4ce305275",
-        "sha256": "0jbaqgpznaaxn4i4s3ixw802sfl6ppjimp0jzkqs43r1zrfsiszy",
+        "rev": "574d1eac1c200690e27b8eb4e24887f8df7ac27c",
+        "sha256": "0s6h7r9jin9sd8l85hdjwl3jsvzkddn3blggy78w4f21qa3chymz",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/052eabdcb15dff97a742b3a43fda1fe4ce305275.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/574d1eac1c200690e27b8eb4e24887f8df7ac27c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ system ? builtins.currentSystem, sources ? import ./nix/sources.nix, ghcVersion ? "96" }:
+{ system ? builtins.currentSystem, sources ? import ./nix/sources.nix, ghcVersion ? "96", installHls ? true }:
 
 let
   selectHls = self: super: {
@@ -32,6 +32,5 @@ mkShell {
     stack-wrapped
     nix
     cabal-docspec
-    haskell-language-server
-  ];
+  ] ++ (if installHls then [ haskell-language-server ] else []);
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ system ? builtins.currentSystem, sources ? import ./nix/sources.nix, ghcVersion ? "944" }:
+{ system ? builtins.currentSystem, sources ? import ./nix/sources.nix, ghcVersion ? "94" }:
 
 let
   selectHls = self: super: {

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ system ? builtins.currentSystem, sources ? import ./nix/sources.nix, ghcVersion ? "94" }:
+{ system ? builtins.currentSystem, sources ? import ./nix/sources.nix, ghcVersion ? "96" }:
 
 let
   selectHls = self: super: {

--- a/src/Data/Unrestricted/Linear/Internal/Instances.hs
+++ b/src/Data/Unrestricted/Linear/Internal/Instances.hs
@@ -186,7 +186,8 @@ instance (KnownNat n, Consumable a) => Consumable (V n a) where
 
 instance (KnownNat n, Dupable a) => Dupable (V n a) where
   dupR (V xs) =
-    V . Unsafe.toLinear (Vector.fromListN (V.theLength @n))
+    V
+      . Unsafe.toLinear (Vector.fromListN (V.theLength @n))
       Data.<$> dupR (Unsafe.toLinear Vector.toList xs)
 
 -- Some stock instances

--- a/src/Data/V/Linear/Internal.hs
+++ b/src/Data/V/Linear/Internal.hs
@@ -78,8 +78,8 @@ map f (V xs) = V $ Unsafe.toLinear (Vector.map (\x -> f x)) xs
 
 (<*>) :: V n (a %1 -> b) %1 -> V n a %1 -> V n b
 (V fs) <*> (V xs) =
-  V $
-    Unsafe.toLinear2 (Vector.zipWith (\f x -> f $ x)) fs xs
+  V
+    $ Unsafe.toLinear2 (Vector.zipWith (\f x -> f $ x)) fs xs
 
 infixl 4 <*> -- same fixity as base.<*>
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,4 @@
-resolver: nightly-2023-04-21 
+resolver: lts-22.34
 packages:
 - '.'
 extra-deps:
-# linear-generic has been temporarily removed from Stackage nightly, see https://github.com/commercialhaskell/stackage/pull/6951
-- linear-generics-0.2.1@sha256:dfe005e94e9080a12a6e30ce2f2bd552f4085cea380161b785b04a3c2fd39a8a,5894

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,17 +3,10 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages:
-- completed:
-    hackage: linear-generics-0.2.1@sha256:dfe005e94e9080a12a6e30ce2f2bd552f4085cea380161b785b04a3c2fd39a8a,5894
-    pantry-tree:
-      sha256: b5e5d4fadb4f3603647fffbee0626d14ac4076b1cc2256c721835a32db25f513
-      size: 2818
-  original:
-    hackage: linear-generics-0.2.1@sha256:dfe005e94e9080a12a6e30ce2f2bd552f4085cea380161b785b04a3c2fd39a8a,5894
+packages: []
 snapshots:
 - completed:
-    sha256: 9f8b7563aeafe035eae2304131454e6c1a96611ad9921dde6981474e988a5873
-    size: 608629
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2023/4/21.yaml
-  original: nightly-2023-04-21
+    sha256: edbd50d7e7c85c13ad5f5835ae2db92fab1e9cf05ecf85340e2622ec0a303df1
+    size: 720020
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/34.yaml
+  original: lts-22.34


### PR DESCRIPTION
This pull request changes the default version of GHC to be the one used by the latest stackage LTS available at the moment.