### PR TITLE
Add MonadIO instances for StateT and ReaderT

### DIFF
--- a/src/Control/Monad/IO/Class/Linear.hs
+++ b/src/Control/Monad/IO/Class/Linear.hs
@@ -24,3 +24,9 @@ instance MonadIO Linear.IO where
 
 instance MonadIO RIO where
   liftIO = RIO.fromIO
+
+instance (MonadIO m) => MonadIO (Linear.StateT s m) where
+  liftIO = Linear.lift . liftIO
+
+instance (MonadIO m, Dupable r) => MonadIO (Linear.ReaderT r m) where
+  liftIO = Linear.lift . liftIO


### PR DESCRIPTION
This small PR adds MonadIO instances for `StateT` and `ReaderT`