### PR TITLE
CI: add GHC 9.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     name: cabal test - GHC ${{ matrix.ghc-version }}
     strategy:
       matrix:
-        ghc-version: [96, 98, 910, 912]
+        ghc-version: [94, 96, 98, 910, 912]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
         stack-ghc-version = "ghc9103";
 
         # Versions used by CI's Cabal-based matrix
-        ci-ghc-versions = ["96" "98" "910" "912"];
+        ci-ghc-versions = ["94" "96" "98" "910" "912"];
 
         cabal-docspec = import ./nix/cabal-docspec.nix { inherit pkgs; };
 


### PR DESCRIPTION
Since apparently we can actually compile with 9.4. We can also compile against 9.2 since #509 . At least I think so, because recent Nixpkgs don't have 9.2, and so I can't properly test with my setup nor the CI's.