### PR TITLE
Coerce `System.IO` and `Linear.IO` into `RIO`

### DIFF
--- a/src/Control/Monad/IO/Class/Linear.hs
+++ b/src/Control/Monad/IO/Class/Linear.hs
@@ -7,6 +7,8 @@ import qualified Control.Functor.Linear as Linear
 import Prelude.Linear
 import qualified System.IO as System
 import qualified System.IO.Linear as Linear
+import System.IO.Resource.Linear (RIO)
+import qualified System.IO.Resource.Linear as RIO
 
 -- | Like 'NonLinear.MonadIO' but allows to lift both linear
 -- and non-linear 'IO' actions into a linear monad.
@@ -19,3 +21,6 @@ class (Linear.Monad m) => MonadIO m where
 
 instance MonadIO Linear.IO where
   liftIO = id
+
+instance MonadIO RIO where
+  liftIO = RIO.fromIO

--- a/src/Streaming/Linear/Internal/Consume.hs
+++ b/src/Streaming/Linear/Internal/Consume.hs
@@ -62,6 +62,7 @@ module Streaming.Linear.Internal.Consume
 where
 
 import qualified Control.Functor.Linear as Control
+import Control.Monad.IO.Class.Linear (liftSystemIO)
 import qualified Data.Bool.Linear as Linear
 import Data.Functor.Identity
 import Data.Text (Text)
@@ -116,7 +117,7 @@ stdoutLn' stream = loop stream
         Return r -> Control.return r
         Effect ms -> ms Control.>>= stdoutLn'
         Step (str :> stream) -> Control.do
-          fromSystemIO $ Text.putStrLn str
+          liftSystemIO $ Text.putStrLn str
           stdoutLn' stream
 {-# INLINEABLE stdoutLn' #-}
 

--- a/src/Streaming/Linear/Internal/Produce.hs
+++ b/src/Streaming/Linear/Internal/Produce.hs
@@ -45,6 +45,7 @@ module Streaming.Linear.Internal.Produce
 where
 
 import qualified Control.Functor.Linear as Control
+import Control.Monad.IO.Class.Linear (liftSystemIOU)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Unrestricted.Linear
@@ -344,7 +345,7 @@ stdinLn = AffineStream () getALine Control.pure
   where
     getALine :: () %1 -> IO (Either (Of Text ()) ())
     getALine () = Control.do
-      Ur line <- fromSystemIOU System.getLine
+      Ur line <- liftSystemIOU System.getLine
       Control.return $ Left (Text.pack line :> ())
 
 -- | An affine stream of reading lines, crashing on failed parse.
@@ -353,7 +354,7 @@ readLn = AffineStream () readALine Control.pure
   where
     readALine :: (Read a) => () %1 -> IO (Either (Of a ()) ())
     readALine () = Control.do
-      Ur line <- fromSystemIOU System.getLine
+      Ur line <- liftSystemIOU System.getLine
       Control.return $ Left (Prelude.read line :> ())
 
 -- | An affine stream iterating an initial state forever.

--- a/src/System/IO/Resource/Linear.hs
+++ b/src/System/IO/Resource/Linear.hs
@@ -32,6 +32,9 @@ module System.IO.Resource.Linear
     RIO,
     run,
 
+    -- * Interfacing with "System.IO"
+    fromSystemIO,
+
     -- * Using Resource Handles
     -- $monad
     -- $files

--- a/src/System/IO/Resource/Linear.hs
+++ b/src/System/IO/Resource/Linear.hs
@@ -32,7 +32,8 @@ module System.IO.Resource.Linear
     RIO,
     run,
 
-    -- * Interfacing with "System.IO"
+    -- * Interfacing with IO
+    fromIO,
     fromSystemIO,
     fromSystemIOU,
 

--- a/src/System/IO/Resource/Linear.hs
+++ b/src/System/IO/Resource/Linear.hs
@@ -34,6 +34,7 @@ module System.IO.Resource.Linear
 
     -- * Interfacing with "System.IO"
     fromSystemIO,
+    fromSystemIOU,
 
     -- * Using Resource Handles
     -- $monad

--- a/src/System/IO/Resource/Linear/Internal.hs
+++ b/src/System/IO/Resource/Linear/Internal.hs
@@ -88,19 +88,23 @@ run (RIO action) = do
       result <- action'
       Control.return $ move result
 
+-- | Coerces a linear IO action into a 'RIO' action.
+fromIO :: Linear.IO a %1 -> RIO a
+fromIO action = RIO (\_ -> action)
+
 -- | Coerces a standard IO action into a 'RIO' action.
 -- Note that the value @a@ must be used linearly in the 'RIO' monad.
 fromSystemIO :: System.IO a %1 -> RIO a
 fromSystemIO action =
   -- Should not be applied to a function that acquires or releases resources.
-  RIO (\_ -> Linear.fromSystemIO action)
+  fromIO (Linear.fromSystemIO action)
 
 -- | Coerces a standard IO action into a 'RIO' action, allowing you to use
 -- the result of type @a@ in a non-linear manner by wrapping it inside
 -- 'Ur'.
 fromSystemIOU :: System.IO a -> RIO (Ur a)
 fromSystemIOU action =
-  fromSystemIO (Ur Prelude.<$> action)
+  fromIO (Linear.fromSystemIOU action)
 
 -- monad
 

--- a/src/System/IO/Resource/Linear/Internal.hs
+++ b/src/System/IO/Resource/Linear/Internal.hs
@@ -95,6 +95,13 @@ fromSystemIO action =
   -- Should not be applied to a function that acquires or releases resources.
   RIO (\_ -> Linear.fromSystemIO action)
 
+-- | Coerces a standard IO action into a 'RIO' action, allowing you to use
+-- the result of type @a@ in a non-linear manner by wrapping it inside
+-- 'Ur'.
+fromSystemIOU :: System.IO a -> RIO (Ur a)
+fromSystemIOU action =
+  fromSystemIO (Ur Prelude.<$> action)
+
 -- monad
 
 instance Control.Functor RIO where

--- a/src/System/IO/Resource/Linear/Internal.hs
+++ b/src/System/IO/Resource/Linear/Internal.hs
@@ -88,9 +88,12 @@ run (RIO action) = do
       result <- action'
       Control.return $ move result
 
--- | Should not be applied to a function that acquires or releases resources.
-unsafeFromSystemIO :: System.IO a %1 -> RIO a
-unsafeFromSystemIO action = RIO (\_ -> Linear.fromSystemIO action)
+-- | Coerces a standard IO action into a 'RIO' action.
+-- Note that the value @a@ must be used linearly in the 'RIO' monad.
+fromSystemIO :: System.IO a %1 -> RIO a
+fromSystemIO action =
+  -- Should not be applied to a function that acquires or releases resources.
+  RIO (\_ -> Linear.fromSystemIO action)
 
 -- monad
 
@@ -235,7 +238,7 @@ unsafeFromSystemIOResource ::
   (a -> System.IO b) ->
   (Resource a %1 -> RIO (Ur b, Resource a))
 unsafeFromSystemIOResource action (UnsafeResource key resource) =
-  unsafeFromSystemIO
+  fromSystemIO
     ( do
         c <- action resource
         Prelude.return (Ur c, UnsafeResource key resource)


### PR DESCRIPTION
As discussed in https://github.com/tweag/linear-base/discussions/504, this PR adds/exports these functions from the RIO module: `fromIO`, `fromSystemIO` and `fromSystemIOU`.

It also adds a `MonadIO` instance for `RIO`.