### PR TITLE
Support for Data.Complex

### DIFF
--- a/linear-base.cabal
+++ b/linear-base.cabal
@@ -71,6 +71,7 @@ library
         Data.Bifunctor.Linear.Internal.Bifunctor
         Data.Bifunctor.Linear.Internal.SymmetricMonoidal
         Data.Bool.Linear
+        Data.Complex.Linear
         Data.Either.Linear
         Data.Functor.Linear
         Data.Functor.Linear.Internal.Functor

--- a/src/Data/Complex/Linear.hs
+++ b/src/Data/Complex/Linear.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+-- |
+-- Linear versions of 'Data.Complex' functions.
+--
+-- Consult the original "Data.Complex" module for more detailed information.
+module Data.Complex.Linear
+    ( realPart
+    , imagPart
+    , conjugate
+    , NonLinear.mkPolar
+    , NonLinear.cis
+    , NonLinear.polar
+    , NonLinear.magnitude
+    , NonLinear.phase
+    ) where
+
+import Data.Complex (Complex ((:+)))
+import qualified Data.Complex as NonLinear
+import Data.Num.Linear
+import Data.Unrestricted.Linear
+
+realPart :: Consumable a => Complex a %1 -> a
+realPart (x :+ y) = lseq y x
+
+imagPart :: Consumable a => Complex a %1 -> a
+imagPart (x :+ y) = lseq x y
+
+conjugate :: AdditiveGroup a => Complex a %1 -> Complex a
+conjugate (x :+ y) =  x :+ (negate y)

--- a/src/Data/Functor/Linear/Internal/Applicative.hs
+++ b/src/Data/Functor/Linear/Internal/Applicative.hs
@@ -23,6 +23,7 @@ module Data.Functor.Linear.Internal.Applicative
 where
 
 import qualified Control.Monad.Trans.Reader as NonLinear
+import Data.Complex
 import Data.Functor.Compose
 import Data.Functor.Const
 import Data.Functor.Identity
@@ -119,6 +120,11 @@ deriving via
   Generically1 Identity
   instance
     Applicative Identity
+
+deriving via
+  Generically1 Complex
+  instance
+    Applicative Complex
 
 instance (Applicative f, Applicative g) => Applicative (Compose f g) where
   pure x = Compose (pure (pure x))

--- a/src/Data/Functor/Linear/Internal/Functor.hs
+++ b/src/Data/Functor/Linear/Internal/Functor.hs
@@ -26,6 +26,7 @@ import qualified Control.Monad.Trans.Except as NonLinear
 import qualified Control.Monad.Trans.Maybe as NonLinear
 import qualified Control.Monad.Trans.Reader as NonLinear
 import qualified Control.Monad.Trans.State.Strict as Strict
+import Data.Complex
 import Data.Functor.Compose
 import Data.Functor.Const
 import Data.Functor.Identity
@@ -115,6 +116,11 @@ deriving via
   Generically1 Identity
   instance
     Functor Identity
+
+deriving via
+  Generically1 Complex
+  instance
+    Functor Complex
 
 instance (Functor f, Functor g) => Functor (Sum f g) where
   fmap f (InL fa) = InL (fmap f fa)

--- a/src/Data/Functor/Linear/Internal/Traversable.hs
+++ b/src/Data/Functor/Linear/Internal/Traversable.hs
@@ -31,6 +31,7 @@ import qualified Control.Functor.Linear.Internal.Class as Control
 import qualified Control.Functor.Linear.Internal.Instances as Control
 import Control.Functor.Linear.Internal.Kan
 import qualified Control.Functor.Linear.Internal.State as Control
+import Data.Complex
 import Data.Functor.Const
 import qualified Data.Functor.Linear.Internal.Applicative as Data
 import qualified Data.Functor.Linear.Internal.Functor as Data
@@ -192,6 +193,9 @@ instance Traversable UInt where
   traverse = genericTraverse
 
 instance Traversable UWord where
+  traverse = genericTraverse
+
+instance Traversable Complex where
   traverse = genericTraverse
 
 -- | This type class derives the definition of 'genericTraverse' by induction on

--- a/src/Data/Num/Linear.hs
+++ b/src/Data/Num/Linear.hs
@@ -42,6 +42,7 @@ where
 
 -- TODO: flesh out laws
 
+import Data.Complex
 import qualified Data.Int
 import Data.Monoid.Linear
 import Data.Unrestricted.Linear
@@ -350,4 +351,41 @@ deriving via MovableNum Data.Word.Word64 instance Semiring Data.Word.Word64
 deriving via MovableNum Data.Word.Word64 instance Ring Data.Word.Word64
 deriving via MovableNum Data.Word.Word64 instance FromInteger Data.Word.Word64
 deriving via MovableNum Data.Word.Word64 instance Num Data.Word.Word64
+
+deriving via
+  MovableNum (Complex a)
+  instance
+    (Movable a, Prelude.RealFloat a) => Additive (Complex a)
+deriving via
+  MovableNum (Complex a)
+  instance
+    (Movable a, Prelude.RealFloat a) => AddIdentity (Complex a)
+deriving via
+  MovableNum (Complex a)
+  instance
+    (Movable a, Prelude.RealFloat a) => AdditiveGroup (Complex a)
+deriving via
+  MovableNum (Complex a)
+  instance
+    (Movable a, Prelude.RealFloat a) => Multiplicative (Complex a)
+deriving via
+  MovableNum (Complex a)
+  instance
+    (Movable a, Prelude.RealFloat a) => MultIdentity (Complex a)
+deriving via
+  MovableNum (Complex a)
+  instance
+    (Movable a, Prelude.RealFloat a) => Semiring (Complex a)
+deriving via
+  MovableNum (Complex a)
+  instance
+    (Movable a, Prelude.RealFloat a) => Ring (Complex a)
+deriving via
+  MovableNum (Complex a)
+  instance
+    (Movable a, Prelude.RealFloat a) => FromInteger (Complex a)
+deriving via
+  MovableNum (Complex a)
+  instance
+    (Movable a, Prelude.RealFloat a) => Num (Complex a)
 {- ORMOLU_ENABLE -}

--- a/src/Data/Ord/Linear/Internal/Eq.hs
+++ b/src/Data/Ord/Linear/Internal/Eq.hs
@@ -12,6 +12,7 @@ module Data.Ord.Linear.Internal.Eq
 where
 
 import Data.Bool.Linear
+import Data.Complex
 import Data.Int (Int16, Int32, Int64, Int8)
 import Data.Unrestricted.Linear
 import Data.Word (Word16, Word32, Word64, Word8)
@@ -99,6 +100,8 @@ deriving via MovableEq Word32 instance Eq Word32
 deriving via MovableEq Word64 instance Eq Word64
 
 deriving via MovableEq Word8 instance Eq Word8
+
+deriving via MovableEq (Complex a) instance (Movable a, Prelude.Eq a) => Eq (Complex a)
 
 newtype MovableEq a = MovableEq a
 

--- a/src/Data/Unrestricted/Linear/Internal/Consumable.hs
+++ b/src/Data/Unrestricted/Linear/Internal/Consumable.hs
@@ -26,6 +26,7 @@ module Data.Unrestricted.Linear.Internal.Consumable
   )
 where
 
+import Data.Complex
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Monoid as Monoid
 import qualified Data.Replicator.Linear.Internal as Replicator
@@ -163,6 +164,11 @@ deriving via
   Generically (Ur a)
   instance
     Consumable (Ur a)
+
+deriving via
+  Generically (Complex a)
+  instance
+    (_) => Consumable (Complex a)
 
 -- Data.Semigroup instances
 

--- a/src/Data/Unrestricted/Linear/Internal/Dupable.hs
+++ b/src/Data/Unrestricted/Linear/Internal/Dupable.hs
@@ -29,6 +29,7 @@ module Data.Unrestricted.Linear.Internal.Dupable
   )
 where
 
+import Data.Complex
 import Data.List.NonEmpty (NonEmpty)
 import Data.Replicator.Linear.Internal (Replicator (..))
 import qualified Data.Replicator.Linear.Internal as Replicator
@@ -215,6 +216,11 @@ deriving via
   Generically (a, b, c, d, e)
   instance
     (Dupable a, Dupable b, Dupable c, Dupable d, Dupable e) => Dupable (a, b, c, d, e)
+
+deriving via
+  Generically (Complex a)
+  instance
+    (Dupable a) => Dupable (Complex a)
 
 deriving newtype instance (Dupable a) => Dupable (Semigroup.Sum a)
 

--- a/src/Data/Unrestricted/Linear/Internal/Movable.hs
+++ b/src/Data/Unrestricted/Linear/Internal/Movable.hs
@@ -23,6 +23,7 @@ module Data.Unrestricted.Linear.Internal.Movable
   )
 where
 
+import Data.Complex
 import qualified Data.Functor.Linear.Internal.Applicative as Data
 import qualified Data.Functor.Linear.Internal.Functor as Data
 import Data.List.NonEmpty (NonEmpty (..))
@@ -143,6 +144,11 @@ instance (Movable a) => Movable (NonEmpty a) where
 
 instance Movable (Ur a) where
   move (Ur a) = Ur (Ur a)
+
+deriving via
+  Generically (Complex a)
+  instance
+    (Movable a) => Movable (Complex a)
 
 -- Some stock instances
 deriving newtype instance (Movable a) => Movable (Semigroup.Sum a)


### PR DESCRIPTION
I'm aiming to make [Data.Complex](https://hackage.haskell.org/package/base-4.21.0.0/docs/Data-Complex.html) in the base package  to be an instance of each linear version of type class.
I would like your opinion on which type classes are preferable for `Complex a` and which functions in `Data.Complex` should be reimplemented in linear-base.