### PR TITLE
Import Multiplicity from GHC.Types

### DIFF
--- a/src/Control/Functor/Linear/Internal/Reader.hs
+++ b/src/Control/Functor/Linear/Internal/Reader.hs
@@ -35,7 +35,7 @@ import qualified Data.Functor.Linear.Internal.Functor as Data
 import Data.Kind (FUN)
 import Data.Unrestricted.Linear.Internal.Consumable
 import Data.Unrestricted.Linear.Internal.Dupable
-import GHC.Exts (Multiplicity (..))
+import GHC.Types (Multiplicity (..))
 import Prelude.Linear.Internal (runIdentity', ($), (.))
 
 -- # Linear ReaderT


### PR DESCRIPTION
GHC 9.2 did not yet export Multiplicity from GHC.Exts. The rest of the repository imports Multiplicity from ghc-prim:GHC.Types, from which the type has always been exported, but this one occurrence in Control.Functor.Linear.Internal.Reader didn't.