### PR TITLE
Fix: use Unsatisfiable for banned instances (unrestricted Monoid / Semigroup for linear containers)

### DIFF
--- a/src/Data/HashMap/Mutable/Linear/Internal.hs
+++ b/src/Data/HashMap/Mutable/Linear/Internal.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE InstanceSigs #-}
@@ -25,7 +27,9 @@ import qualified Data.Functor.Linear as Data
 import Data.Hashable
 import qualified Data.Maybe as NonLinear
 import Data.Unrestricted.Linear
+import GHC.TypeLits (ErrorMessage (..))
 import Prelude.Linear hiding (filter, insert, lookup, mapMaybe, read, (+))
+import Prelude.Linear.Unsatisfiable (Unsatisfiable, unsatisfiable)
 import Unsafe.Coerce (unsafeCoerce)
 import qualified Unsafe.Linear as Unsafe
 import Prelude ((+))
@@ -481,8 +485,8 @@ instance Data.Functor (HashMap k) where
         )
         arr
 
-instance Prelude.Semigroup (HashMap k v) where
-  (<>) = error "Prelude.<>: invariant violation, unrestricted HashMap"
+instance (Unsatisfiable ('Text "Using Prelude's Semigroup methods on a Data.HashMap.Mutable.Linear is vacuous as there can't be an unrestricted such Hashmap")) => Prelude.Semigroup (HashMap k v) where
+  (<>) = unsatisfiable
 
 instance (Keyed k) => Semigroup (HashMap k v) where
   (<>) = union

--- a/src/Data/Set/Mutable/Linear/Internal.hs
+++ b/src/Data/Set/Mutable/Linear/Internal.hs
@@ -1,10 +1,13 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LinearTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
 {-# OPTIONS_HADDOCK hide #-}
@@ -14,7 +17,9 @@ module Data.Set.Mutable.Linear.Internal where
 import qualified Data.HashMap.Mutable.Linear as Linear
 import Data.Monoid.Linear
 import Data.Unrestricted.Linear
+import GHC.TypeLits (ErrorMessage (..))
 import qualified Prelude.Linear as Linear hiding (insert)
+import Prelude.Linear.Unsatisfiable (Unsatisfiable, unsatisfiable)
 import Prelude (Bool, Int)
 import qualified Prelude
 
@@ -70,8 +75,11 @@ fromList xs f =
 -- # Typeclass Instances
 -------------------------------------------------------------------------------
 
-instance Prelude.Semigroup (Set a) where
-  (<>) = Prelude.error "Prelude.(<>): invariant violation, unrestricted Set"
+instance
+  (Unsatisfiable ('Text "Using Prelude's Semigroup methods on a Data.Set.Mutable.Linear is vacuous as there can't be an unrestricted such Set")) =>
+  Prelude.Semigroup (Set a)
+  where
+  (<>) = unsatisfiable
 
 instance (Keyed a) => Semigroup (Set a) where
   (<>) = union


### PR DESCRIPTION
Currently, `Prelude.Semigroup` instance for (linear) HashMap / Set results in a *runtime* error.
This PR explicitly bans these instances by using `Unsatisfiable` type constraint family.